### PR TITLE
Reworking throwing exceptions in MockDirectory

### DIFF
--- a/TestHelpers.Tests/MockDirectoryTests.cs
+++ b/TestHelpers.Tests/MockDirectoryTests.cs
@@ -907,29 +907,35 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
-        public void MockDirectory_GetParent_ShouldThrowArgumentNullExceptionIfPathIsNull()
-        {
-            // Arrange
+        [TestCase(null,
+            ExpectedException = typeof(ArgumentNullException))]
+        [TestCase("",
+            ExpectedException = typeof(ArgumentException),
+            ExpectedMessage = "Path cannot be the empty string or all whitespace.")]
+        [TestCase(":",
+            ExpectedException = typeof(ArgumentException),
+            ExpectedMessage = "The path is not of a legal form.")]
+        public void MockDirectory_GetParent_ShouldFailForInvalidPath(string path){
             var fileSystem = new MockFileSystem();
 
-            // Act
-            TestDelegate act = () => fileSystem.Directory.GetParent(null);
-
-            // Assert
-            Assert.Throws<ArgumentNullException>(act);
+            fileSystem.Directory.GetParent(path);
         }
 
+
         [Test]
-        public void MockDirectory_GetParent_ShouldThrowArgumentExceptionIfPathIsEmpty()
+        [ExpectedException(typeof(ArgumentException),
+            ExpectedMessage = "Illegal characters in path.")]
+        public void MockDirectory_GetParent_ShouldThrowArgumentExceptionIfPathHasIllegalCharacters()
         {
-            // Arrange
+            if (XFS.IsUnixPlatform())
+            {
+                Assert.Pass("Path.GetInvalidPathChars() does not return anything on Mono if not running on Windows");
+                return;
+            }
+
             var fileSystem = new MockFileSystem();
 
-            // Act
-            TestDelegate act = () => fileSystem.Directory.GetParent(string.Empty);
-
-            // Assert
-            Assert.Throws<ArgumentException>(act);
+            fileSystem.Directory.GetParent(XFS.Path(@"c:\foo\bar<|foo"));
         }
 
         [Test]
@@ -945,24 +951,6 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             Assert.IsNotNull(actualResult);
         }
 
-        [Test]
-        public void MockDirectory_GetParent_ShouldThrowArgumentExceptionIfPathHasIllegalCharacters()
-        {
-            if (XFS.IsUnixPlatform())
-            {
-                Assert.Pass("Path.GetInvalidChars() does not return anything on Mono");
-                return;
-            }
-
-            // Arrange
-            var fileSystem = new MockFileSystem();
-
-            // Act
-            TestDelegate act = () => fileSystem.Directory.GetParent(XFS.Path("c:\\director\ty\\has\\illegal\\character"));
-
-            // Assert
-            Assert.Throws<ArgumentException>(act);
-        }
 
         [Test]
         public void MockDirectory_GetParent_ShouldReturnNullIfPathIsRoot()

--- a/TestHelpers.Tests/MockDirectoryTests.cs
+++ b/TestHelpers.Tests/MockDirectoryTests.cs
@@ -7,6 +7,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
     using XFS = MockUnixSupport;
 
     [TestFixture]
+    [SetUICulture("en-US")]
     public class MockDirectoryTests
     {
         [Test]
@@ -436,6 +437,51 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             // Assert
             Assert.IsTrue(fileSystem.Directory.Exists(XFS.Path(@"\\server\share\path\to\create\", () => false)));
+        }
+
+        [Test]
+        [TestCase(null,
+            ExpectedException = typeof(ArgumentNullException))]
+        [TestCase("",
+            ExpectedException = typeof(ArgumentException),
+            ExpectedMessage = "Path cannot be the empty string or all whitespace.")]
+        [TestCase(":",
+            ExpectedException = typeof(ArgumentException),
+            ExpectedMessage = "The path is not of a legal form.")]
+        public void MockDirectory_CreateDirectory_ShouldFailForInvalidPath(string path)
+        {
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\foo\exists.txt"), new MockFileData("Demo text content") }
+            });
+
+            fileSystem.Directory.CreateDirectory(path);
+        }
+
+        [Test]
+        [ExpectedException(typeof(IOException),
+            ExpectedMessage = @"Cannot create ""c:\foo\exists.txt"" because a file or directory with the same name already exists.")]
+        public void MockDirectory_CreateDirectory_ShouldFailIfFileAlreadyExists()
+        {
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\foo\exists.txt"), new MockFileData("Demo text content") }
+            });
+
+            fileSystem.Directory.CreateDirectory(XFS.Path(@"c:\foo\exists.txt"));
+        }
+
+        [Test]
+        public void MockDirectory_CreateDirecotry_ShouldSucceedIfDirectoryAlreadyExists()
+        {
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\foo.txt"), new MockFileData("Demo text content") }
+            });
+
+            var result = fileSystem.Directory.CreateDirectory(XFS.Path(@"c:\foo"));
+
+            Assert.IsNotNull(result);
         }
 
         [Test]

--- a/TestHelpers.Tests/MockDirectoryTests.cs
+++ b/TestHelpers.Tests/MockDirectoryTests.cs
@@ -630,6 +630,35 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
+        [ExpectedException(typeof(IOException),
+            ExpectedMessage="The directory name is invalid.")]
+        public void MockDirectory_GetFiles_ShouldThrowDirectoryNotFoundException_IfPathIsAnExistentFile()
+        {
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\foo\bar.txt"),  new MockDirectoryData() }
+            });
+
+            fileSystem.Directory.GetFiles(XFS.Path(@"c:\foo\bar.txt"));
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentException),
+            ExpectedMessage = "Illegal characters in path.")]
+        public void MockDirectory_GetFiles_ShouldThrowArgumentExceptionIfPathHasIllegalCharacters()
+        {
+            if (XFS.IsUnixPlatform())
+            {
+                Assert.Pass("Path.GetInvalidPathChars() does not return anything on Mono if not running on Windows");
+                return;
+            }
+
+            var fileSystem = new MockFileSystem();
+
+            fileSystem.Directory.GetFiles(XFS.Path(@"c:\foo\bar<|foo"));
+        }
+
+        [Test]
         public void MockDirectory_GetFiles_Returns_Files()
         {
             string testPath = XFS.Path(@"c:\foo\bar.txt");

--- a/TestHelpers.Tests/MockDirectoryTests.cs
+++ b/TestHelpers.Tests/MockDirectoryTests.cs
@@ -978,27 +978,15 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             Assert.IsNull(actualResult);
         }
 
-        public static IEnumerable<string[]> MockDirectory_GetParent_Cases
+        [Test]
+        public void MockDirectory_GetParent_ShouldReturnTheParentWithoutTrailingDirectorySeparatorChar()
         {
-            get
-            {
-                yield return new [] { XFS.Path(@"c:\a"), XFS.Path(@"c:\") };
-                yield return new [] { XFS.Path(@"c:\a\b\c\d"), XFS.Path(@"c:\a\b\c") };
-                yield return new [] { XFS.Path(@"c:\a\b\c\d\"), XFS.Path(@"c:\a\b\c") };
-            }
-        }
-
-        public void MockDirectory_GetParent_ShouldReturnTheParentWithoutTrailingDirectorySeparatorChar(string path, string expectedResult)
-        {
-            // Arrange
             var fileSystem = new MockFileSystem();
-            fileSystem.AddDirectory(path);
+            fileSystem.AddDirectory(XFS.Path(@"c:\a\b\c\d"));
 
-            // Act
-            var actualResult = fileSystem.Directory.GetParent(path);
-
-            // Assert
-            Assert.AreEqual(expectedResult, actualResult.FullName);
+            Assert.That(fileSystem.Directory.GetParent(XFS.Path(@"c:\a")).FullName, Is.EqualTo(XFS.Path(@"c:\")));
+            Assert.That(fileSystem.Directory.GetParent(XFS.Path(@"c:\a\b\c\d")).FullName, Is.EqualTo(XFS.Path(@"c:\a\b\c")));
+            Assert.That(fileSystem.Directory.GetParent(XFS.Path(@"c:\a\b\c\d\")).FullName, Is.EqualTo(XFS.Path(@"c:\a\b\c")));
         }
 
         [Test]

--- a/TestHelpers.Tests/MockDirectoryTests.cs
+++ b/TestHelpers.Tests/MockDirectoryTests.cs
@@ -871,6 +871,19 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             Assert.Throws<DirectoryNotFoundException>(action);
         }
 
+        [Test]
+        [ExpectedException(typeof(IOException),
+            ExpectedMessage = "The directory name is invalid.")]
+        public void MockDirectory_EnumerateDirectories_ShouldThrowDirectoryNotFoundException_IfPathIsAnExistentFile()
+        {
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\foo\bar.txt"),  new MockDirectoryData() }
+            });
+
+            fileSystem.Directory.EnumerateDirectories(XFS.Path(@"c:\foo\bar.txt"));
+        }
+
         public static IEnumerable<object[]> GetPathsForMoving()
         {
             yield return new object[] { @"a:\folder1\", @"A:\folder3\", "file.txt", @"folder2\file2.txt" };

--- a/TestingHelpers/MockDirectory.cs
+++ b/TestingHelpers/MockDirectory.cs
@@ -143,16 +143,15 @@ namespace System.IO.Abstractions.TestingHelpers
 
         public override string[] GetFiles(string path, string searchPattern, SearchOption searchOption)
         {
-            if(path == null)
-                throw new ArgumentNullException();
-
-            if (!Exists(path))
-            {
-                throw new DirectoryNotFoundException(string.Format(CultureInfo.InvariantCulture, "Could not find a part of the path '{0}'.", path));
-            }
+            ThrowExceptionIfNull(path, "path");
+            ThrowExceptionIfNull(searchPattern, "searchPattern");
+            ThrowExceptionIfPathContainsInvalidChars(path);
+            ThrowExceptionIfFileExists(path, "The directory name is invalid.");
+            ThrowExceptionIfDirectoryDoesNotExist(path, string.Format("Could not find a part of the path '{0}'.", path));
 
             return GetFilesInternal(mockFileDataAccessor.AllFiles, path, searchPattern, searchOption);
         }
+
 
         private string[] GetFilesInternal(IEnumerable<string> files, string path, string searchPattern, SearchOption searchOption)
         {
@@ -419,6 +418,14 @@ namespace System.IO.Abstractions.TestingHelpers
             if (mockFileDataAccessor.FileExists(path))
             {
                 throw new IOException(message);
+            }
+        }
+
+        private void ThrowExceptionIfDirectoryDoesNotExist(string path, string message)
+        {
+            if (!Exists(path))
+            {
+                throw new DirectoryNotFoundException(message);
             }
         }
 

--- a/TestingHelpers/MockDirectory.cs
+++ b/TestingHelpers/MockDirectory.cs
@@ -347,13 +347,13 @@ namespace System.IO.Abstractions.TestingHelpers
 
         public override IEnumerable<string> EnumerateDirectories(string path, string searchPattern, SearchOption searchOption)
         {
+            ThrowExceptionIfNull(path, "path");
+            ThrowExceptionIfNull(searchPattern, "searchPattern");
+            ThrowExceptionIfPathContainsInvalidChars(path);
+            ThrowExceptionIfFileExists(path, "The directory name is invalid.");
+            ThrowExceptionIfDirectoryDoesNotExist(path, string.Format("Could not find a part of the path '{0}'.", path));
+
             path = EnsurePathEndsWithDirectorySeparator(path);
-
-            if (!Exists(path))
-            {
-                throw new DirectoryNotFoundException(string.Format(CultureInfo.InvariantCulture, "Could not find a part of the path '{0}'.", path));
-            }
-
             var dirs = GetFilesInternal(mockFileDataAccessor.AllDirectories, path, searchPattern, searchOption);
             return dirs.Where(p => p != path);
         }

--- a/TestingHelpers/MockDirectory.cs
+++ b/TestingHelpers/MockDirectory.cs
@@ -228,21 +228,9 @@ namespace System.IO.Abstractions.TestingHelpers
 
         public override DirectoryInfoBase GetParent(string path)
         {
-            if (path == null)
-            {
-                throw new ArgumentNullException("path");
-            }
-
-            if (path.Length == 0)
-            {
-                throw new ArgumentException("Path cannot be the empty string or all whitespace.", "path");
-            }
-
-            var invalidChars = mockFileDataAccessor.Path.GetInvalidPathChars();
-            if (path.IndexOfAny(invalidChars) > -1)
-            {
-                throw new ArgumentException("Path contains invalid path characters.", "path");
-            }
+            ThrowExceptionIfNull(path, "path");
+            ThrowExceptionIfPathIsEmptyOrContainsWhitespacesOnly(path);
+            ThrowExceptionIfPathContainsInvalidChars(path);
 
             var absolutePath = mockFileDataAccessor.Path.GetFullPath(path);
             var sepAsString = mockFileDataAccessor.Path.DirectorySeparatorChar.ToString(CultureInfo.InvariantCulture);
@@ -434,6 +422,14 @@ namespace System.IO.Abstractions.TestingHelpers
             }
         }
 
+        private void ThrowExceptionIfPathContainsInvalidChars(string path)
+        {
+            var invalidChars = mockFileDataAccessor.Path.GetInvalidPathChars();
+            if (path.IndexOfAny(invalidChars) > -1)
+            {
+                throw new ArgumentException("Illegal characters in path.");
+            }
+        }
         #endregion
 
         static string EnsurePathEndsWithDirectorySeparator(string path)


### PR DESCRIPTION
Some refactorings. Also there were some checks missing in `EnumerateDirectories(...)` and `GetFiles(...)`.
