### PR TITLE
Modified MockPath and added basic tests

### DIFF
--- a/TestHelpers.Tests/MockPathTests.cs
+++ b/TestHelpers.Tests/MockPathTests.cs
@@ -1,0 +1,210 @@
+﻿using System.Diagnostics;
+using NUnit.Framework;
+
+namespace System.IO.Abstractions.TestingHelpers.Tests
+{
+    public class MockPathTests
+    {
+        const string TestPath = "C:\\test\\test.bmp";
+
+        private MockPath SetupMockPath()
+        {
+            return new MockPath();
+        }
+
+        [Test]
+        public void ChangeExtension_ExtensionNoPeriod_PeriodAdded()
+        {
+            //Arrange
+            var mockPath = SetupMockPath();
+
+            //Act
+            var result = mockPath.ChangeExtension(TestPath, "doc");
+
+            //Assert
+            Assert.AreEqual("C:\\test\\test.doc", result);
+        }
+
+        [Test]
+        public void Combine_SentTwoPaths_Combines()
+        {
+            //Arrange
+            var mockPath = SetupMockPath();
+
+            //Act
+            var result = mockPath.Combine("C:\\test", "test.bmp");
+
+            //Assert
+            Assert.AreEqual("C:\\test\\test.bmp", result);
+        }
+
+        [Test]
+        public void GetDirectoryName_SentPath_ReturnsDirectory()
+        {
+            //Arrange
+            var mockPath = SetupMockPath();
+
+            //Act
+            var result = mockPath.GetDirectoryName(TestPath);
+
+            //Assert
+            Assert.AreEqual("C:\\test", result);
+        }
+
+        [Test]
+        public void GetExtension_SendInPath_ReturnsExtension()
+        {
+            //Arrange
+            var mockPath = SetupMockPath();
+
+            //Act
+            var result = mockPath.GetExtension(TestPath);
+
+            //Assert
+            Assert.AreEqual(".bmp", result);
+        }
+
+        [Test]
+        public void GetFileName_SendInPath_ReturnsFilename()
+        {
+            //Arrange
+            var mockPath = SetupMockPath();
+
+            //Act
+            var result = mockPath.GetFileName(TestPath);
+
+            //Assert
+            Assert.AreEqual("test.bmp", result);
+        }
+
+        [Test]
+        public void GetFileNameWithoutExtension_SendInPath_ReturnsFileNameNoExt()
+        {
+            //Arrange
+            var mockPath = SetupMockPath();
+
+            //Act
+            var result = mockPath.GetFileNameWithoutExtension(TestPath);
+
+            //Assert
+            Assert.AreEqual("test", result);
+        }
+
+        [Test]
+        public void GetFullPath_SendInPath_ReturnsFullPath()
+        {
+            //Arrange
+            var mockPath = SetupMockPath();
+
+            //Act
+            var result = mockPath.GetFullPath(TestPath);
+
+            //Assert
+            Assert.AreEqual(TestPath, result);
+        }
+
+        [Test]
+        public void GetInvalidFileNameChars_Called_ReturnsChars()
+        {
+            //Arrange
+            var mockPath = SetupMockPath();
+
+            //Act
+            var result = mockPath.GetInvalidFileNameChars();
+
+            //Assert
+            Assert.IsTrue(result.Length > 0);
+        }
+
+        [Test]
+        public void GetInvalidPathChars_Called_ReturnsChars()
+        {
+            //Arrange
+            var mockPath = SetupMockPath();
+
+            //Act
+            var result = mockPath.GetInvalidPathChars();
+
+            //Assert
+            Assert.IsTrue(result.Length > 0);
+        }
+
+        [Test]
+        public void GetPathRoot_SendInPath_ReturnsRoot()
+        {
+            //Arrange
+            var mockPath = SetupMockPath();
+
+            //Act
+            var result = mockPath.GetPathRoot(TestPath);
+
+            //Assert
+            Assert.AreEqual("C:\\", result);
+        }
+
+        [Test]
+        public void GetRandomFileName_Called_ReturnsStringLengthGreaterThanZero()
+        {
+            //Arrange
+            var mockPath = SetupMockPath();
+
+            //Act
+            var result = mockPath.GetRandomFileName();
+
+            //Assert
+            Assert.IsTrue(result.Length>0);
+        }
+
+        [Test]
+        public void GetTempFileName_Called_ReturnsStringLengthGreaterThanZero()
+        {
+            //Arrange
+            var mockPath = SetupMockPath();
+
+            //Act
+            var result = mockPath.GetTempFileName();
+
+            //Assert
+            Assert.IsTrue(result.Length > 0);
+        }
+
+        [Test]
+        public void GetTempPath_Called_ReturnsStringLengthGreaterThanZero()
+        {
+            //Arrange
+            var mockPath = SetupMockPath();
+
+            //Act
+            var result = mockPath.GetTempPath();
+
+            //Assert
+            Assert.IsTrue(result.Length > 0);
+        }
+
+        [Test]
+        public void HasExtension_PathSentIn_DeterminesExtension()
+        {
+            //Arrange
+            var mockPath = SetupMockPath();
+
+            //Act
+            var result = mockPath.HasExtension(TestPath);
+
+            //Assert
+            Assert.AreEqual(true, result);
+        }
+
+        [Test]
+        public void IsPathRooted_PathSentIn_DeterminesPathExists()
+        {
+            //Arrange
+            var mockPath = SetupMockPath();
+
+            //Act
+            var result = mockPath.IsPathRooted(TestPath);
+
+            //Assert
+            Assert.AreEqual(true, result);
+        }
+    }
+}

--- a/TestHelpers.Tests/TestHelpers.Tests.csproj
+++ b/TestHelpers.Tests/TestHelpers.Tests.csproj
@@ -55,7 +55,7 @@
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
   <PropertyGroup>
-      <AssemblyOriginatorKeyFile>..\StrongName.pfx</AssemblyOriginatorKeyFile>
+    <AssemblyOriginatorKeyFile>..\StrongName.pfx</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="nunit.framework">
@@ -80,6 +80,7 @@
     <Compile Include="MockFileInfoTests.cs" />
     <Compile Include="MockFileSystemTests.cs" />
     <Compile Include="MockFileTests.cs" />
+    <Compile Include="MockPathTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/TestingHelpers/MockPath.cs
+++ b/TestingHelpers/MockPath.cs
@@ -5,106 +5,11 @@ using System.Text;
 
 namespace System.IO.Abstractions.TestingHelpers
 {
-    public class MockPath : PathBase
+    /// <summary>
+    /// PathWrapper calls direct to Path but all this does is string manipulation so we can inherit directly from PathWrapper as no IO is done
+    /// </summary>
+    public class MockPath : PathWrapper
     {
-        public override char AltDirectorySeparatorChar
-        {
-            get { throw new NotImplementedException("This test helper hasn't been implemented yet. They are implemented on an as-needed basis. As it seems like you need it, now would be a great time to send us a pull request over at https://github.com/tathamoddie/System.IO.Abstractions. You know, because it's open source and all."); }
-        }
-
-        public override char DirectorySeparatorChar
-        {
-            get { throw new NotImplementedException("This test helper hasn't been implemented yet. They are implemented on an as-needed basis. As it seems like you need it, now would be a great time to send us a pull request over at https://github.com/tathamoddie/System.IO.Abstractions. You know, because it's open source and all."); }
-        }
-
-        public override char[] InvalidPathChars
-        {
-            get { throw new NotImplementedException("This test helper hasn't been implemented yet. They are implemented on an as-needed basis. As it seems like you need it, now would be a great time to send us a pull request over at https://github.com/tathamoddie/System.IO.Abstractions. You know, because it's open source and all."); }
-        }
-
-        public override char PathSeparator
-        {
-            get { throw new NotImplementedException("This test helper hasn't been implemented yet. They are implemented on an as-needed basis. As it seems like you need it, now would be a great time to send us a pull request over at https://github.com/tathamoddie/System.IO.Abstractions. You know, because it's open source and all."); }
-        }
-
-        public override char VolumeSeparatorChar
-        {
-            get { throw new NotImplementedException("This test helper hasn't been implemented yet. They are implemented on an as-needed basis. As it seems like you need it, now would be a great time to send us a pull request over at https://github.com/tathamoddie/System.IO.Abstractions. You know, because it's open source and all."); }
-        }
-
-        public override string ChangeExtension(string path, string extension)
-        {
-            throw new NotImplementedException("This test helper hasn't been implemented yet. They are implemented on an as-needed basis. As it seems like you need it, now would be a great time to send us a pull request over at https://github.com/tathamoddie/System.IO.Abstractions. You know, because it's open source and all.");
-        }
-
-        public override string Combine(string path1, string path2)
-        {
-            throw new NotImplementedException("This test helper hasn't been implemented yet. They are implemented on an as-needed basis. As it seems like you need it, now would be a great time to send us a pull request over at https://github.com/tathamoddie/System.IO.Abstractions. You know, because it's open source and all.");
-        }
-
-        public override string GetDirectoryName(string path)
-        {
-            throw new NotImplementedException("This test helper hasn't been implemented yet. They are implemented on an as-needed basis. As it seems like you need it, now would be a great time to send us a pull request over at https://github.com/tathamoddie/System.IO.Abstractions. You know, because it's open source and all.");
-        }
-
-        public override string GetExtension(string path)
-        {
-            throw new NotImplementedException("This test helper hasn't been implemented yet. They are implemented on an as-needed basis. As it seems like you need it, now would be a great time to send us a pull request over at https://github.com/tathamoddie/System.IO.Abstractions. You know, because it's open source and all.");
-        }
-
-        public override string GetFileName(string path)
-        {
-            throw new NotImplementedException("This test helper hasn't been implemented yet. They are implemented on an as-needed basis. As it seems like you need it, now would be a great time to send us a pull request over at https://github.com/tathamoddie/System.IO.Abstractions. You know, because it's open source and all.");
-        }
-
-        public override string GetFileNameWithoutExtension(string path)
-        {
-            throw new NotImplementedException("This test helper hasn't been implemented yet. They are implemented on an as-needed basis. As it seems like you need it, now would be a great time to send us a pull request over at https://github.com/tathamoddie/System.IO.Abstractions. You know, because it's open source and all.");
-        }
-
-        public override string GetFullPath(string path)
-        {
-            throw new NotImplementedException("This test helper hasn't been implemented yet. They are implemented on an as-needed basis. As it seems like you need it, now would be a great time to send us a pull request over at https://github.com/tathamoddie/System.IO.Abstractions. You know, because it's open source and all.");
-        }
-
-        public override char[] GetInvalidFileNameChars()
-        {
-            throw new NotImplementedException("This test helper hasn't been implemented yet. They are implemented on an as-needed basis. As it seems like you need it, now would be a great time to send us a pull request over at https://github.com/tathamoddie/System.IO.Abstractions. You know, because it's open source and all.");
-        }
-
-        public override char[] GetInvalidPathChars()
-        {
-            throw new NotImplementedException("This test helper hasn't been implemented yet. They are implemented on an as-needed basis. As it seems like you need it, now would be a great time to send us a pull request over at https://github.com/tathamoddie/System.IO.Abstractions. You know, because it's open source and all.");
-        }
-
-        public override string GetPathRoot(string path)
-        {
-            throw new NotImplementedException("This test helper hasn't been implemented yet. They are implemented on an as-needed basis. As it seems like you need it, now would be a great time to send us a pull request over at https://github.com/tathamoddie/System.IO.Abstractions. You know, because it's open source and all.");
-        }
-
-        public override string GetRandomFileName()
-        {
-            throw new NotImplementedException("This test helper hasn't been implemented yet. They are implemented on an as-needed basis. As it seems like you need it, now would be a great time to send us a pull request over at https://github.com/tathamoddie/System.IO.Abstractions. You know, because it's open source and all.");
-        }
-
-        public override string GetTempFileName()
-        {
-            throw new NotImplementedException("This test helper hasn't been implemented yet. They are implemented on an as-needed basis. As it seems like you need it, now would be a great time to send us a pull request over at https://github.com/tathamoddie/System.IO.Abstractions. You know, because it's open source and all.");
-        }
-
-        public override string GetTempPath()
-        {
-            throw new NotImplementedException("This test helper hasn't been implemented yet. They are implemented on an as-needed basis. As it seems like you need it, now would be a great time to send us a pull request over at https://github.com/tathamoddie/System.IO.Abstractions. You know, because it's open source and all.");
-        }
-
-        public override bool HasExtension(string path)
-        {
-            throw new NotImplementedException("This test helper hasn't been implemented yet. They are implemented on an as-needed basis. As it seems like you need it, now would be a great time to send us a pull request over at https://github.com/tathamoddie/System.IO.Abstractions. You know, because it's open source and all.");
-        }
-
-        public override bool IsPathRooted(string path)
-        {
-            throw new NotImplementedException("This test helper hasn't been implemented yet. They are implemented on an as-needed basis. As it seems like you need it, now would be a great time to send us a pull request over at https://github.com/tathamoddie/System.IO.Abstractions. You know, because it's open source and all.");
-        }
+        
     }
 }


### PR DESCRIPTION
I was testing using Abstractions and went to use MockPath but they were all unimplemented. As the actual calls to Path are just string manipulations I inherited MockPath from PathWrapper and wrote unit tests to prove there is no disk access.
