### PR TITLE
Override GetTempFileName as the Path implementation actually hits the disk

### DIFF
--- a/TestHelpers.Tests/MockPathTests.cs
+++ b/TestHelpers.Tests/MockPathTests.cs
@@ -168,6 +168,20 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
+        public void GetTempFileName_Called_CreatesEmptyFileInTempDirectory()
+        {
+            //Arrange
+            var fileSystem = new MockFileSystem();
+            var mockPath = new MockPath(fileSystem);
+
+            //Act
+            var result = mockPath.GetTempFileName();
+
+            Assert.True(fileSystem.FileExists(result));
+            Assert.AreEqual(0, fileSystem.FileInfo.FromFileName(result).Length);
+        }
+
+        [Test]
         public void GetTempPath_Called_ReturnsStringLengthGreaterThanZero()
         {
             //Arrange

--- a/TestingHelpers/MockPath.cs
+++ b/TestingHelpers/MockPath.cs
@@ -27,5 +27,17 @@
 
             return path;
         }
+
+        public override string GetTempFileName()
+        {
+            string fileName = mockFileDataAccessor.Path.GetRandomFileName();
+            string tempDir = mockFileDataAccessor.Path.GetTempPath();
+
+            string fullPath = mockFileDataAccessor.Path.Combine(tempDir, fileName);
+
+            mockFileDataAccessor.AddFile(fullPath, new MockFileData(String.Empty));
+
+            return fullPath;
+        }
     }
 }


### PR DESCRIPTION
See http://msdn.microsoft.com/en-us/library/system.io.path.gettempfilename(v=vs.110).aspx

**Creates a uniquely named, zero-byte temporary file on disk and returns the full path of that file.**
