### PR TITLE
MockDirectoryData wasn't public, and so everyone else couldn't use it!

### DIFF
--- a/TestingHelpers/MockFileData.cs
+++ b/TestingHelpers/MockFileData.cs
@@ -59,7 +59,7 @@ namespace System.IO.Abstractions.TestingHelpers
         }
     }
 
-    class MockDirectoryData : MockFileData {
+    public class MockDirectoryData : MockFileData {
         public override bool IsDirectory { get { return true; } }
 
         public MockDirectoryData() : base(string.Empty) {


### PR DESCRIPTION
Somehow when I made MockDirectoryData, I didn't mark it as public, and so it wasn't usable outside of the test project...
