### PR TITLE
fixed Directory.Exists

### DIFF
--- a/TestHelpers.Tests/MockDirectoryTests.cs
+++ b/TestHelpers.Tests/MockDirectoryTests.cs
@@ -375,6 +375,25 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             Assert.IsTrue(result);
         }
 
+        [TestCase(@"\\s")]
+        [TestCase(@"<")]
+        [TestCase("\t")]
+        public void MockDirectory_Exists_ShouldReturnFalseForIllegalPath(string path)
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { @"c:\foo\bar.txt", new MockFileData("Demo text content") },
+                { @"c:\baz.txt", new MockFileData("Demo text content") }
+            });
+
+            // Act
+            var result = fileSystem.Directory.Exists(path);
+
+            // Assert
+            Assert.IsFalse(result);
+        }
+
         [Test]
         public void MockDirectory_CreateDirectory_ShouldCreateFolderInMemoryFileSystem()
         {

--- a/TestingHelpers/MockDirectory.cs
+++ b/TestingHelpers/MockDirectory.cs
@@ -83,10 +83,17 @@ namespace System.IO.Abstractions.TestingHelpers
 
         public override bool Exists(string path)
         {
-            path = EnsurePathEndsWithDirectorySeparator(path);
+            try
+            {
+                path = EnsurePathEndsWithDirectorySeparator(path);
 
-            path = mockFileDataAccessor.Path.GetFullPath(path);
-            return mockFileDataAccessor.AllDirectories.Any(p => p.Equals(path, StringComparison.OrdinalIgnoreCase));
+                path = mockFileDataAccessor.Path.GetFullPath(path);
+                return mockFileDataAccessor.AllDirectories.Any(p => p.Equals(path, StringComparison.OrdinalIgnoreCase));
+            }
+            catch (Exception)
+            {
+                return false;
+            }
         }
 
         public override DirectorySecurity GetAccessControl(string path)


### PR DESCRIPTION
the method `Directory.Exists` should never throw an exception. it should then return `false`
fixes #86
