### PR TITLE
Throwing DirectoryNotFound exception when directory does not exist.

### DIFF
--- a/TestHelpers.Tests/MockDirectoryTests.cs
+++ b/TestHelpers.Tests/MockDirectoryTests.cs
@@ -368,7 +368,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         {
             // Arrange
             var fileSystem = new MockFileSystem();
-            fileSystem.AddFile(XFS.Path(@"c:\foo\bar.txt"), new MockFileData("Demo text content"));
+            fileSystem.AddFileWithCreate(XFS.Path(@"c:\foo\bar.txt"), new MockFileData("Demo text content"));
 
             // Act
             var result = fileSystem.Directory.Exists(XFS.Path(@"c:\foo\"));

--- a/TestHelpers.Tests/MockFileCreateTests.cs
+++ b/TestHelpers.Tests/MockFileCreateTests.cs
@@ -21,6 +21,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             Assert.That(fileSystem.FileExists(fullPath), Is.False);
 
+            fileSystem.Directory.CreateDirectory(Path.GetDirectoryName(fullPath));
+
             sut.Create(fullPath).Close();
 
             Assert.That(fileSystem.FileExists(fullPath), Is.True);
@@ -34,6 +36,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var data = new UTF8Encoding(false).GetBytes("Test string");
 
             var sut = new MockFile(fileSystem);
+            fileSystem.Directory.CreateDirectory(Path.GetDirectoryName(fullPath));
             using (var stream = sut.Create(fullPath))
             {
                 stream.Write(data, 0, data.Length);
@@ -52,6 +55,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var fileSystem = new MockFileSystem();
 
             var mockFile = new MockFile(fileSystem);
+
+            fileSystem.Directory.CreateDirectory(Path.GetDirectoryName(path));
 
             // Create a file
             using (var stream = mockFile.Create(path))

--- a/TestHelpers.Tests/MockFileDeleteTests.cs
+++ b/TestHelpers.Tests/MockFileDeleteTests.cs
@@ -12,7 +12,7 @@
             var fileSystem = new MockFileSystem();
             var path = XFS.Path("C:\\test");
             var directory = fileSystem.Path.GetDirectoryName(path);
-            fileSystem.AddFile(path, new MockFileData("Bla"));
+            fileSystem.AddFileWithCreate(path, new MockFileData("Bla"));
 
             var fileCount1 = fileSystem.Directory.GetFiles(directory, "*").Length;
             fileSystem.File.Delete(path);

--- a/TestHelpers.Tests/MockFileInfoTests.cs
+++ b/TestHelpers.Tests/MockFileInfoTests.cs
@@ -428,7 +428,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         {
             // Arrange
             var fileSystem = new MockFileSystem();
-            fileSystem.AddFile(XFS.Path(@"c:\temp\file.txt"), new MockFileData(new byte[] { 1, 2 }));
+            fileSystem.AddFileWithCreate(XFS.Path(@"c:\temp\file.txt"), new MockFileData(new byte[] { 1, 2 }));
             var fileInfo = fileSystem.FileInfo.FromFileName(XFS.Path(@"c:\temp\file.txt"));
 
             // Act
@@ -446,7 +446,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         {
             // Arrange
             var fileSystem = new MockFileSystem();
-            fileSystem.AddFile(XFS.Path(@"c:\temp\file.txt"), new MockFileData(@"line 1\r\nline 2"));
+            fileSystem.AddFileWithCreate(XFS.Path(@"c:\temp\file.txt"), new MockFileData(@"line 1\r\nline 2"));
             var fileInfo = fileSystem.FileInfo.FromFileName(XFS.Path(@"c:\temp\file.txt"));
 
             // Act

--- a/TestHelpers.Tests/MockFileOpenTests.cs
+++ b/TestHelpers.Tests/MockFileOpenTests.cs
@@ -40,12 +40,14 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         [Test]
         public void MockFile_Open_CreatesNewFileFileOnCreate()
         {
-            string filepath = XFS.Path(@"c:\something\doesnt\exist.txt");
-            var filesystem = new MockFileSystem(new Dictionary<string, MockFileData>());
+            string filePath = XFS.Path(@"c:\something\doesnt\exist.txt");
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>());
 
-            var stream = filesystem.File.Open(filepath, FileMode.Create);
+            fileSystem.Directory.CreateDirectory(Path.GetDirectoryName(filePath));
 
-            Assert.That(filesystem.File.Exists(filepath), Is.True);
+            var stream = fileSystem.File.Open(filePath, FileMode.Create);
+
+            Assert.That(fileSystem.File.Exists(filePath), Is.True);
             Assert.That(stream.Position, Is.EqualTo(0));
             Assert.That(stream.Length, Is.EqualTo(0));
         }
@@ -53,12 +55,13 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         [Test]
         public void MockFile_Open_CreatesNewFileFileOnCreateNew()
         {
-            string filepath = XFS.Path(@"c:\something\doesnt\exist.txt");
-            var filesystem = new MockFileSystem(new Dictionary<string, MockFileData>());
+            string filePath = XFS.Path(@"c:\something\doesnt\exist.txt");
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>());
 
-            var stream = filesystem.File.Open(filepath, FileMode.CreateNew);
+            fileSystem.Directory.CreateDirectory(Path.GetDirectoryName(filePath));
+            var stream = fileSystem.File.Open(filePath, FileMode.CreateNew);
 
-            Assert.That(filesystem.File.Exists(filepath), Is.True);
+            Assert.That(fileSystem.File.Exists(filePath), Is.True);
             Assert.That(stream.Position, Is.EqualTo(0));
             Assert.That(stream.Length, Is.EqualTo(0));
         }
@@ -151,12 +154,13 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         [Test]
         public void MockFile_Open_CreatesNewFileOnOpenOrCreate()
         {
-            string filepath = XFS.Path(@"c:\something\doesnt\exist.txt");
-            var filesystem = new MockFileSystem(new Dictionary<string, MockFileData>());
+            string filePath = XFS.Path(@"c:\something\doesnt\exist.txt");
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>());
 
-            var stream = filesystem.File.Open(filepath, FileMode.OpenOrCreate);
+            fileSystem.Directory.CreateDirectory(filePath);
+            var stream = fileSystem.File.Open(filePath, FileMode.OpenOrCreate);
 
-            Assert.That(filesystem.File.Exists(filepath), Is.True);
+            Assert.That(fileSystem.File.Exists(filePath), Is.True);
             Assert.That(stream.Position, Is.EqualTo(0));
             Assert.That(stream.Length, Is.EqualTo(0));
         }
@@ -187,7 +191,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var file = new MockFileData(@"I'm here");
             var lastWriteTime = new DateTime(2012, 03, 21);
             file.LastWriteTime = lastWriteTime;
-            fs.AddFile(filepath, file);
+            fs.AddFileWithCreate(filepath, file);
 
             // Act
             using (var reader = fs.File.OpenText(filepath))
@@ -208,7 +212,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var file = new MockFileData(@"I'm here");
             var lastAccessTime = new DateTime(2012, 03, 21);
             file.LastAccessTime = lastAccessTime;
-            fs.AddFile(filepath, file);
+            fs.AddFileWithCreate(filepath, file);
 
             // Act
             using (var reader = fs.File.OpenText(filepath))
@@ -229,7 +233,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var file = new MockFileData(@"I'm here");
             var creationTime = new DateTime(2012, 03, 21);
             file.CreationTime = creationTime;
-            fs.AddFile(filepath, file);
+            fs.AddFileWithCreate(filepath, file);
 
             // Act
             using (var reader = fs.File.OpenText(filepath))

--- a/TestHelpers.Tests/MockFileStreamTests.cs
+++ b/TestHelpers.Tests/MockFileStreamTests.cs
@@ -13,16 +13,18 @@
         public void MockFileStream_Flush_WritesByteToFile()
         {
             // Arrange
-            var filepath = XFS.Path(@"c:\something\foo.txt");
-            var filesystem = new MockFileSystem(new Dictionary<string, MockFileData>());
-            var cut = new MockFileStream(filesystem, filepath);
+            var filePath = XFS.Path(@"c:\something\foo.txt");
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>());
+
+            fileSystem.Directory.CreateDirectory(filePath);
+            var cut = new MockFileStream(fileSystem, filePath);
 
             // Act
             cut.WriteByte(255);
             cut.Flush();
 
             // Assert
-            CollectionAssert.AreEqual(new byte[]{255}, filesystem.GetFile(filepath).Contents);
+            CollectionAssert.AreEqual(new byte[]{255}, fileSystem.GetFile(filePath).Contents);
         }
 
         [Test]
@@ -31,7 +33,7 @@
             var fileSystem = new MockFileSystem();
             var path = XFS.Path("C:\\test");
             var directory = fileSystem.Path.GetDirectoryName(path);
-            fileSystem.AddFile(path, new MockFileData("Bla"));
+            fileSystem.AddFileWithCreate(path, new MockFileData("Bla"));
             var stream = fileSystem.File.Open(path, FileMode.Open, FileAccess.ReadWrite, FileShare.Delete);
 
             var fileCount1 = fileSystem.Directory.GetFiles(directory, "*").Length;

--- a/TestHelpers.Tests/MockFileSystemTests.cs
+++ b/TestHelpers.Tests/MockFileSystemTests.cs
@@ -113,7 +113,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             // Arrange
             const string baseDirectory = @"C:\Test";
             var fileSystem = new MockFileSystem();
-            fileSystem.AddFile(baseDirectory, new MockFileData(string.Empty));
+            fileSystem.AddFileWithCreate(baseDirectory, new MockFileData(string.Empty));
             fileSystem.File.SetAttributes(baseDirectory, FileAttributes.ReadOnly);
 
             // Act

--- a/TestHelpers.Tests/MockFileTests.cs
+++ b/TestHelpers.Tests/MockFileTests.cs
@@ -338,7 +338,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             string path = XFS.Path(@"c:\something\demo.txt");
             var fileSystem = new MockFileSystem();
             var fileContent = new byte[] { 1, 2, 3, 4 };
-            
+            fileSystem.Directory.CreateDirectory(path);
+
             // Act
             fileSystem.File.WriteAllBytes(path, fileContent);
 
@@ -355,6 +356,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             string path = XFS.Path(@"c:\something\demo.txt");
             var fileSystem = new MockFileSystem();
             var fileContent = new byte[] { 1, 2, 3, 4 };
+            fileSystem.Directory.CreateDirectory(path);
 
             // Act
             fileSystem.File.WriteAllBytes(path, fileContent);
@@ -390,6 +392,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var fileSystem = new MockFileSystem();
 
             var bytes = new UTF8Encoding(true).GetBytes(fileContent);
+            fileSystem.Directory.CreateDirectory(filePath);
             var stream = fileSystem.File.OpenWrite(filePath);
             stream.Write(bytes, 0, bytes.Length);
             stream.Close();
@@ -475,18 +478,19 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         [Test]
         public void MockFile_AppendText_CreatesNewFileForAppendToNonExistingFile()
         {
-            string filepath = XFS.Path(@"c:\something\doesnt\exist.txt");
-            var filesystem = new MockFileSystem(new Dictionary<string, MockFileData>());
+            string filePath = XFS.Path(@"c:\something\doesnt\exist.txt");
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>());
 
-            var stream = filesystem.File.AppendText(filepath);
+            fileSystem.Directory.CreateDirectory(filePath);
+            var stream = fileSystem.File.AppendText(filePath);
 
             stream.Write("New too!");
             stream.Flush();
             stream.Close();
 
-            var file = filesystem.GetFile(filepath);
+            var file = fileSystem.GetFile(filePath);
             Assert.That(file.TextContents, Is.EqualTo("New too!"));
-            Assert.That(filesystem.FileExists(filepath));
+            Assert.That(fileSystem.FileExists(filePath));
         }
 
         [Test]

--- a/TestHelpers.Tests/MockFileWriteAllTextTests.cs
+++ b/TestHelpers.Tests/MockFileWriteAllTextTests.cs
@@ -16,6 +16,7 @@
             string path = XFS.Path(@"c:\something\demo.txt");
             string fileContent = "Hello there!";
             var fileSystem = new MockFileSystem();
+            fileSystem.Directory.CreateDirectory(path);
 
             // Act
             fileSystem.File.WriteAllText(path, fileContent);
@@ -34,6 +35,7 @@
             // Arrange
             string path = XFS.Path(@"c:\something\demo.txt");
             var fileSystem = new MockFileSystem();
+            fileSystem.Directory.CreateDirectory(path);
 
             // Act
             fileSystem.File.WriteAllText(path, "foo");
@@ -112,6 +114,7 @@
             byte[] expectedBytes = encodingsWithContents.Value;
             Encoding encoding = encodingsWithContents.Key;
             var fileSystem = new MockFileSystem();
+            fileSystem.Directory.CreateDirectory(path);
 
             // Act
             fileSystem.File.WriteAllText(path, FileContent, encoding);
@@ -131,6 +134,7 @@
             var expected = "Hello there!" + Environment.NewLine + "Second line!" + Environment.NewLine;
 
             var fileSystem = new MockFileSystem();
+            fileSystem.Directory.CreateDirectory(path);
 
             // Act
             fileSystem.File.WriteAllLines(path, fileContent);

--- a/TestHelpers.Tests/MockPathTests.cs
+++ b/TestHelpers.Tests/MockPathTests.cs
@@ -8,6 +8,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
     public class MockPathTests
     {
         static readonly string TestPath = XFS.Path("C:\\test\\test.bmp");
+        readonly IMockFileDataAccessor mockFileDataAccessor;
 
         private MockPath SetupMockPath()
         {
@@ -327,7 +328,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         public void GetTempFileName_Called_ReturnsStringLengthGreaterThanZero()
         {
             //Arrange
-            var mockPath = new MockPath(new MockFileSystem());
+            var fileSystem = new MockFileSystem();
+            var mockPath = new MockPath(fileSystem);
+
+            //Creating directory explicitly because in normal system Tempory path always exist.
+            fileSystem.Directory.CreateDirectory(mockPath.GetTempPath());
 
             //Act
             var result = mockPath.GetTempFileName();
@@ -342,6 +347,9 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             //Arrange
             var fileSystem = new MockFileSystem();
             var mockPath = new MockPath(fileSystem);
+
+            //Creating directory explicitly because in normal system Tempory path always exist.
+            fileSystem.Directory.CreateDirectory(mockPath.GetTempPath());
 
             //Act
             var result = mockPath.GetTempFileName();

--- a/TestingHelpers/MockFileSystem.cs
+++ b/TestingHelpers/MockFileSystem.cs
@@ -32,7 +32,20 @@ namespace System.IO.Abstractions.TestingHelpers
 
             if (files == null) return;
             foreach (var entry in files)
-                AddFile(entry.Key, entry.Value);
+                AddFileWithCreate(entry.Key, entry.Value);
+        }
+
+        public void AddFileWithCreate(string path, MockFileData value)
+        {
+            var fixedPath = FixPath(path);
+
+            var directoryName = Path.GetDirectoryName(fixedPath);
+            if (!directory.Exists(directoryName))
+            {
+                directory.CreateDirectory(directoryName);
+            }
+
+            AddFile(fixedPath, value);
         }
 
         public FileBase File
@@ -94,7 +107,7 @@ namespace System.IO.Abstractions.TestingHelpers
 
                 if (!directory.Exists(directoryPath))
                 {
-                    AddDirectory(directoryPath);
+                    throw new DirectoryNotFoundException();
                 }
 
                 files[fixedPath] = mockFile;


### PR DESCRIPTION
When updating legacy code so it can be tested with unit tests I ran into a small problem. When you, in the actual fileSystem from Microsoft, call the AddFile method. The only thing it does is add the file to the already existing directory. If that directory is not present it will give you an DirectoryNotFoundException. For the MockFileSystem I would expect the same behavior as below:

I was running a test on the below code and made sure that the directory did not exist in the mocked file system.

Test:

``` C#
    [TestMethod]
    public void WhenCallingDoSomethingWithoutExistingDirectoryShouldCreateDirectory()
    {
            var foo = new Foo();
            string path = @"C:\temp\createThisDirectory";

            foo.DoSomething(path);

            //Assert using fluent assertions.
            mockFileSystem.Directory.Exists(@"C:\temp").Should().BeTrue();
    }
```

Code:

``` C#
    public class Foo
    {
        private readonly IFileSystem fileSystem;

        public Foo(IFileSystem fileSystem)
        {
            this.fileSystem = fileSystem;
        }

        public void DoSomething(string path)
        {
            //..........some code here..........

            //This should not be TRUE because the c:\temp will always exist in the real filesystem.
            if (!Directory.Exists(Path.GetDirectoryName(path)))
            {
                Directory.CreateDirectory(Path.GetDirectoryName(path));
            }

            //Below line was already mocked and seeing the code aboveI would expect
            //the test to fail below because that would have happend if it was not
            //mocked using the real filesystem. The directory is not there yet.

            fileSystem.File.WriteAllBytes(path, aByteArray);

            //.........some more code here...........
         }
    }
```

It turned out that the line: 'fileSystem.File.WriteAllBytes(path, aByteArray);', dit not fail. After some research in the 'System.IO.Abstractions' turned out that the method WriteAllBytes() makes use of the AddFile() method. The AddFile() method looked like this:

``` C#
         public void AddFile(string path, MockFileData mockFile)
         {
             var fixedPath = FixPath(path);
             lock (files)
             {
                 if (FileExists(fixedPath))
                 {
                     var isReadOnly = (files[fixedPath].Attributes & FileAttributes.ReadOnly) == FileAttributes.ReadOnly;
                     var isHidden = (files[fixedPath].Attributes & FileAttributes.Hidden) == FileAttributes.Hidden;

                     if (isReadOnly || isHidden)
                     {
                         throw new UnauthorizedAccessException(string.Format(CultureInfo.InvariantCulture, "Access to the path '{0}' is denied.", path));
                     }
                 }

                 var directoryPath = Path.GetDirectoryName(fixedPath);

                 if (!directory.Exists(directoryPath))
                 {
                      AddDirectory(directoryPath);
                 }

                 files[fixedPath] = mockFile;
             }
         }
```

The reason it dit not fail is obviously:

``` C#
                 if (!directory.Exists(directoryPath))
                 {
                      AddDirectory(directoryPath);
                 }
```

A quick fix for this was the following:

``` C#
                 if (!directory.Exists(directoryPath))
                 {
                      throw new DirectoryNotFoundException();
                 }
```

In order to make all the tests work I created the following function and replaced every occurance of AddFile() with AddFileWithCreate() in the tests. The difference here is that with the first a directory has to be present like the actual filesystem and the second creates the directory if it's not there.

``` C#
        public void AddFileWithCreate(string path, MockFileData value)
        {
            var fixedPath = FixPath(path);

            var directoryName = Path.GetDirectoryName(fixedPath);
            if (!directory.Exists(directoryName))
            {
                directory.CreateDirectory(directoryName);
            }

            AddFile(fixedPath, value);
        }
```

If in the test there was another function used like WriteAllBytes() I created the directory in the test using:

``` C#
    fileSystem.Directory.CreateDirectory(Path.GetDirectoryName(fullPath));
```

In my opinion this makes system.IO.Abstractions better suitable for a smooth simulation of the actual fileSystem. Please let me know what you think about this. 

Kind regards,
Brian Langhoor
