### PR TITLE
GetFiles will find files that have special chars

### DIFF
--- a/TestHelpers.Tests/MockDirectoryTests.cs
+++ b/TestHelpers.Tests/MockDirectoryTests.cs
@@ -111,8 +111,29 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.Directory.GetFiles(@"c:\", "*.gif", SearchOption.AllDirectories);
 
             // Assert
-
             Assert.That(result, Is.EquivalentTo( expected));
+        }
+
+        [Test]
+        public void MockDirectory_GetFiles_FilterShouldFindFilesWithSpecialChars()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { @"c:\a.1#.pdf", new MockFileData("Demo text content") },
+                { @"c:\b\b #1.txt", new MockFileData("Demo text content") }
+            });
+            var expected = new[]
+            {
+                @"c:\a.1#.pdf",
+                @"c:\b\b #1.txt",
+            };
+
+            // Act
+            var result = fileSystem.Directory.GetFiles(@"c:\", "*.*", SearchOption.AllDirectories);
+
+            // Assert
+            Assert.That(result, Is.EquivalentTo(expected));
         }
 
         [Test]

--- a/TestingHelpers/MockDirectory.cs
+++ b/TestingHelpers/MockDirectory.cs
@@ -143,13 +143,13 @@ namespace System.IO.Abstractions.TestingHelpers
 
             path = mockFileDataAccessor.Path.GetFullPath(path);
 
-            const string allDirectoriesPattern = @"([\w\d\s-\.]*\\)*";
+            const string allDirectoriesPattern = @"([^<>:""/\\|?*]*\\)*";
             
             var fileNamePattern = searchPattern == "*"
                 ? @"[^\\]*?\\?"
                 : Regex.Escape(searchPattern)
-                    .Replace(@"\*", @"[\w\d\s-\.]*?")
-                    .Replace(@"\?", @"[\w\d\s-\.]?");
+                    .Replace(@"\*", @"[^<>:""/\\|?*]*?")
+                    .Replace(@"\?", @"[^<>:""/\\|?*]?");
 
             var pathPattern = string.Format(
                 @"(?i:^{0}{1}{2}$)",


### PR DESCRIPTION
I noticed that using `"*.*"` with GetFiles leaves out files with special chars such as hash symbol. This differs from real behavior. The regex is changed to allow all chars except reserved per MSDN: http://msdn.microsoft.com/en-us/library/windows/desktop/aa365247(v=vs.85).aspx#file_and_directory_names
