### PR TITLE
Adapted some Directory methods in TestingHelpers

### DIFF
--- a/TestHelpers.Tests/MockDirectoryInfoTests.cs
+++ b/TestHelpers.Tests/MockDirectoryInfoTests.cs
@@ -50,7 +50,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
   
         [Test]
-        public void MockDirectoryInfo_FullName_ShouldReturnFullNameIncludingTrailingPathDelimiter() 
+        public void MockDirectoryInfo_FullName_ShouldReturnFullNameWithoutIncludingTrailingPathDelimiter() 
         {
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
             {
@@ -63,7 +63,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = directoryInfo.FullName;
 
-            Assert.That(result, Is.EqualTo(@"c:\temp\folder\"));
+            Assert.That(result, Is.EqualTo(@"c:\temp\folder"));
         }
 
         [Test]
@@ -95,6 +95,21 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = directoryInfo.GetFileSystemInfos("f*");
 
             Assert.That(result.Length, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void MockDirectoryInfo_GetParent_ShouldReturnDirectoriesAndNamesWithSearchPattern()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddDirectory(@"c:\a\b\c");
+            var directoryInfo = new MockDirectoryInfo(fileSystem, @"c:\a\b\c");
+
+            // Act
+            var result = directoryInfo.Parent;
+
+            // Assert
+            Assert.AreEqual(@"c:\a\b", result.FullName);
         }
     }
 }

--- a/TestHelpers.Tests/MockDirectoryTests.cs
+++ b/TestHelpers.Tests/MockDirectoryTests.cs
@@ -28,7 +28,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             // Assert
             Assert.That(result, Is.EquivalentTo(expected));
         }
-  
+
         private MockFileSystem SetupFileSystem()
         {
             return new MockFileSystem(new Dictionary<string, MockFileData>
@@ -648,6 +648,88 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
           fileSystem.Directory.SetCurrentDirectory(directory);
 
           Assert.AreEqual(directory, fileSystem.Directory.GetCurrentDirectory());
+        }
+
+        [Test]
+        public void MockDirectory_GetParent_ShouldThrowArgumentNullExceptionIfPathIsNull()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+
+            // Act
+            TestDelegate act = () => fileSystem.Directory.GetParent(null);
+
+            // Assert
+            Assert.Throws<ArgumentNullException>(act);
+        }
+
+        [Test]
+        public void MockDirectory_GetParent_ShouldThrowArgumentExceptionIfPathIsEmpty()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+
+            // Act
+            TestDelegate act = () => fileSystem.Directory.GetParent(string.Empty);
+
+            // Assert
+            Assert.Throws<ArgumentException>(act);
+        }
+
+        [Test]
+        public void MockDirectory_GetParent_ShouldReturnADirectoryInfoIfPathDoesNotExist()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+
+            // Act
+            var actualResult =  fileSystem.Directory.GetParent(@"c:\directory\does\not\exist");
+
+            // Assert
+            Assert.IsNotNull(actualResult);
+        }
+
+        [Test]
+        public void MockDirectory_GetParent_ShouldThrowArgumentExceptionIfPathHasIllegalCharacters()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+
+            // Act
+            TestDelegate act = () => fileSystem.Directory.GetParent("c:\\director\ty\\has\\illegal\\character");
+
+            // Assert
+            Assert.Throws<ArgumentException>(act);
+        }
+
+        [Test]
+        public void MockDirectory_GetParent_ShouldReturnNullIfPathIsRoot()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddDirectory(@"c:\");
+
+            // Act
+           var actualResult = fileSystem.Directory.GetParent(@"c:\");
+
+            // Assert
+            Assert.IsNull(actualResult);
+        }
+
+        [TestCase(@"c:\a", @"c:\")]
+        [TestCase(@"c:\a\b\c\d", @"c:\a\b\c")]
+        [TestCase(@"c:\a\b\c\d\", @"c:\a\b\c")]
+        public void MockDirectory_GetParent_ShouldReturnTheParentWithoutTrailingDirectorySeparatorChar(string path, string expectedResult)
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddDirectory(path);
+
+            // Act
+            var actualResult = fileSystem.Directory.GetParent(path);
+
+            // Assert
+            Assert.AreEqual(expectedResult, actualResult.FullName);
         }
     }
 }

--- a/TestHelpers.Tests/MockFileInfoTests.cs
+++ b/TestHelpers.Tests/MockFileInfoTests.cs
@@ -186,7 +186,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             // Act
             var result = fileInfo.Directory;
 
-            Assert.AreEqual(@"c:\temp\level1\level2\", result.FullName);
+            Assert.AreEqual(@"c:\temp\level1\level2", result.FullName);
         }
 
         [Test]

--- a/TestHelpers.Tests/MockFileSystemTests.cs
+++ b/TestHelpers.Tests/MockFileSystemTests.cs
@@ -106,5 +106,21 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             // Assert
             Assert.IsTrue(fileSystem.Directory.Exists(baseDirectory));
         }
+
+        [Test]
+        public void MockFileSystem_AddDirectory_ShouldThrowExceptionIfDirectoryIsReadOnly()
+        {
+            // Arrange
+            const string baseDirectory = @"C:\Test";
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddFile(baseDirectory, new MockFileData(string.Empty));
+            fileSystem.File.SetAttributes(baseDirectory, FileAttributes.ReadOnly);
+
+            // Act
+            TestDelegate act = () => fileSystem.AddDirectory(baseDirectory);
+
+            // Assert
+            Assert.Throws<UnauthorizedAccessException>(act);
+        }
     }
 }

--- a/TestingHelpers/MockDirectory.cs
+++ b/TestingHelpers/MockDirectory.cs
@@ -28,15 +28,32 @@ namespace System.IO.Abstractions.TestingHelpers
 
         public override DirectoryInfoBase CreateDirectory(string path, DirectorySecurity directorySecurity)
         {
+            if (path == null)
+            {
+                throw new ArgumentNullException("path");
+            }
+
+            if (path.Length == 0)
+            {
+                throw new ArgumentException("Path cannot be the empty string or all whitespace.", "path");
+            }
+
+            if (mockFileDataAccessor.FileExists(path))
+            {
+                var message = string.Format(CultureInfo.InvariantCulture, @"Cannot create ""{0}"" because a file or directory with the same name already exists.", path);
+                var ex = new IOException(message);
+                ex.Data.Add("Path", path);
+                throw ex;
+            }
+
             path = EnsurePathEndsWithDirectorySeparator(mockFileDataAccessor.Path.GetFullPath(path));
+
             if (!Exists(path))
+            {
                 mockFileDataAccessor.AddDirectory(path);
+            }
+
             var created = new MockDirectoryInfo(mockFileDataAccessor, path);
-
-            var parent = GetParent(path);
-            if (parent != null)
-                CreateDirectory(GetParent(path).FullName, directorySecurity);
-
             return created;
         }
 
@@ -57,7 +74,7 @@ namespace System.IO.Abstractions.TestingHelpers
                 throw new DirectoryNotFoundException(path + " does not exist or could not be found.");
 
             if (!recursive &&
-                affectedPaths.Count() > 1)
+                affectedPaths.Count > 1)
                 throw new IOException("The directory specified by " + path + " is read-only, or recursive is false and " + path + " is not an empty directory.");
 
             foreach (var affectedPath in affectedPaths)
@@ -218,11 +235,38 @@ namespace System.IO.Abstractions.TestingHelpers
 
         public override DirectoryInfoBase GetParent(string path)
         {
-            var parent = new DirectoryInfo(path).Parent;
-            if (parent == null)
-                return null;
+            if (path == null)
+            {
+                throw new ArgumentNullException("path");
+            }
 
-            return new MockDirectoryInfo(mockFileDataAccessor, parent.FullName);
+            if (path.Length == 0)
+            {
+                throw new ArgumentException("Path cannot be the empty string or all whitespace.", "path");
+            }
+
+            if (path.IndexOfAny(mockFileDataAccessor.Path.GetInvalidPathChars()) > -1)
+            {
+                throw new ArgumentException("Path contains invalid path characters.", "path");
+            }
+
+            var absolutePath = mockFileDataAccessor.Path.GetFullPath(path);
+            var sepAsString = mockFileDataAccessor.Path.DirectorySeparatorChar.ToString(CultureInfo.InvariantCulture);
+            var startIndex = absolutePath.EndsWith(sepAsString, StringComparison.OrdinalIgnoreCase) ? absolutePath.Length - 1 : absolutePath.Length;
+            var lastIndex = absolutePath.LastIndexOf(mockFileDataAccessor.Path.DirectorySeparatorChar, startIndex - 1);
+            if (lastIndex < 0)
+            {
+                return null;
+            }
+
+            var parentPath = absolutePath.Substring(0, lastIndex);
+            if (string.IsNullOrEmpty(parentPath))
+            {
+                return null;
+            }
+
+            var parent = new MockDirectoryInfo(mockFileDataAccessor, parentPath);
+            return parent;
         }
 
         public override void Move(string sourceDirName, string destDirName) {

--- a/TestingHelpers/MockDirectoryInfo.cs
+++ b/TestingHelpers/MockDirectoryInfo.cs
@@ -11,10 +11,11 @@ namespace System.IO.Abstractions.TestingHelpers
         readonly IMockFileDataAccessor mockFileDataAccessor;
         readonly string directoryPath;
 
-        private static string EnsurePathEndsWithDirectorySeparator(string directoryPath) {
-            if (!directoryPath.EndsWith(Path.DirectorySeparatorChar.ToString(CultureInfo.InvariantCulture), StringComparison.OrdinalIgnoreCase))
-                directoryPath += Path.DirectorySeparatorChar;
-            return directoryPath;
+        private static string EnsurePathEndsWithDirectorySeparator(string path)
+        {
+            if (!path.EndsWith(Path.DirectorySeparatorChar.ToString(CultureInfo.InvariantCulture), StringComparison.OrdinalIgnoreCase))
+                path += Path.DirectorySeparatorChar;
+            return path;
         }
 
         public MockDirectoryInfo(IMockFileDataAccessor mockFileDataAccessor, string directoryPath)
@@ -72,7 +73,18 @@ namespace System.IO.Abstractions.TestingHelpers
 
         public override string FullName
         {
-            get { return directoryPath; }
+            get
+            {
+                var root = mockFileDataAccessor.Path.GetPathRoot(directoryPath);
+                if (string.Equals(directoryPath, root, StringComparison.OrdinalIgnoreCase))
+                {
+                    // drives have the trailing slash
+                    return directoryPath;
+                }
+
+                // directories do not have a trailing slash
+                return directoryPath.TrimEnd('\\');
+            }
         }
 
         public override DateTime LastAccessTime

--- a/TestingHelpers/MockFileSystem.cs
+++ b/TestingHelpers/MockFileSystem.cs
@@ -80,7 +80,9 @@ namespace System.IO.Abstractions.TestingHelpers
             lock (files)
             {
                 if (!directory.Exists(directoryPath))
-                    directory.CreateDirectory(directoryPath);
+                {
+                    AddDirectory(directoryPath);
+                }
 
                 files[fixedPath] = mockFile;
             }
@@ -96,8 +98,18 @@ namespace System.IO.Abstractions.TestingHelpers
                     (files[fixedPath].Attributes & FileAttributes.ReadOnly) == FileAttributes.ReadOnly)
                     throw new UnauthorizedAccessException(string.Format(CultureInfo.InvariantCulture, "Access to the path '{0}' is denied.", path));
 
-                files[fixedPath] = new MockDirectoryData();
-                directory.CreateDirectory(fixedPath);
+                var lastIndex = 0;
+                while ((lastIndex = path.IndexOf('\\', lastIndex + 1)) > -1)
+                {
+                    var segment = path.Substring(0, lastIndex + 1);
+                    if (!directory.Exists(segment))
+                    {
+                        files[segment] = new MockDirectoryData();
+                    }
+                }
+
+                var s = path.EndsWith("\\", StringComparison.OrdinalIgnoreCase) ? path : path + "\\";
+                files[s] = new MockDirectoryData();
             }
         }
 


### PR DESCRIPTION
adapted MockFileSystem.AddFile
- it now uses MockFileSystem.AddDirectory

adapted MockDirectory.CreateDirectory
- added vaildation of parameters
- removed recursion

adapted MockDirectory.GetParent
- needed because it did not return the proper values

adapted MockFileSystem.AddDirectory
- because with the other changes it would end in an infinite loop

added/adapted tests for these changes
