### PR TITLE
Added code and test to create the mocked directory when called MockFileS...

### DIFF
--- a/TestHelpers.Tests/MockFileSystemTests.cs
+++ b/TestHelpers.Tests/MockFileSystemTests.cs
@@ -92,5 +92,19 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             Assert.That(memoryStream.Length > 0, "Length didnt increase after serialization task.");
         }
+
+        [Test]
+        public void MockFileSystem_AddDirectory_ShouldCreateDirectory()
+        {
+            // Arrange
+            const string baseDirectory = @"C:\Test";
+            var fileSystem = new MockFileSystem();
+
+            // Act
+            fileSystem.AddDirectory(baseDirectory);
+
+            // Assert
+            Assert.IsTrue(fileSystem.Directory.Exists(baseDirectory));
+        }
     }
 }

--- a/TestingHelpers/MockFileSystem.cs
+++ b/TestingHelpers/MockFileSystem.cs
@@ -96,6 +96,7 @@ namespace System.IO.Abstractions.TestingHelpers
                     throw new UnauthorizedAccessException(string.Format("Access to the path '{0}' is denied.", path));
 
                 files[fixedPath] = new MockDirectoryData();
+                directory.CreateDirectory(fixedPath);
             }
         }
 


### PR DESCRIPTION
...ystem.AddDirectory()

I've been getting some failed tests in my project due to Directory.Exists() failing even though I'm calling MockFileSystem.AddDirectory().  I coded this up to help MockFileSystem work better in this scenario.
