### PR TITLE
Improved test coverage for MockDirectory (and some more methods implemented)

### DIFF
--- a/TestingHelpers/MockDirectoryInfo.cs
+++ b/TestingHelpers/MockDirectoryInfo.cs
@@ -25,7 +25,7 @@ namespace System.IO.Abstractions.TestingHelpers
 
         public override void Delete()
         {
-            throw new NotImplementedException("This test helper hasn't been implemented yet. They are implemented on an as-needed basis. As it seems like you need it, now would be a great time to send us a pull request over at https://github.com/tathamoddie/System.IO.Abstractions. You know, because it's open source and all.");
+            mockFileDataAccessor.Directory.Delete(directoryPath);
         }
 
         public override void Refresh()
@@ -94,7 +94,7 @@ namespace System.IO.Abstractions.TestingHelpers
 
         public override string Name
         {
-            get { return new MockPath().GetFileName(directoryPath); }
+            get { return new MockPath().GetFileName(directoryPath.TrimEnd('\\')); }
         }
 
         public override void Create()
@@ -189,6 +189,9 @@ namespace System.IO.Abstractions.TestingHelpers
 
         public override void MoveTo(string destDirName)
         {
+            if (!destDirName.EndsWith(Path.DirectorySeparatorChar.ToString()))
+                destDirName += Path.DirectorySeparatorChar;
+
             mockFileDataAccessor.Directory.Move(directoryPath, destDirName);
         }
 
@@ -207,7 +210,10 @@ namespace System.IO.Abstractions.TestingHelpers
 
         public override DirectoryInfoBase Root
         {
-            get { throw new NotImplementedException("This test helper hasn't been implemented yet. They are implemented on an as-needed basis. As it seems like you need it, now would be a great time to send us a pull request over at https://github.com/tathamoddie/System.IO.Abstractions. You know, because it's open source and all."); }
+            get
+            {
+                return new MockDirectoryInfo(mockFileDataAccessor, mockFileDataAccessor.Directory.GetDirectoryRoot(FullName));
+            }
         }
     }
 }

--- a/TestingHelpers/MockFile.cs
+++ b/TestingHelpers/MockFile.cs
@@ -81,7 +81,7 @@ namespace System.IO.Abstractions.TestingHelpers
 
         public override StreamWriter CreateText(string path)
         {
-            throw new NotImplementedException("This test helper hasn't been implemented yet. They are implemented on an as-needed basis. As it seems like you need it, now would be a great time to send us a pull request over at https://github.com/tathamoddie/System.IO.Abstractions. You know, because it's open source and all.");
+            return new StreamWriter(Create(path));
         }
 
         public override void Decrypt(string path)

--- a/TestingHelpers/MockFileInfo.cs
+++ b/TestingHelpers/MockFileInfo.cs
@@ -155,7 +155,8 @@ namespace System.IO.Abstractions.TestingHelpers
 
         public override void MoveTo(string destFileName)
         {
-            throw new NotImplementedException("This test helper hasn't been implemented yet. They are implemented on an as-needed basis. As it seems like you need it, now would be a great time to send us a pull request over at https://github.com/tathamoddie/System.IO.Abstractions. You know, because it's open source and all.");
+            CopyTo(destFileName);
+            Delete();
         }
 
         public override Stream Open(FileMode mode)
@@ -175,7 +176,7 @@ namespace System.IO.Abstractions.TestingHelpers
 
         public override Stream OpenRead()
         {
-            throw new NotImplementedException("This test helper hasn't been implemented yet. They are implemented on an as-needed basis. As it seems like you need it, now would be a great time to send us a pull request over at https://github.com/tathamoddie/System.IO.Abstractions. You know, because it's open source and all.");
+            return new MockFileStream(mockFileSystem, path);
         }
 
         public override StreamReader OpenText()

--- a/TestingHelpers/MockFileSystem.cs
+++ b/TestingHelpers/MockFileSystem.cs
@@ -61,23 +61,32 @@ namespace System.IO.Abstractions.TestingHelpers
             get { return directoryInfoFactory; }
         }
 
+        private string FixPath(string path)
+        {
+            return path.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
+        }
+
         public MockFileData GetFile(string path)
         {
+            path = FixPath(path);
             return FileExists(path) ? files[path] : null;
         }
 
         public void AddFile(string path, MockFileData mockFile)
         {
+            path = FixPath(path);
             files.Add(path, mockFile);
         }
 
         public void RemoveFile(string path)
         {
+            path = FixPath(path);
             files.Remove(path);
         }
 
         public bool FileExists(string path)
         {
+            path = FixPath(path);
             return files.ContainsKey(path);
         }
 


### PR DESCRIPTION
Improved test coverage on MockDirectory and MockDirectoryInfo
Implemented MockDirectory.GetRootDirectory
Reimplemented MockDirectory.Move (previous system failed a new test I wrote)
Implemented MockFile.CreateText
Implemented MockFileInfo.MoveTo
