### PR TITLE
file move should throw if dest dir doesn't exist.

### DIFF
--- a/TestHelpers.Tests/MockFileTests.cs
+++ b/TestHelpers.Tests/MockFileTests.cs
@@ -628,7 +628,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             const string sourceFileContent = "this is some content";
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
             {
-                {sourceFilePath, new MockFileData(sourceFileContent)}
+                {sourceFilePath, new MockFileData(sourceFileContent)},
+                {@"c:\somethingelse\dummy.txt", new MockFileData(new byte[] {0})}
             });
 
             const string destFilePath = @"c:\somethingelse\demo1.txt";
@@ -838,6 +839,24 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var exception = Assert.Throws<FileNotFoundException>(() => fileSystem.File.Move(sourceFilePath, destFilePath));
 
             Assert.That(exception.FileName, Is.EqualTo(@"c:\something\demo.txt"));
+        }
+
+        [Test]
+        public void MockFile_Move_ShouldThrowDirectoryNotFoundExceptionWhenSourcePathDoesNotExist_Message()
+        {
+            const string sourceFilePath = @"c:\something\demo.txt";
+            const string destFilePath = @"c:\somethingelse\demo.txt";
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+              {
+                  {sourceFilePath, new MockFileData(new byte[] {0})}
+              });
+
+            //var exists = fileSystem.Directory.Exists(@"c:\something");
+            //exists = fileSystem.Directory.Exists(@"c:\something22");
+
+            var exception = Assert.Throws<DirectoryNotFoundException>(() => fileSystem.File.Move(sourceFilePath, destFilePath));
+            //Message = "Could not find a part of the path."
+            Assert.That(exception.Message, Is.EqualTo(@"Could not find a part of the path."));
         }
 
         [Test]

--- a/TestingHelpers/MockFile.cs
+++ b/TestingHelpers/MockFile.cs
@@ -197,6 +197,12 @@ namespace System.IO.Abstractions.TestingHelpers
             if (sourceFile == null)
                 throw new FileNotFoundException(string.Format("The file \"{0}\" could not be found.", sourceFileName), sourceFileName);
 
+            var destDir = mockFileDataAccessor.Directory.GetParent(destFileName);
+            if (!destDir.Exists)
+            {
+                throw new DirectoryNotFoundException("Could not find a part of the path.");
+            }
+
             mockFileDataAccessor.AddFile(destFileName, new MockFileData(sourceFile.Contents));
             mockFileDataAccessor.RemoveFile(sourceFileName);
         }


### PR DESCRIPTION
I discovered this issue when my app created a dir, but tried to move a file to the wrong dir andy my unit test mock didn't catch it.
