### PR TITLE
Updated all FileSystemWatcher events to be virtual, to make them possibl...

### DIFF
--- a/System.IO.Abstractions/FileSystemWatcherBase.cs
+++ b/System.IO.Abstractions/FileSystemWatcherBase.cs
@@ -16,11 +16,11 @@ namespace System.IO.Abstractions
         public abstract string Path { get; set; }
         public abstract ISite Site { get; set; }
         public abstract ISynchronizeInvoke SynchronizingObject { get; set; }
-        public event FileSystemEventHandler Changed;
-        public event FileSystemEventHandler Created;
-        public event FileSystemEventHandler Deleted;
-        public event ErrorEventHandler Error;
-        public event RenamedEventHandler Renamed;
+        public virtual event FileSystemEventHandler Changed;
+        public virtual event FileSystemEventHandler Created;
+        public virtual event FileSystemEventHandler Deleted;
+        public virtual event ErrorEventHandler Error;
+        public virtual event RenamedEventHandler Renamed;
         public abstract void BeginInit();
         public abstract void Dispose();
         public abstract void EndInit();


### PR DESCRIPTION
...e to raise via mocks.

I realized that without making the events virtual there is no way for mocks to raise them.  While I'm not a fan of virtual events (as you can shoot yourself in the foot by overriding events) I could not figure out a better way to allow mocks to raise events without changing the `FileSystemWatcherBase` to be an interface methods publicly.  
