### PR TITLE
Fixed NullReferenceException behavior in MockDirectory.GetFiles

### DIFF
--- a/TestHelpers.Tests/MockDirectoryTests.cs
+++ b/TestHelpers.Tests/MockDirectoryTests.cs
@@ -505,6 +505,15 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
+        public void MockDirectory_GetFiles_ShouldThrowArgumentNullException_IfPathParamIsNull()
+        {
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>());
+
+            TestDelegate action = () => fileSystem.Directory.GetFiles(null);
+            Assert.Throws<ArgumentNullException>(action);
+        }
+
+        [Test]
         public void MockDirectory_GetFiles_ShouldThrowDirectoryNotFoundException_IfPathDoesNotExists()
         {
             // Arrange

--- a/TestingHelpers/MockDirectory.cs
+++ b/TestingHelpers/MockDirectory.cs
@@ -156,6 +156,9 @@ namespace System.IO.Abstractions.TestingHelpers
 
         public override string[] GetFiles(string path, string searchPattern, SearchOption searchOption)
         {
+            if(path == null)
+                throw new ArgumentNullException();
+
             if (!Exists(path))
             {
                 throw new DirectoryNotFoundException(string.Format(CultureInfo.InvariantCulture, "Could not find a part of the path '{0}'.", path));


### PR DESCRIPTION
MockDirectory.GetFiles was erroneously returning a NullReferenceException when passing
in a null path. Changed to match Directory.GetFiles behavior which is to
throw an ArgumentNullException.
