### PR TITLE
Fixing interpretation of search patterns

### DIFF
--- a/TestHelpers.Tests/MockDirectoryTests.cs
+++ b/TestHelpers.Tests/MockDirectoryTests.cs
@@ -16,12 +16,14 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var fileSystem = SetupFileSystem();
             var expected = new[]
             {
-                XFS.Path(@"c:\a\a.txt"),
-                XFS.Path(@"c:\a\b.gif"),
-                XFS.Path(@"c:\a\c.txt"),
-                XFS.Path(@"c:\a\a\a.txt"),
-                XFS.Path(@"c:\a\a\b.txt"),
-                XFS.Path(@"c:\a\a\c.gif")
+                XFS.Path(@"c:\a\testA.so"),
+                XFS.Path(@"c:\a\testB.gif"),
+                XFS.Path(@"c:\a\testC.txt"),
+                XFS.Path(@"c:\a\a\testA.so"),
+                XFS.Path(@"c:\a\a\testA.so1"),
+                XFS.Path(@"c:\a\a\testB.txt"),
+                XFS.Path(@"c:\a\a\testB.txtold"),
+                XFS.Path(@"c:\a\a\testC.gif")
             };
 
             // Act
@@ -35,15 +37,18 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         {
             return new MockFileSystem(new Dictionary<string, MockFileData>
             {
-                { XFS.Path(@"c:\a.gif"), new MockFileData("Demo text content") },
-                { XFS.Path(@"c:\b.txt"), new MockFileData("Demo text content") },
-                { XFS.Path(@"c:\c.txt"), new MockFileData("Demo text content") },
-                { XFS.Path(@"c:\a\a.txt"), new MockFileData("Demo text content") },
-                { XFS.Path(@"c:\a\b.gif"), new MockFileData("Demo text content") },
-                { XFS.Path(@"c:\a\c.txt"), new MockFileData("Demo text content") },
-                { XFS.Path(@"c:\a\a\a.txt"), new MockFileData("Demo text content") },
-                { XFS.Path(@"c:\a\a\b.txt"), new MockFileData("Demo text content") },
-                { XFS.Path(@"c:\a\a\c.gif"), new MockFileData("Demo text content") },
+                { XFS.Path(@"c:\testA.gif"), new MockFileData("Demo text content") },
+                { XFS.Path(@"c:\testB.txt"), new MockFileData("Demo text content") },
+                { XFS.Path(@"c:\testC.txt"), new MockFileData("Demo text content") },
+                { XFS.Path(@"c:\a\testA.so"), new MockFileData("Demo text content") },
+                { XFS.Path(@"c:\a\testB.gif"), new MockFileData("Demo text content") },
+                { XFS.Path(@"c:\a\testC.txt"), new MockFileData("Demo text content") },
+                { XFS.Path(@"c:\a\a\testA.so"), new MockFileData("Demo text content") },
+                { XFS.Path(@"c:\a\a\testA.so1"), new MockFileData("Demo text content") },
+                { XFS.Path(@"c:\a\a\testB.txt"), new MockFileData("Demo text content") },
+                { XFS.Path(@"c:\a\a\testB.txtold"), new MockFileData("Demo text content") },
+                { XFS.Path(@"c:\a\a\testC.gif"), new MockFileData("Demo text content") },
+                { XFS.Path(@"c:\a\emptysub\"), new MockDirectoryData() },
             });
             
         }
@@ -55,9 +60,9 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var fileSystem = SetupFileSystem();
             var expected = new[]
             {
-                XFS.Path(@"c:\a\a.txt"),
-                XFS.Path(@"c:\a\b.gif"),
-                XFS.Path(@"c:\a\c.txt")
+                XFS.Path(@"c:\a\testA.so"),
+                XFS.Path(@"c:\a\testB.gif"),
+                XFS.Path(@"c:\a\testC.txt")
             };
 
             // Act
@@ -74,9 +79,9 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var fileSystem = SetupFileSystem();
             var expected = new[]
             {
-                XFS.Path(@"c:\a.gif"),
-                XFS.Path(@"c:\a\b.gif"),
-                XFS.Path(@"c:\a\a\c.gif")
+                XFS.Path(@"c:\testA.gif"),
+                XFS.Path(@"c:\a\testB.gif"),
+                XFS.Path(@"c:\a\a\testC.gif")
             };
 
             // Act
@@ -143,7 +148,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         {
             // Arrange
             var fileSystem = SetupFileSystem();
-            var expected = new[] { XFS.Path(@"c:\a.gif") };
+            var expected = new[] { XFS.Path(@"c:\testA.gif") };
 
             // Act
             var result = fileSystem.Directory.GetFiles(XFS.Path(@"c:\"), "*.gif", SearchOption.TopDirectoryOnly);
@@ -993,12 +998,14 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var fileSystem = SetupFileSystem();
             IEnumerable<string> expected = new[]
             {
-                XFS.Path(@"c:\a\a.txt"),
-                XFS.Path(@"c:\a\b.gif"),
-                XFS.Path(@"c:\a\c.txt"),
-                XFS.Path(@"c:\a\a\a.txt"),
-                XFS.Path(@"c:\a\a\b.txt"),
-                XFS.Path(@"c:\a\a\c.gif")
+                XFS.Path(@"c:\a\testA.so"),
+                XFS.Path(@"c:\a\testB.gif"),
+                XFS.Path(@"c:\a\testC.txt"),
+                XFS.Path(@"c:\a\a\testA.so"),
+                XFS.Path(@"c:\a\a\testA.so1"),
+                XFS.Path(@"c:\a\a\testB.txt"),
+                XFS.Path(@"c:\a\a\testB.txtold"),
+                XFS.Path(@"c:\a\a\testC.gif")
             };
 
             // Act
@@ -1015,9 +1022,9 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var fileSystem = SetupFileSystem();
             var expected = new[]
             {
-                XFS.Path(@"c:\a.gif"),
-                XFS.Path(@"c:\a\b.gif"),
-                XFS.Path(@"c:\a\a\c.gif")
+                XFS.Path(@"c:\testA.gif"),
+                XFS.Path(@"c:\a\testB.gif"),
+                XFS.Path(@"c:\a\a\testC.gif")
             };
 
             // Act
@@ -1028,19 +1035,22 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
-        public void MockDirectory_EnumerateFileSystemEntries_ShouldReturnAllFilesBelowPathWhenPatternIsWildcardAndSearchOptionIsAllDirectories()
+        public void MockDirectory_EnumerateFileSystemEntries_ShouldReturnAllFilesAndDirectoriesBelowPathWhenPatternIsWildcardAndSearchOptionIsAllDirectories()
         {
             // Arrange
             var fileSystem = SetupFileSystem();
             IEnumerable<string> expected = new[]
             {
-                XFS.Path(@"c:\a\a.txt"),
-                XFS.Path(@"c:\a\b.gif"),
-                XFS.Path(@"c:\a\c.txt"),
-                XFS.Path(@"c:\a\a\a.txt"),
-                XFS.Path(@"c:\a\a\b.txt"),
-                XFS.Path(@"c:\a\a\c.gif"),
-                XFS.Path(@"c:\a\a\")
+                XFS.Path(@"c:\a\testA.so"),
+                XFS.Path(@"c:\a\testB.gif"),
+                XFS.Path(@"c:\a\testC.txt"),
+                XFS.Path(@"c:\a\a\testA.so"),
+                XFS.Path(@"c:\a\a\testA.so1"),
+                XFS.Path(@"c:\a\a\testB.txt"),
+                XFS.Path(@"c:\a\a\testB.txtold"),
+                XFS.Path(@"c:\a\a\testC.gif"),
+                XFS.Path(@"c:\a\a\"),
+                XFS.Path(@"c:\a\emptysub\")
             };
 
             // Act
@@ -1057,9 +1067,9 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var fileSystem = SetupFileSystem();
             var expected = new[]
             {
-                XFS.Path(@"c:\a.gif"),
-                XFS.Path(@"c:\a\b.gif"),
-                XFS.Path(@"c:\a\a\c.gif")
+                XFS.Path(@"c:\testA.gif"),
+                XFS.Path(@"c:\a\testB.gif"),
+                XFS.Path(@"c:\a\a\testC.gif")
             };
 
             // Act

--- a/TestHelpers.Tests/MockDirectoryTests.cs
+++ b/TestHelpers.Tests/MockDirectoryTests.cs
@@ -54,6 +54,49 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
+        public void MockDirectory_GetFiles_ShouldFilterByTwoLetterExtensionBasedSearchPattern()
+        {
+            var fileSystem = SetupFileSystem();
+
+            var expected = new[]
+            {
+                XFS.Path(@"c:\a\testA.so"),
+                XFS.Path(@"c:\a\a\testA.so")
+            };
+
+            var result = fileSystem.Directory.GetFiles(XFS.Path(@"c:\a"), "te*.so", SearchOption.AllDirectories);
+            Assert.That(result, Is.EquivalentTo(expected));
+
+            result = fileSystem.Directory.GetFiles(XFS.Path(@"c:\a"), "test?.so", SearchOption.AllDirectories);
+            Assert.That(result, Is.EquivalentTo(expected));
+        }
+
+        [Test]
+        public void MockDirectory_GetFiles_ShouldFilterByThreeLetterExtensionBasedSearchPattern()
+        {
+            var fileSystem = SetupFileSystem();
+
+            var expectedForAsteriskWildcard = new[]
+            {
+                XFS.Path(@"c:\a\testC.txt"),
+                XFS.Path(@"c:\a\a\testB.txt"),
+                XFS.Path(@"c:\a\a\testB.txtold")
+            };
+
+            var result = fileSystem.Directory.GetFiles(XFS.Path(@"c:\a"), "te*.txt", SearchOption.AllDirectories);
+            Assert.That(result, Is.EquivalentTo(expectedForAsteriskWildcard));
+
+            var expectedForQuestionmarkWildcard = new[]
+            {
+                XFS.Path(@"c:\a\testC.txt"),
+                XFS.Path(@"c:\a\a\testB.txt"),
+            };
+
+            result = fileSystem.Directory.GetFiles(XFS.Path(@"c:\a"), "test?.txt", SearchOption.AllDirectories);
+            Assert.That(result, Is.EquivalentTo(expectedForQuestionmarkWildcard));
+        }
+
+        [Test]
         public void MockDirectory_GetFiles_ShouldReturnFilesDirectlyBelowPathWhenPatternIsWildcardAndSearchOptionIsTopDirectoryOnly()
         {
             // Arrange
@@ -67,25 +110,6 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             // Act
             var result = fileSystem.Directory.GetFiles(XFS.Path(@"c:\a"), "*", SearchOption.TopDirectoryOnly);
-
-            // Assert
-            Assert.That(result, Is.EquivalentTo(expected));
-        }
-
-        [Test]
-        public void MockDirectory_GetFiles_ShouldFilterByExtensionBasedSearchPattern()
-        {
-            // Arrange
-            var fileSystem = SetupFileSystem();
-            var expected = new[]
-            {
-                XFS.Path(@"c:\testA.gif"),
-                XFS.Path(@"c:\a\testB.gif"),
-                XFS.Path(@"c:\a\a\testC.gif")
-            };
-
-            // Act
-            var result = fileSystem.Directory.GetFiles(XFS.Path(@"c:\"), "*.gif", SearchOption.AllDirectories);
 
             // Assert
             Assert.That(result, Is.EquivalentTo(expected));
@@ -115,7 +139,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             };
 
             // Act
-            var result = fileSystem.Directory.GetFiles(XFS.Path(@"c:\"), "*.gif", SearchOption.AllDirectories);
+            var result = fileSystem.Directory.GetFiles(XFS.Path(@"C:\"), "*.gif", SearchOption.AllDirectories);
 
             // Assert
             Assert.That(result, Is.EquivalentTo( expected));
@@ -546,7 +570,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             // Assert
             Assert.IsFalse(fileSystem.Directory.Exists(XFS.Path(@"c:\bar")));
-            Assert.IsFalse(fileSystem.Directory.Exists(XFS.Path(@"c:\bar\bar2")));
+            Assert.IsFalse(fileSystem.Directory.Exists(XFS.Path(@"C:\bar\bar2")));
         }
 
         [Test]
@@ -669,6 +693,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.AddDirectory(XFS.Path(@"C:\Folder\.foo\"));
             fileSystem.AddDirectory(XFS.Path(@"C:\Folder\foo"));
             fileSystem.AddDirectory(XFS.Path(@"C:\Folder\foo.foo"));
+            fileSystem.AddDirectory(XFS.Path(@"C:\Folder\foo.foobar"));
             fileSystem.AddDirectory(XFS.Path(@"C:\Folder\.foo\.foo"));
             fileSystem.AddFile(XFS.Path(@"C:\Folder\.foo\bar"), new MockFileData(string.Empty));
 
@@ -687,6 +712,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.AddDirectory(XFS.Path(@"C:\Folder\.foo\"));
             fileSystem.AddDirectory(XFS.Path(@"C:\Folder\foo"));
             fileSystem.AddDirectory(XFS.Path(@"C:\Folder\foo.foo"));
+            fileSystem.AddDirectory(XFS.Path(@"C:\Folder\foo.foobar"));
             fileSystem.AddDirectory(XFS.Path(@"C:\Folder\.foo\.foo"));
             fileSystem.AddFile(XFS.Path(@"C:\Folder\.foo\bar"), new MockFileData(string.Empty));
 

--- a/TestHelpers.Tests/StringExtensionsTests.cs
+++ b/TestHelpers.Tests/StringExtensionsTests.cs
@@ -58,5 +58,27 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             Assert.That(result, Is.EquivalentTo(expected));
         }
 
+        [TestCase("*", Result = @"^.*$")]
+        [TestCase("nowildcard.txt", Result = @"^nowildcard\.txt$")]
+        [TestCase("*.txt", Result = @"^.*\.txt.*$")]
+        [TestCase("test?.txt", Result = @"^test.\.txt$")]
+        [TestCase("*.so", Result = @"^.*\.so$")]
+        [TestCase("*.abcd", Result = @"^.*\.abcd$")]
+        public string WildcardToRegexForFilenames(string wildcard)
+        {
+            return wildcard.WildcardToRegex(forFilename: true);
+        }
+
+        [TestCase("*", Result = @"^.*$")]
+        [TestCase("nowildcard.txt", Result = @"^nowildcard\.txt$")]
+        [TestCase("*.txt", Result = @"^.*\.txt$")]
+        [TestCase("test?.txt", Result = @"^test.\.txt$")]
+        [TestCase("*.so", Result = @"^.*\.so$")]
+        [TestCase("*.abcd", Result = @"^.*\.abcd$")]
+        public string WildcardToRegex(string wildcard)
+        {
+            return wildcard.WildcardToRegex();
+        }
+
     }
 }

--- a/TestingHelpers/StringExtensions.cs
+++ b/TestingHelpers/StringExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace System.IO.Abstractions.TestingHelpers
 {
@@ -19,6 +20,30 @@ namespace System.IO.Abstractions.TestingHelpers
             }
 
             return list.ToArray();
+        }
+
+        // from http://www.codeproject.com/Articles/11556/Converting-Wildcards-to-Regexes
+        // with some adaptions to match the rules on
+        // https://msdn.microsoft.com/en-us/library/ms143327%28v=vs.110%29.aspx
+        internal static string WildcardToRegex(this string pattern, bool forFilename = false)
+        {
+            var appendExtensionWildcard = false;
+
+            if (forFilename && pattern.Contains("*"))
+            {
+                // bla.txt => .txt
+                var extension = Path.GetExtension(pattern);
+                if (extension.Length == 4)
+                {
+                    appendExtensionWildcard = true;
+                }
+            }
+
+            return "^" + Regex.Escape(pattern)
+                              .Replace(@"\*", ".*")
+                              .Replace(@"\?", ".")
+                       + (appendExtensionWildcard ? ".*" : "") 
+                       + "$";
         }
 
         [Pure]


### PR DESCRIPTION
The `searchPattern` passed on to `GetFiles(...)` should be processed as Microsoft [describes](https://msdn.microsoft.com/de-de/library/wz42302f%28v=vs.110%29.aspx):

> When using the asterisk wildcard character in a searchPattern, such as "_.txt", the matching behavior when the extension is exactly three characters long is different than when the extension is more or less than three characters long. A searchPattern with a file extension of exactly three characters returns files having an extension of three or more characters, where the first three characters match the file extension specified in the searchPattern. A searchPattern with a file extension of one, two, or more than three characters returns only files having extensions of exactly that length that match the file extension specified in the searchPattern. When using the question mark wildcard character, this method returns only files that match the specified file extension. For example, given two files, "file1.txt" and "file1.txtother", in a directory, a search pattern of "file?.txt" returns just the first file, while a search pattern of "file_.txt" returns both files. 

In the current implementation of [`GetFilesInternal(...)`](https://github.com/tathamoddie/System.IO.Abstractions/blob/71c432a1b06be7153532293799012a68b038bf45/TestingHelpers/MockDirectory.cs#L171-L198), there are various regular expressions concerning invalid path chars. I think those are not neccessary:
1. It shouldn't be able to add Files and Directories with invalid chars to the _MockFileSystem_.
2. An exception should be thrown if a path containing invalid paths is passed on to `GetFiles(...)`.

For 2), I've filed an independent pull request (#131).

As the special searchPattern-behaviour for three-letter-extensions is not used by `GetDirectories(...)` I had to introduce a new method `GetDirectoriesInternal(...)`.
