### PR TITLE
made all File.Open methods mimic core framework semantics as closely as possible

### DIFF
--- a/TestingHelpers/MockFile.cs
+++ b/TestingHelpers/MockFile.cs
@@ -226,7 +226,6 @@ namespace System.IO.Abstractions.TestingHelpers
 
         public override Stream Open(string path, FileMode mode, FileAccess access, FileShare share)
         {
-            //return new MockFileStream(path, mode, access, share);
             bool exists = mockFileDataAccessor.FileExists(path);
 
             if (mode == FileMode.CreateNew && exists)
@@ -267,7 +266,6 @@ namespace System.IO.Abstractions.TestingHelpers
         public override Stream OpenWrite(string path)
         {
             return new MockFileStream(mockFileDataAccessor, path);
-            //return Open(path, FileMode.OpenOrCreate, FileAccess.Write, FileShare.None);
         }
 
         public override byte[] ReadAllBytes(string path)


### PR DESCRIPTION
The current implementation had "Please implement" exceptions, so I investigated how the core framework utilizes File.Open and realigned them as closely as possible with the core framework semantics.
