### PR TITLE
Implement OpenWrite by extending MemoryStream into MockFileStream

### DIFF
--- a/TestHelpers.Tests/MockFileTests.cs
+++ b/TestHelpers.Tests/MockFileTests.cs
@@ -483,5 +483,40 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             Assert.That(fileSystem.GetFile(destFilePath).TextContents, Is.EqualTo(sourceFileContent));
             Assert.That(fileSystem.FileExists(sourceFilePath), Is.False);
         }
+
+        [Test]
+        public void MockFile_OpenWrite_ShouldCreateNewFiles() {
+            const string filePath = @"c:\something\demo.txt";
+            const string fileContent = "this is some content";
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>());
+
+            var bytes = new UTF8Encoding(true).GetBytes(fileContent);
+            var stream = fileSystem.File.OpenWrite(filePath);
+            stream.Write(bytes, 0, bytes.Length);
+            stream.Close();
+
+            Assert.That(fileSystem.FileExists(filePath), Is.True);
+            Assert.That(fileSystem.GetFile(filePath).TextContents, Is.EqualTo(fileContent));
+        }
+
+        [Test]
+        public void MockFile_OpenWrite_ShouldOverwriteExistingFiles()
+        {
+            const string filePath = @"c:\something\demo.txt";
+            const string startFileContent = "this is some content";
+            const string endFileContent = "this is some other content";
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>()
+                                                    {
+                                                        {filePath, new MockFileData(startFileContent)}
+                                                    });
+
+            var bytes = new UTF8Encoding(true).GetBytes(endFileContent);
+            var stream = fileSystem.File.OpenWrite(filePath);
+            stream.Write(bytes, 0, bytes.Length);
+            stream.Close();
+
+            Assert.That(fileSystem.FileExists(filePath), Is.True);
+            Assert.That(fileSystem.GetFile(filePath).TextContents, Is.EqualTo(endFileContent));
+        }
     }
 }

--- a/TestingHelpers/MockFile.cs
+++ b/TestingHelpers/MockFile.cs
@@ -171,7 +171,7 @@ namespace System.IO.Abstractions.TestingHelpers
 
         public override Stream OpenWrite(string path)
         {
-            throw new NotImplementedException("This test helper hasn't been implemented yet. They are implemented on an as-needed basis. As it seems like you need it, now would be a great time to send us a pull request over at https://github.com/tathamoddie/System.IO.Abstractions. You know, because it's open source and all.");
+            return new MockFileStream(mockFileDataAccessor, path);
         }
 
         public override byte[] ReadAllBytes(string path)

--- a/TestingHelpers/MockFileStream.cs
+++ b/TestingHelpers/MockFileStream.cs
@@ -1,0 +1,35 @@
+﻿namespace System.IO.Abstractions.TestingHelpers
+{
+    public class MockFileStream : MemoryStream
+    {
+        readonly IMockFileDataAccessor mockFileDataAccessor;
+        readonly string path;
+
+        public MockFileStream(IMockFileDataAccessor mockFileDataAccessor, string path)
+        {
+            this.mockFileDataAccessor = mockFileDataAccessor;
+            this.path = path;
+
+            if (mockFileDataAccessor.FileExists(path))
+            {
+                /* only way to make an expandable MemoryStream that starts with a particular content */
+                var data = mockFileDataAccessor.GetFile(path).Contents;
+                base.Write(data, 0, data.Length);
+                base.Seek(0, SeekOrigin.Begin);
+            }
+        }
+
+        public override void Close() {
+            if (mockFileDataAccessor.FileExists(path))
+                mockFileDataAccessor.RemoveFile(path);
+
+            /* reset back to the beginning .. */
+            base.Seek(0, SeekOrigin.Begin);
+            /* .. read everything out */
+            var data = new byte[base.Length];
+            base.Read(data, 0, (int)base.Length);
+            /* .. put it in the mock system */
+            mockFileDataAccessor.AddFile(path, new MockFileData(data));
+        }
+    }
+}

--- a/TestingHelpers/TestingHelpers.csproj
+++ b/TestingHelpers/TestingHelpers.csproj
@@ -79,6 +79,7 @@
     <Compile Include="MockFileData.cs" />
     <Compile Include="MockFileInfo.cs" />
     <Compile Include="MockFileInfoFactory.cs" />
+    <Compile Include="MockFileStream.cs" />
     <Compile Include="MockFileSystem.cs" />
     <Compile Include="MockPath.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
Most of what MockFileStream does is that it remembers to write back into the mock filesystem on close.
