### PR TITLE
Added support in MockFileInfo for both get and set of properties includi...

### DIFF
--- a/TestHelpers.Tests/MockFileInfoTests.cs
+++ b/TestHelpers.Tests/MockFileInfoTests.cs
@@ -100,6 +100,198 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
+        public void MockFileInfo_CreationTimeUtc_ShouldSetCreationTimeUtcOfFileInMemoryFileSystem()
+        {
+            // Arrange
+            var creationTime = DateTime.Now.AddHours(-4);
+            var fileData = new MockFileData("Demo text content") { CreationTime = creationTime };
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { @"c:\a.txt", fileData }
+            });
+            var fileInfo = new MockFileInfo(fileSystem, @"c:\a.txt");
+
+            // Act
+            var newUtcTime = DateTime.UtcNow;
+            fileInfo.CreationTimeUtc = newUtcTime;
+
+            // Assert
+            Assert.AreEqual(newUtcTime, fileInfo.CreationTimeUtc);
+        }
+
+
+        [Test]
+        public void MockFileInfo_CreationTime_ShouldReturnCreationTimeOfFileInMemoryFileSystem()
+        {
+            // Arrange
+            var creationTime = DateTime.Now.AddHours(-4);
+            var fileData = new MockFileData("Demo text content") { CreationTime = creationTime };
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { @"c:\a.txt", fileData }
+            });
+            var fileInfo = new MockFileInfo(fileSystem, @"c:\a.txt");
+
+            // Act
+            var result = fileInfo.CreationTime;
+
+            // Assert
+            Assert.AreEqual(creationTime, result);
+        }
+
+        [Test]
+        public void MockFileInfo_CreationTime_ShouldSetCreationTimeOfFileInMemoryFileSystem()
+        {
+            // Arrange
+            var creationTime = DateTime.Now.AddHours(-4);
+            var fileData = new MockFileData("Demo text content") { CreationTime = creationTime };
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { @"c:\a.txt", fileData }
+            });
+            var fileInfo = new MockFileInfo(fileSystem, @"c:\a.txt");
+
+            // Act
+            var newTime = DateTime.Now;
+            fileInfo.CreationTime = newTime;
+
+            // Assert
+            Assert.AreEqual(newTime, fileInfo.CreationTime);
+        }
+
+        [Test]
+        public void MockFileInfo_IsReadOnly_ShouldSetReadOnlyAttributeOfFileInMemoryFileSystem()
+        {
+            // Arrange
+            var fileData = new MockFileData("Demo text content");
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { @"c:\a.txt", fileData }
+            });
+            var fileInfo = new MockFileInfo(fileSystem, @"c:\a.txt");
+
+            // Act
+            fileInfo.IsReadOnly = true;
+
+            // Assert
+            Assert.AreEqual(FileAttributes.ReadOnly, fileData.Attributes & FileAttributes.ReadOnly);
+        }
+
+        [Test]
+        public void MockFileInfo_IsReadOnly_ShouldSetNotReadOnlyAttributeOfFileInMemoryFileSystem()
+        {
+            // Arrange
+            var fileData = new MockFileData("Demo text content") {Attributes = FileAttributes.ReadOnly};
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { @"c:\a.txt", fileData }
+            });
+            var fileInfo = new MockFileInfo(fileSystem, @"c:\a.txt");
+
+            // Act
+            fileInfo.IsReadOnly = false;
+
+            // Assert
+            Assert.AreNotEqual(FileAttributes.ReadOnly, fileData.Attributes & FileAttributes.ReadOnly);
+        }
+
+        [Test]
+        public void MockFileInfo_AppendText_ShouldAddTextToFileInMemoryFileSystem()
+        {
+            // Arrange
+            var fileData = new MockFileData("Demo text content");
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { @"c:\a.txt", fileData }
+            });
+            var fileInfo = new MockFileInfo(fileSystem, @"c:\a.txt");
+
+            // Act
+            using (var file = fileInfo.AppendText())
+                file.WriteLine("This should be at the end");
+
+            string newcontents;
+            using (var newfile = fileInfo.OpenText())
+                newcontents = newfile.ReadToEnd();
+
+            // Assert
+            Assert.AreEqual("Demo text contentThis should be at the end\r\n", newcontents);
+        }
+
+        [Test]
+        public void MockFileInfo_OpenWrite_ShouldAddDataToFileInMemoryFileSystem()
+        {
+            // Arrange
+            var fileData = new MockFileData("Demo text content");
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { @"c:\a.txt", fileData }
+            });
+            var fileInfo = new MockFileInfo(fileSystem, @"c:\a.txt");
+            var bytesToAdd = new byte[] {65, 66, 67, 68, 69};
+
+            // Act
+            using (var file = fileInfo.OpenWrite())
+                file.Write(bytesToAdd, 0, bytesToAdd.Length);
+
+            string newcontents;
+            using (var newfile = fileInfo.OpenText())
+                newcontents = newfile.ReadToEnd();
+
+            // Assert
+            Assert.AreEqual("ABCDEtext content", newcontents);
+        }
+
+        [Test]
+        public void MockFileInfo_Encrypt_ShouldReturnXorOfFileInMemoryFileSystem()
+        {
+            // Arrange
+            var fileData = new MockFileData("Demo text content");
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { @"c:\a.txt", fileData }
+            });
+            var fileInfo = new MockFileInfo(fileSystem, @"c:\a.txt");
+
+            // Act
+            fileInfo.Encrypt();
+
+            string newcontents;
+            using (var newfile = fileInfo.OpenText())
+            {
+                newcontents = newfile.ReadToEnd();
+            }
+
+            // Assert
+            Assert.AreNotEqual("Demo text content", newcontents);
+        }
+
+        [Test]
+        public void MockFileInfo_Decrypt_ShouldReturnCorrectContentsFileInMemoryFileSystem()
+        {
+            // Arrange
+            var fileData = new MockFileData("Demo text content");
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { @"c:\a.txt", fileData }
+            });
+            var fileInfo = new MockFileInfo(fileSystem, @"c:\a.txt");
+            fileInfo.Encrypt();
+
+            // Act
+            fileInfo.Decrypt();
+
+            string newcontents;
+            using (var newfile = fileInfo.OpenText())
+            {
+                newcontents = newfile.ReadToEnd();
+            }
+
+            // Assert
+            Assert.AreEqual("Demo text content", newcontents);
+        }
+
+        [Test]
         public void MockFileInfo_LastAccessTimeUtc_ShouldReturnLastAccessTimeUtcOfFileInMemoryFileSystem()
         {
             // Arrange
@@ -116,6 +308,26 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             // Assert
             Assert.AreEqual(lastAccessTime.ToUniversalTime(), result);
+        }
+
+        [Test]
+        public void MockFileInfo_LastAccessTimeUtc_ShouldSetCreationTimeUtcOfFileInMemoryFileSystem()
+        {
+            // Arrange
+            var lastAccessTime = DateTime.Now.AddHours(-4);
+            var fileData = new MockFileData("Demo text content") { LastAccessTime = lastAccessTime };
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { @"c:\a.txt", fileData }
+            });
+            var fileInfo = new MockFileInfo(fileSystem, @"c:\a.txt");
+
+            // Act
+            var newUtcTime = DateTime.UtcNow;
+            fileInfo.LastAccessTimeUtc = newUtcTime;
+
+            // Assert
+            Assert.AreEqual(newUtcTime, fileInfo.LastAccessTimeUtc);
         }
 
         [Test]
@@ -136,7 +348,27 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             // Assert
             Assert.AreEqual(lastWriteTime.ToUniversalTime(), result);
         }
- 
+
+        [Test]
+        public void MockFileInfo_LastWriteTimeUtc_ShouldSetLastWriteTimeUtcOfFileInMemoryFileSystem()
+        {
+            // Arrange
+            var lastWriteTime = DateTime.Now.AddHours(-4);
+            var fileData = new MockFileData("Demo text content") { LastWriteTime = lastWriteTime };
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { @"c:\a.txt", fileData }
+            });
+            var fileInfo = new MockFileInfo(fileSystem, @"c:\a.txt");
+
+            // Act
+            var newUtcTime = DateTime.UtcNow;
+            fileInfo.LastWriteTime = newUtcTime;
+
+            // Assert
+            Assert.AreEqual(newUtcTime, fileInfo.LastWriteTime);
+        }
+
         [Test]
         public void MockFileInfo_GetExtension_ShouldReturnExtension()
         {

--- a/TestingHelpers/MockFileInfo.cs
+++ b/TestingHelpers/MockFileInfo.cs
@@ -1,4 +1,6 @@
-﻿using System.Security.AccessControl;
+﻿using System.IO.Pipes;
+using System.Linq;
+using System.Security.AccessControl;
 
 namespace System.IO.Abstractions.TestingHelpers
 {
@@ -41,8 +43,16 @@ namespace System.IO.Abstractions.TestingHelpers
 
         public override DateTime CreationTime
         {
-            get { throw new NotImplementedException("This test helper hasn't been implemented yet. They are implemented on an as-needed basis. As it seems like you need it, now would be a great time to send us a pull request over at https://github.com/tathamoddie/System.IO.Abstractions. You know, because it's open source and all."); }
-            set { throw new NotImplementedException("This test helper hasn't been implemented yet. They are implemented on an as-needed basis. As it seems like you need it, now would be a great time to send us a pull request over at https://github.com/tathamoddie/System.IO.Abstractions. You know, because it's open source and all."); }
+            get
+            {
+                if (MockFileData == null) throw new FileNotFoundException("File not found", path);
+                return MockFileData.CreationTime.DateTime;
+            }
+            set
+            {
+                if (MockFileData == null) throw new FileNotFoundException("File not found", path);
+                MockFileData.CreationTime = value;
+            }
         }
 
         public override DateTime CreationTimeUtc
@@ -52,7 +62,11 @@ namespace System.IO.Abstractions.TestingHelpers
                 if (MockFileData == null) throw new FileNotFoundException("File not found", path);
                 return MockFileData.CreationTime.UtcDateTime;
             }
-            set { throw new NotImplementedException("This test helper hasn't been implemented yet. They are implemented on an as-needed basis. As it seems like you need it, now would be a great time to send us a pull request over at https://github.com/tathamoddie/System.IO.Abstractions. You know, because it's open source and all."); }
+            set
+            {
+                if (MockFileData == null) throw new FileNotFoundException("File not found", path);
+                MockFileData.CreationTime = value.ToLocalTime();
+            }
         }
 
         public override bool Exists
@@ -77,8 +91,16 @@ namespace System.IO.Abstractions.TestingHelpers
 
         public override DateTime LastAccessTime
         {
-            get { throw new NotImplementedException("This test helper hasn't been implemented yet. They are implemented on an as-needed basis. As it seems like you need it, now would be a great time to send us a pull request over at https://github.com/tathamoddie/System.IO.Abstractions. You know, because it's open source and all."); }
-            set { throw new NotImplementedException("This test helper hasn't been implemented yet. They are implemented on an as-needed basis. As it seems like you need it, now would be a great time to send us a pull request over at https://github.com/tathamoddie/System.IO.Abstractions. You know, because it's open source and all."); }
+            get
+            {
+                if (MockFileData == null) throw new FileNotFoundException("File not found", path);
+                return MockFileData.LastAccessTime.DateTime;
+            }
+            set
+            {
+                if (MockFileData == null) throw new FileNotFoundException("File not found", path);
+                MockFileData.LastAccessTime = value;
+            }
         }
 
         public override DateTime LastAccessTimeUtc
@@ -88,7 +110,11 @@ namespace System.IO.Abstractions.TestingHelpers
                 if (MockFileData == null) throw new FileNotFoundException("File not found", path);
                 return MockFileData.LastAccessTime.UtcDateTime;
             }
-            set { throw new NotImplementedException("This test helper hasn't been implemented yet. They are implemented on an as-needed basis. As it seems like you need it, now would be a great time to send us a pull request over at https://github.com/tathamoddie/System.IO.Abstractions. You know, because it's open source and all."); }
+            set
+            {
+                if (MockFileData == null) throw new FileNotFoundException("File not found", path);
+                MockFileData.LastAccessTime = value;
+            }
         }
 
         public override DateTime LastWriteTime
@@ -98,7 +124,11 @@ namespace System.IO.Abstractions.TestingHelpers
                 if (MockFileData == null) throw new FileNotFoundException("File not found", path);
                 return MockFileData.LastWriteTime.DateTime;
             }
-            set { throw new NotImplementedException("This test helper hasn't been implemented yet. They are implemented on an as-needed basis. As it seems like you need it, now would be a great time to send us a pull request over at https://github.com/tathamoddie/System.IO.Abstractions. You know, because it's open source and all."); }
+            set
+            {
+                if (MockFileData == null) throw new FileNotFoundException("File not found", path);
+                MockFileData.LastWriteTime = value;
+            }
         }
 
         public override DateTime LastWriteTimeUtc
@@ -108,7 +138,11 @@ namespace System.IO.Abstractions.TestingHelpers
                 if (MockFileData == null) throw new FileNotFoundException("File not found", path);
                 return MockFileData.LastWriteTime.UtcDateTime;    
             }
-            set { throw new NotImplementedException("This test helper hasn't been implemented yet. They are implemented on an as-needed basis. As it seems like you need it, now would be a great time to send us a pull request over at https://github.com/tathamoddie/System.IO.Abstractions. You know, because it's open source and all."); }
+            set
+            {
+                if (MockFileData == null) throw new FileNotFoundException("File not found", path);
+                MockFileData.LastWriteTime = value.ToLocalTime();
+            }
         }
 
         public override string Name {
@@ -117,7 +151,9 @@ namespace System.IO.Abstractions.TestingHelpers
 
         public override StreamWriter AppendText()
         {
-            throw new NotImplementedException("This test helper hasn't been implemented yet. They are implemented on an as-needed basis. As it seems like you need it, now would be a great time to send us a pull request over at https://github.com/tathamoddie/System.IO.Abstractions. You know, because it's open source and all.");
+            if (MockFileData == null) throw new FileNotFoundException("File not found", path);
+            return new StreamWriter(new MockFileStream(mockFileSystem, FullName, true));
+            //return ((MockFileDataModifier) MockFileData).AppendText();
         }
 
         public override FileInfoBase CopyTo(string destFileName)
@@ -144,12 +180,18 @@ namespace System.IO.Abstractions.TestingHelpers
 
         public override void Decrypt()
         {
-            throw new NotImplementedException("This test helper hasn't been implemented yet. They are implemented on an as-needed basis. As it seems like you need it, now would be a great time to send us a pull request over at https://github.com/tathamoddie/System.IO.Abstractions. You know, because it's open source and all.");
+            if (MockFileData == null) throw new FileNotFoundException("File not found", path);
+            var contents = MockFileData.Contents;
+            for (var i = 0; i < contents.Length; i++)
+                contents[i] ^= (byte)(i % 256);
         }
 
         public override void Encrypt()
         {
-            throw new NotImplementedException("This test helper hasn't been implemented yet. They are implemented on an as-needed basis. As it seems like you need it, now would be a great time to send us a pull request over at https://github.com/tathamoddie/System.IO.Abstractions. You know, because it's open source and all.");
+            if (MockFileData == null) throw new FileNotFoundException("File not found", path);
+            var contents = MockFileData.Contents;
+            for(var i = 0; i < contents.Length; i++)
+                contents[i] ^= (byte) (i % 256);
         }
 
         public override FileSecurity GetAccessControl()
@@ -195,7 +237,7 @@ namespace System.IO.Abstractions.TestingHelpers
 
         public override Stream OpenWrite()
         {
-            throw new NotImplementedException("This test helper hasn't been implemented yet. They are implemented on an as-needed basis. As it seems like you need it, now would be a great time to send us a pull request over at https://github.com/tathamoddie/System.IO.Abstractions. You know, because it's open source and all.");
+            return new MockFileStream(mockFileSystem, path);
         }
 
         public override FileInfoBase Replace(string destinationFileName, string destinationBackupFileName)
@@ -233,8 +275,19 @@ namespace System.IO.Abstractions.TestingHelpers
 
         public override bool IsReadOnly
         {
-            get { throw new NotImplementedException("This test helper hasn't been implemented yet. They are implemented on an as-needed basis. As it seems like you need it, now would be a great time to send us a pull request over at https://github.com/tathamoddie/System.IO.Abstractions. You know, because it's open source and all."); }
-            set { throw new NotImplementedException("This test helper hasn't been implemented yet. They are implemented on an as-needed basis. As it seems like you need it, now would be a great time to send us a pull request over at https://github.com/tathamoddie/System.IO.Abstractions. You know, because it's open source and all."); }
+            get
+            {
+                if (MockFileData == null) throw new FileNotFoundException("File not found", path);
+                return (MockFileData.Attributes & FileAttributes.ReadOnly) == FileAttributes.ReadOnly;
+            }
+            set
+            {
+                if (MockFileData == null) throw new FileNotFoundException("File not found", path);
+                if(value)
+                    MockFileData.Attributes |= FileAttributes.ReadOnly;
+                else 
+                    MockFileData.Attributes &= ~FileAttributes.ReadOnly;
+            }
         }
 
         public override long Length

--- a/TestingHelpers/MockFileStream.cs
+++ b/TestingHelpers/MockFileStream.cs
@@ -6,7 +6,7 @@
         readonly IMockFileDataAccessor mockFileDataAccessor;
         readonly string path;
 
-        public MockFileStream(IMockFileDataAccessor mockFileDataAccessor, string path)
+        public MockFileStream(IMockFileDataAccessor mockFileDataAccessor, string path, bool forAppend = false)
         {
             this.mockFileDataAccessor = mockFileDataAccessor;
             this.path = path;
@@ -15,8 +15,13 @@
             {
                 /* only way to make an expandable MemoryStream that starts with a particular content */
                 var data = mockFileDataAccessor.GetFile(path).Contents;
-                base.Write(data, 0, data.Length);
-                base.Seek(0, SeekOrigin.Begin);
+                if (data != null && data.Length > 0)
+                {
+                    base.Write(data, 0, data.Length);
+                    base.Seek(0, forAppend
+                        ? SeekOrigin.End
+                        : SeekOrigin.Begin);
+                }
             }
         }
 


### PR DESCRIPTION
...ng:

CreationTime, CreationTimeUtc,
LastAccessTime, LastAccessTimeUtc,
LastWriteTime, LastWriteTimeUtc,
IsReadOnly.

Encrypt and Decrypt will now respond by internally performing a XOR across the byte array.

OpenWrite and AppendText now work.

NOTE: No attempt is currently made to insure a file marked read only file is not written to.

Tests added to cover these new features.
MockFileStream supports append (defaults to no append)
