### PR TITLE
Added GetFileSystemEntries(string path, string pattern, SearchOption opt...

### DIFF
--- a/System.IO.Abstractions/DirectoryBase.cs
+++ b/System.IO.Abstractions/DirectoryBase.cs
@@ -24,6 +24,7 @@ namespace System.IO.Abstractions
         public abstract string[] GetFiles(string path, string searchPattern, SearchOption searchOption);
         public abstract string[] GetFileSystemEntries(string path);
         public abstract string[] GetFileSystemEntries(string path, string searchPattern);
+        public abstract string[] GetFileSystemEntries(string path, string searchPattern, SearchOption searchOption);
         public abstract DateTime GetLastAccessTime(string path);
         public abstract DateTime GetLastAccessTimeUtc(string path);
         public abstract DateTime GetLastWriteTime(string path);

--- a/System.IO.Abstractions/DirectoryWrapper.cs
+++ b/System.IO.Abstractions/DirectoryWrapper.cs
@@ -100,6 +100,11 @@ namespace System.IO.Abstractions
             return Directory.GetFileSystemEntries(path, searchPattern);
         }
 
+        public override string[] GetFileSystemEntries(string path, string searchPattern, SearchOption searchOption)
+        {
+            return Directory.GetFileSystemEntries(path, searchPattern, searchOption);
+        }
+
         public override DateTime GetLastAccessTime(string path)
         {
             return Directory.GetLastAccessTime(path);

--- a/System.IO.Abstractions/System.IO.Abstractions.csproj
+++ b/System.IO.Abstractions/System.IO.Abstractions.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>System.IO.Abstractions</RootNamespace>
     <AssemblyName>System.IO.Abstractions</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
@@ -31,6 +31,7 @@
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
+    <TargetFrameworkProfile>Client</TargetFrameworkProfile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/TestingHelpers/MockDirectory.cs
+++ b/TestingHelpers/MockDirectory.cs
@@ -180,8 +180,13 @@ namespace System.IO.Abstractions.TestingHelpers
 
         public override string[] GetFileSystemEntries(string path, string searchPattern)
         {
-            var dirs = GetDirectories(path, searchPattern);
-            var files = GetFiles(path, searchPattern);
+            return GetFileSystemEntries(path, searchPattern, SearchOption.TopDirectoryOnly);
+        }
+
+        public override string[] GetFileSystemEntries(string path, string searchPattern, SearchOption searchOption)
+        {
+            var dirs = GetDirectories(path, searchPattern, searchOption);
+            var files = GetFiles(path, searchPattern, searchOption);
 
             return dirs.Union(files).ToArray();
         }

--- a/TestingHelpers/TestingHelpers.csproj
+++ b/TestingHelpers/TestingHelpers.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>System.IO.Abstractions.TestingHelpers</RootNamespace>
     <AssemblyName>System.IO.Abstractions.TestingHelpers</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
@@ -33,6 +33,7 @@
     <BootstrapperEnabled>true</BootstrapperEnabled>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <TargetFrameworkProfile>Client</TargetFrameworkProfile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
Added GetFileSystemEntries(string path, string pattern, SearchOption options) method to directories

There is just one small problem: this method was added in .net4, and so I had to update the target framework to 4. How is the project handling multiple framework versions?

Signed-off-by: Martin Evans martindevans@gmail.com
