### PR TITLE
MockFile.AppendAllText creates the file if it doesn't exist.

### DIFF
--- a/TestHelpers.Tests/MockFileTests.cs
+++ b/TestHelpers.Tests/MockFileTests.cs
@@ -30,6 +30,56 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
+        public void MockFile_AppendAllText_ShouldCreateIfNotExist()
+        {
+            // Arrange
+            string path = @"c:\something\demo.txt";
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { path, new MockFileData("Demo text content") }
+            });
+
+            // Act
+            var path2 = @"c:\something\demo2.txt";
+            fileSystem.File.AppendAllText(path2, "some text");
+            var path3 = @"c:\something\demo3.txt";
+            fileSystem.File.AppendAllText(path3, "some text", Encoding.Unicode);
+
+            // Assert
+            Assert.AreEqual(
+                "some text",
+                fileSystem.File.ReadAllText(path2));
+            Assert.AreEqual(
+                "some text",
+                fileSystem.File.ReadAllText(path3, Encoding.Unicode));
+        }
+
+        [Test]
+        public void MockFile_AppendAllText_ShouldFailIfNotExistButDirectoryAlsoNotExist()
+        {
+            // Arrange
+            string path = @"c:\something\demo.txt";
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { path, new MockFileData("Demo text content") }
+            });
+
+            var file = new MockFile(fileSystem);
+
+
+            // Act
+            path = @"c:\something2\demo.txt";
+
+            // Assert
+            Exception ex;
+            ex = Assert.Throws<DirectoryNotFoundException>(() => fileSystem.File.AppendAllText(path, "some text"));
+            Assert.That(ex.Message, Is.EqualTo(String.Format("Could not find a part of the path '{0}'.", path)));
+
+            ex = Assert.Throws<DirectoryNotFoundException>(() => fileSystem.File.AppendAllText(path, "some text", Encoding.Unicode));
+            Assert.That(ex.Message, Is.EqualTo(String.Format("Could not find a part of the path '{0}'.", path)));
+        }
+
+        [Test]
         public void MockFile_AppendAllText_ShouldPersistNewTextWithCustomEncoding()
         {
             // Arrange

--- a/TestingHelpers/MockFile.cs
+++ b/TestingHelpers/MockFile.cs
@@ -18,17 +18,41 @@ namespace System.IO.Abstractions.TestingHelpers
 
         public override void AppendAllText(string path, string contents)
         {
-            mockFileDataAccessor
-                .GetFile(path)
-                .TextContents += contents;
+            if (!mockFileDataAccessor.FileExists(path))
+            {
+                var dir = mockFileDataAccessor.Path.GetDirectoryName(path);
+                if (!mockFileDataAccessor.Directory.Exists(dir))
+                {
+                    throw new DirectoryNotFoundException(String.Format("Could not find a part of the path '{0}'.", path));
+                }
+                mockFileDataAccessor.AddFile(path, new MockFileData(contents));
+            }
+            else
+            {
+                mockFileDataAccessor
+                    .GetFile(path)
+                    .TextContents += contents;
+            }
         }
 
         public override void AppendAllText(string path, string contents, Encoding encoding)
         {
-            var file = mockFileDataAccessor.GetFile(path);
-            var originalText = encoding.GetString(file.Contents);
-            var newText = originalText + contents;
-            file.Contents = encoding.GetBytes(newText);
+            if (!mockFileDataAccessor.FileExists(path))
+            {
+                var dir = mockFileDataAccessor.Path.GetDirectoryName(path);
+                if (!mockFileDataAccessor.Directory.Exists(dir))
+                {
+                    throw new DirectoryNotFoundException(String.Format("Could not find a part of the path '{0}'.", path));
+                }
+                mockFileDataAccessor.AddFile(path, new MockFileData(encoding.GetBytes(contents)));
+            }
+            else
+            {
+                var file = mockFileDataAccessor.GetFile(path);
+                var originalText = encoding.GetString(file.Contents);
+                var newText = originalText + contents;
+                file.Contents = encoding.GetBytes(newText);
+            }
         }
 
         public override StreamWriter AppendText(string path)


### PR DESCRIPTION
I noticed this issue when mocking in another project. 
