### PR TITLE
Added two constructors to MockFileData to allow for lazy loading of t…

### DIFF
--- a/TestHelpers.Tests/MockFileDataLazyLoadContentTests.cs
+++ b/TestHelpers.Tests/MockFileDataLazyLoadContentTests.cs
@@ -1,0 +1,111 @@
+﻿using System.Linq;
+using NUnit.Framework;
+
+namespace System.IO.Abstractions.TestingHelpers.Tests
+{
+    [TestFixture]
+    public class MockFileDataLazyLoadContentTests
+    {
+        [Test]
+        public void MockFileData_AcceptsFuncAndReturnsContents()
+        {
+            var contents = Enumerable.Range(0, 100).Select(_ => (byte)_).ToArray();
+            var x = new MockFileData(() => contents);
+            Assert.AreEqual(x.Contents, contents);
+        }
+
+        [Test]
+        public void MockFileData_LazyLoadFuncIsCalledOnDemand()
+        {
+            var contents = Enumerable.Range(19, 42).Select(_ => (byte)_).ToArray();
+            var lazyLoadFuncHasBeenCalled = false;
+            var x = new MockFileData(() =>
+            {
+                lazyLoadFuncHasBeenCalled = true;
+                return contents;
+            });
+            Assert.IsFalse(lazyLoadFuncHasBeenCalled);
+            Assert.AreEqual(x.Contents, contents);
+            Assert.IsTrue(lazyLoadFuncHasBeenCalled);
+        }
+
+        [Test]
+        public void MockFileData_FuncConstructorThrowsOnNullArgument()
+        {
+            Assert.Throws<ArgumentNullException>(() => new MockFileData((Func<byte[]>)null));
+        }
+
+    }
+
+    [TestFixture]
+    public class MockFileDataInsertFileInfoObjectTests
+    {
+        private IFileSystem destinationFileSystem;
+        private FileInfoBase destinationFileInfo;
+
+        private const string sourceFileName = @"a:\c.bin";
+        private const string destinationFileName = @"b:\c\d.bin";
+        private readonly byte[] fileContent = Enumerable.Range(3, 14).Select(_ => (byte)_).ToArray();
+        private const FileAttributes attributes = FileAttributes.Hidden;
+        private readonly DateTime dateCreated = DateTime.Now.AddHours(-3);
+        private readonly DateTime dateLastWritten = DateTime.Now.AddHours(-2);
+        private readonly DateTime dateLastAccessed = DateTime.Now.AddHours(-1);
+
+        [TestFixtureSetUp]
+        public void MockFileData_AcceptsFuncAndReturnsContents()
+        {
+            // create a file in a source file system
+            var sourceFileSystem = new MockFileSystem();
+            sourceFileSystem.File.WriteAllBytes(sourceFileName, fileContent);
+            sourceFileSystem.File.SetAttributes(sourceFileName, attributes);
+            sourceFileSystem.File.SetCreationTime(sourceFileName, dateCreated);
+            sourceFileSystem.File.SetLastWriteTime(sourceFileName, dateLastWritten);
+            sourceFileSystem.File.SetLastAccessTime(sourceFileName, dateLastAccessed);
+            var sourceFile = sourceFileSystem.DirectoryInfo.FromDirectoryName(Path.GetDirectoryName(sourceFileName)).GetFiles().Single();
+
+            // create a new destination file system and copy the source file tehre
+            var dfs = new MockFileSystem();
+            dfs.AddFile(destinationFileName, new MockFileData(sourceFileSystem, sourceFile));
+            destinationFileInfo = dfs.DirectoryInfo.FromDirectoryName(Path.GetDirectoryName(destinationFileName)).GetFiles().Single();
+            destinationFileSystem = dfs;
+        }
+
+        [Test]
+        public void TestThatFileHasRightName()
+        {
+            Assert.AreEqual(destinationFileName, destinationFileInfo.FullName);
+        }
+
+        [Test]
+        public void TestThatFileHasRightContent()
+        {
+            Assert.AreEqual(fileContent, destinationFileSystem.File.ReadAllBytes(destinationFileInfo.FullName));
+        }
+
+        [Test]
+        public void TestThatFileHasRightAttributes()
+        {
+            Assert.AreEqual(attributes, destinationFileInfo.Attributes);
+        }
+
+        [Test]
+        public void TestThatFileHasRightCreationTime()
+        {
+            Assert.AreEqual(dateCreated, destinationFileInfo.CreationTime);
+        }
+
+        [Test]
+        public void TestThatFileHasRightWriteTime()
+        {
+            Assert.AreEqual(dateLastWritten, destinationFileInfo.LastWriteTime);
+        }
+
+        [Test]
+        public void TestThatFileHasRightAccessTime()
+        {
+            Assert.AreEqual(dateLastAccessed, destinationFileInfo.LastAccessTime);
+        }
+
+    }
+
+}

--- a/TestHelpers.Tests/MockFileDataLazyLoadContentTests.cs
+++ b/TestHelpers.Tests/MockFileDataLazyLoadContentTests.cs
@@ -63,7 +63,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             sourceFileSystem.File.SetLastAccessTime(sourceFileName, dateLastAccessed);
             var sourceFile = sourceFileSystem.DirectoryInfo.FromDirectoryName(Path.GetDirectoryName(sourceFileName)).GetFiles().Single();
 
-            // create a new destination file system and copy the source file tehre
+            // create a new destination file system and copy the source file there
             var dfs = new MockFileSystem();
             dfs.AddFile(destinationFileName, new MockFileData(sourceFileSystem, sourceFile));
             destinationFileInfo = dfs.DirectoryInfo.FromDirectoryName(Path.GetDirectoryName(destinationFileName)).GetFiles().Single();

--- a/TestHelpers.Tests/TestHelpers.Tests.csproj
+++ b/TestHelpers.Tests/TestHelpers.Tests.csproj
@@ -105,6 +105,7 @@
     <Compile Include="MockPathTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="MockUnixSupportTests.cs" />
+    <Compile Include="MockFileDataLazyLoadContentTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\System.IO.Abstractions\System.IO.Abstractions.csproj">

--- a/TestingHelpers/MockFileData.cs
+++ b/TestingHelpers/MockFileData.cs
@@ -68,7 +68,7 @@ namespace System.IO.Abstractions.TestingHelpers
         /// <param name="textContents">The textual content encoded into bytes with <see cref="DefaultEncoding"/>.</param>
         public MockFileData(string textContents)
             : this(DefaultEncoding.GetBytes(textContents))
-        { }
+        {}
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MockFileData"/> class with the content of <paramref name="textContents"/> using the encoding of <paramref name="encoding"/>.
@@ -133,6 +133,9 @@ namespace System.IO.Abstractions.TestingHelpers
             lazyLoadContent = () => fileSystem.File.ReadAllBytes(fileInfo.FullName);
         }
 
+        /// <summary>
+        /// Gets or sets the byte contents of the <see cref="MockFileData"/>.
+        /// </summary> 
         public byte[] Contents
         {
             get { return contents ?? (contents = lazyLoadContent()); }


### PR DESCRIPTION
…he file content.

Rationale: when mocking a file system, it is commonly populated with a large number of files, where only a few will be relevant for each test suite. By allowing the files content to be lazy loaded, a huge amount of memory and disk reads can be saved.
