### PR TITLE
Modified Implicit cast from DirectoryInfo to DirectoryInfoBase to correctly handle null values

### DIFF
--- a/System.IO.Abstractions/DirectoryInfoBase.cs
+++ b/System.IO.Abstractions/DirectoryInfoBase.cs
@@ -27,6 +27,8 @@ namespace System.IO.Abstractions
         
         public static implicit operator DirectoryInfoBase(DirectoryInfo directoryInfo)
         {
+            if (directoryInfo == null)
+                return null;
             return new DirectoryInfoWrapper(directoryInfo);
         }
     }

--- a/System.IO.Abstractions/System.IO.Abstractions.ncrunchproject
+++ b/System.IO.Abstractions/System.IO.Abstractions.ncrunchproject
@@ -13,8 +13,8 @@
   <AnalyseExecutionTimes>true</AnalyseExecutionTimes>
   <IncludeStaticReferencesInWorkspace>true</IncludeStaticReferencesInWorkspace>
   <DefaultTestTimeout>60000</DefaultTestTimeout>
-  <UseBuildConfiguration />
-  <UseBuildPlatform />
-  <ProxyProcessPath />
+  <UseBuildConfiguration></UseBuildConfiguration>
+  <UseBuildPlatform></UseBuildPlatform>
+  <ProxyProcessPath></ProxyProcessPath>
   <UseCPUArchitecture>AutoDetect</UseCPUArchitecture>
 </ProjectConfiguration>

--- a/TestingHelpers/TestingHelpers.csproj
+++ b/TestingHelpers/TestingHelpers.csproj
@@ -88,12 +88,6 @@
     <Compile Include="StringExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\System.IO.Abstractions\System.IO.Abstractions.csproj">
-      <Project>{4D398F3A-0784-4401-93CD-46CD2FBD6B92}</Project>
-      <Name>System.IO.Abstractions</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
     <BootstrapperPackage Include="Microsoft.Net.Client.3.5">
       <Visible>False</Visible>
       <ProductName>.NET Framework 3.5 SP1 Client Profile</ProductName>
@@ -112,6 +106,12 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="TestingHelpers.nuspec" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\System.IO.Abstractions\System.IO.Abstractions.csproj">
+      <Project>{4D398F3A-0784-4401-93CD-46CD2FBD6B92}</Project>
+      <Name>System.IO.Abstractions</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\nuget.targets" />

--- a/TestingHelpers/TestingHelpers.ncrunchproject
+++ b/TestingHelpers/TestingHelpers.ncrunchproject
@@ -13,8 +13,8 @@
   <AnalyseExecutionTimes>true</AnalyseExecutionTimes>
   <IncludeStaticReferencesInWorkspace>true</IncludeStaticReferencesInWorkspace>
   <DefaultTestTimeout>60000</DefaultTestTimeout>
-  <UseBuildConfiguration />
-  <UseBuildPlatform />
-  <ProxyProcessPath />
+  <UseBuildConfiguration></UseBuildConfiguration>
+  <UseBuildPlatform></UseBuildPlatform>
+  <ProxyProcessPath></ProxyProcessPath>
   <UseCPUArchitecture>AutoDetect</UseCPUArchitecture>
 </ProjectConfiguration>


### PR DESCRIPTION
Modified Implicit cast from DirectoryInfo to DirectoryInfoBase to return null if asked to return a null value. Previously it would return a DirectoryInfoWrapper wrapped around a null value which is definitely not what we want!

Signed-off-by: Martin Evans martindevans@gmail.com
