### PR TITLE
Added TestingHelper for directory SetAttributes

### DIFF
--- a/TestHelpers.Tests/MockFileSetAttributesTests.cs
+++ b/TestHelpers.Tests/MockFileSetAttributesTests.cs
@@ -1,0 +1,66 @@
+﻿using System.Collections.Generic;
+using NUnit.Framework;
+using XFS = System.IO.Abstractions.TestingHelpers.MockUnixSupport;
+
+namespace System.IO.Abstractions.TestingHelpers.Tests
+{
+    [TestFixture]
+    public class MockFileSetAttributesTests
+    {
+        [Test]
+        public void MockFile_SetAttributes_ShouldSetAttributesOnFile()
+        {
+            var path = XFS.Path(@"c:\something\demo.txt");
+            var filedata = new MockFileData("test");
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                {path, filedata},
+            });
+
+            fileSystem.File.SetAttributes(path, FileAttributes.Hidden);
+
+            var attributes = fileSystem.File.GetAttributes(path);
+            Assert.That(attributes, Is.EqualTo(FileAttributes.Hidden));
+        }
+
+        [Test]
+        public void MockFile_SetAttributes_ShouldSetAttributesOnDirectory()
+        {
+            var fileSystem = new MockFileSystem();
+            var path = XFS.Path(@"c:\something");
+            fileSystem.AddDirectory(path);
+            var directoryInfo = fileSystem.DirectoryInfo.FromDirectoryName(path);
+            directoryInfo.Attributes = FileAttributes.Directory | FileAttributes.Normal;
+
+            fileSystem.File.SetAttributes(path, FileAttributes.Directory | FileAttributes.Hidden);
+
+            var attributes = fileSystem.File.GetAttributes(path);
+            Assert.That(attributes, Is.EqualTo(FileAttributes.Directory | FileAttributes.Hidden));
+        }
+
+        [Test]
+        [TestCase("", FileAttributes.Normal)]
+        [TestCase("   ", FileAttributes.Normal)]
+        public void MockFile_SetAttributes_ShouldThrowArgumentExceptionIfPathContainsOnlyWhitespaces(string path, FileAttributes attributes)
+        {
+            var fileSystem = new MockFileSystem();
+
+            TestDelegate action = () => fileSystem.File.SetAttributes(path, attributes);
+
+            Assert.Throws<ArgumentException>(action);
+        }
+
+        [Test]
+        public void MockFile_SetAttributes_ShouldThrowFileNotFoundExceptionIfMissingDirectory()
+        {
+            var path = XFS.Path(@"C:\something");
+            var attributes = FileAttributes.Normal;
+            var fileSystem = new MockFileSystem();
+
+            TestDelegate action = () => fileSystem.File.SetAttributes(path, attributes);
+
+            var exception = Assert.Throws<FileNotFoundException>(action);
+            Assert.That(exception.FileName, Is.EqualTo(path));
+        }
+    }
+}

--- a/TestingHelpers/MockFile.cs
+++ b/TestingHelpers/MockFile.cs
@@ -571,7 +571,23 @@ namespace System.IO.Abstractions.TestingHelpers
         {
             mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, "path");
 
-            mockFileDataAccessor.GetFile(path).Attributes = fileAttributes;
+            var possibleFileData = mockFileDataAccessor.GetFile(path);
+            if (possibleFileData == null)
+            {
+                var directoryInfo = mockFileDataAccessor.DirectoryInfo.FromDirectoryName(path);
+                if (directoryInfo.Exists)
+                {
+                    directoryInfo.Attributes = fileAttributes;
+                }
+                else
+                {
+                    throw new FileNotFoundException(string.Format(CultureInfo.InvariantCulture, StringResources.Manager.GetString("COULD_NOT_FIND_FILE_EXCEPTION"), path), path);
+                }
+            }
+            else
+            {
+                possibleFileData.Attributes = fileAttributes;
+            }
         }
 
         public override void SetCreationTime(string path, DateTime creationTime)

--- a/TestingHelpers/MockFileSystem.cs
+++ b/TestingHelpers/MockFileSystem.cs
@@ -64,6 +64,11 @@ namespace System.IO.Abstractions.TestingHelpers
 
         private string FixPath(string path, bool checkCaps = false)
         {
+            if (path == null)
+            {
+                throw new ArgumentNullException(nameof(path), StringResources.Manager.GetString("VALUE_CANNOT_BE_NULL"));
+            }
+            
             var pathSeparatorFixed = path.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
             var fullPath = Path.GetFullPath(pathSeparatorFixed);
 


### PR DESCRIPTION
I've implemented the logic for SetAttributes for directories. The code for files was already in place. And someone else had already provided the code to get attributes from directory paths. I just _borrowed_ and adapted that code.
