### PR TITLE
Add support for framework v3.5 and v2.0.

### DIFF
--- a/System.IO.Abstractions.sln
+++ b/System.IO.Abstractions.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.30723.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.24720.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{5F3BDA62-8052-4C37-97A0-94354AA971B0}"
 	ProjectSection(SolutionItems) = preProject
@@ -13,6 +13,10 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestingHelpers", "TestingHelpers\TestingHelpers.csproj", "{251BD5E5-8133-47A4-AB19-17CF0F43D6AE}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestHelpers.Tests", "TestHelpers.Tests\TestHelpers.Tests.csproj", "{20B02738-952A-40F5-9C10-E2F83013E9FC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.IO.Abstractions35", "System.IO.Abstractions35\System.IO.Abstractions35.csproj", "{C5B51937-7CC9-4D9D-89A6-CEDAB506CAA7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.IO.Abstractions20", "System.IO.Abstractions20\System.IO.Abstractions20.csproj", "{FB76B4A8-A645-4348-A8DE-C7F5E28CE655}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -32,6 +36,14 @@ Global
 		{20B02738-952A-40F5-9C10-E2F83013E9FC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{20B02738-952A-40F5-9C10-E2F83013E9FC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{20B02738-952A-40F5-9C10-E2F83013E9FC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C5B51937-7CC9-4D9D-89A6-CEDAB506CAA7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C5B51937-7CC9-4D9D-89A6-CEDAB506CAA7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C5B51937-7CC9-4D9D-89A6-CEDAB506CAA7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C5B51937-7CC9-4D9D-89A6-CEDAB506CAA7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FB76B4A8-A645-4348-A8DE-C7F5E28CE655}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FB76B4A8-A645-4348-A8DE-C7F5E28CE655}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FB76B4A8-A645-4348-A8DE-C7F5E28CE655}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FB76B4A8-A645-4348-A8DE-C7F5E28CE655}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/System.IO.Abstractions/DirectoryInfoWrapper.cs
+++ b/System.IO.Abstractions/DirectoryInfoWrapper.cs
@@ -113,47 +113,83 @@ namespace System.IO.Abstractions
 
         public override IEnumerable<DirectoryInfoBase> EnumerateDirectories()
         {
+#if !NET40
+            return GetDirectories();
+#else
             return instance.EnumerateDirectories().Select(directoryInfo => new DirectoryInfoWrapper(directoryInfo));
+#endif
         }
 
         public override IEnumerable<DirectoryInfoBase> EnumerateDirectories(string searchPattern)
         {
+#if !NET40
+            return GetDirectories(searchPattern);
+#else
             return instance.EnumerateDirectories(searchPattern).Select(directoryInfo => new DirectoryInfoWrapper(directoryInfo));
+#endif
         }
 
         public override IEnumerable<DirectoryInfoBase> EnumerateDirectories(string searchPattern, SearchOption searchOption)
         {
+#if !NET40
+            return GetDirectories(searchPattern, searchOption);
+#else
             return instance.EnumerateDirectories(searchPattern, searchOption).Select(directoryInfo => new DirectoryInfoWrapper(directoryInfo));
+#endif
         }
 
         public override IEnumerable<FileInfoBase> EnumerateFiles()
         {
+#if !NET40
+            return GetFiles();
+#else
             return instance.EnumerateFiles().Select(fileInfo => new FileInfoWrapper(fileInfo));
+#endif
         }
 
         public override IEnumerable<FileInfoBase> EnumerateFiles(string searchPattern)
         {
+#if !NET40
+            return GetFiles(searchPattern);
+#else
             return instance.EnumerateFiles(searchPattern).Select(fileInfo => new FileInfoWrapper(fileInfo));
+#endif
         }
 
         public override IEnumerable<FileInfoBase> EnumerateFiles(string searchPattern, SearchOption searchOption)
         {
+#if !NET40
+            return GetFiles(searchPattern, searchOption);
+#else
             return instance.EnumerateFiles(searchPattern, searchOption).Select(fileInfo => new FileInfoWrapper(fileInfo));
+#endif
         }
 
         public override IEnumerable<FileSystemInfoBase> EnumerateFileSystemInfos()
         {
+#if !NET40
+            return GetFileSystemInfos();
+#else
             return instance.EnumerateFileSystemInfos().WrapFileSystemInfos();
+#endif
         }
 
         public override IEnumerable<FileSystemInfoBase> EnumerateFileSystemInfos(string searchPattern)
         {
+#if !NET40
+            return GetFileSystemInfos(searchPattern);
+#else
             return instance.EnumerateFileSystemInfos(searchPattern).WrapFileSystemInfos();
+#endif
         }
 
         public override IEnumerable<FileSystemInfoBase> EnumerateFileSystemInfos(string searchPattern, SearchOption searchOption)
         {
+#if !NET40
+            return GetFileSystemInfos(searchPattern, searchOption);
+#else
             return instance.EnumerateFileSystemInfos(searchPattern, searchOption).WrapFileSystemInfos();
+#endif
         }
 
         public override DirectorySecurity GetAccessControl()
@@ -208,7 +244,20 @@ namespace System.IO.Abstractions
 
         public override FileSystemInfoBase[] GetFileSystemInfos(string searchPattern, SearchOption searchOption)
         {
+#if !NET40
+            if (searchOption == SearchOption.TopDirectoryOnly)
+            {
+                return instance.GetFileSystemInfos(searchPattern).WrapFileSystemInfos();
+            }
+            else
+            {
+                var fis = instance.GetFiles(searchPattern, searchOption).WrapFileSystemInfos();
+                var dis = instance.GetDirectories(searchPattern, searchOption).WrapFileSystemInfos();
+                return fis.Union(dis).ToArray();
+            }
+#else
             return instance.GetFileSystemInfos(searchPattern, searchOption).WrapFileSystemInfos();
+#endif
         }
 
         public override void MoveTo(string destDirName)

--- a/System.IO.Abstractions/DirectoryWrapper.cs
+++ b/System.IO.Abstractions/DirectoryWrapper.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using System.Security.AccessControl;
 
 namespace System.IO.Abstractions
@@ -178,47 +179,93 @@ namespace System.IO.Abstractions
 
         public override IEnumerable<string> EnumerateDirectories(string path)
         {
+#if !NET40
+            return Directory.GetDirectories(path);
+#else
             return Directory.EnumerateDirectories(path);
+#endif
         }
 
         public override IEnumerable<string> EnumerateDirectories(string path, string searchPattern)
         {
+#if !NET40
+            return Directory.GetDirectories(path, searchPattern);
+#else
             return Directory.EnumerateDirectories(path, searchPattern);
+#endif
         }
 
         public override IEnumerable<string> EnumerateDirectories(string path, string searchPattern, SearchOption searchOption)
         {
+#if !NET40
+            return Directory.GetDirectories(path, searchPattern, searchOption);
+#else
             return Directory.EnumerateDirectories(path, searchPattern, searchOption);
+#endif
         }
 
         public override IEnumerable<string> EnumerateFiles(string path)
         {
-           return Directory.EnumerateFiles(path);
+#if !NET40
+            return Directory.GetFiles(path);
+#else
+            return Directory.EnumerateFiles(path);
+#endif
         }
  
         public override IEnumerable<string> EnumerateFiles(string path, string searchPattern)
         {
+#if !NET40
+            return Directory.GetFiles(path, searchPattern);
+#else
             return Directory.EnumerateFiles(path, searchPattern);
+#endif
         }
 
         public override IEnumerable<string> EnumerateFiles(string path, string searchPattern, SearchOption searchOption)
         {
+#if !NET40
+            return Directory.GetFiles(path, searchPattern, searchOption);
+#else
             return Directory.EnumerateFiles(path, searchPattern, searchOption);
+#endif
         }
 
         public override IEnumerable<string> EnumerateFileSystemEntries(string path)
         {
+#if !NET40
+            return Directory.GetFileSystemEntries(path);
+#else
             return Directory.EnumerateFileSystemEntries(path);
+#endif
         }
 
         public override IEnumerable<string> EnumerateFileSystemEntries(string path, string searchPattern)
         {
+#if !NET40
+            return Directory.GetFileSystemEntries(path, searchPattern);
+#else
             return Directory.EnumerateFileSystemEntries(path, searchPattern);
+#endif
         }
 
         public override IEnumerable<string> EnumerateFileSystemEntries(string path, string searchPattern, SearchOption searchOption)
         {
+#if !NET40
+            if (searchOption == SearchOption.TopDirectoryOnly)
+            {
+                return Directory.GetFileSystemEntries(path, searchPattern);
+            }
+            else
+            {
+                var fs = GetFiles(path, searchPattern, searchOption);
+                var ds = GetDirectories(path, searchPattern, searchOption);
+                return fs.Union(ds);
+            }
+            
+#else
             return Directory.EnumerateFileSystemEntries(path, searchPattern, searchOption);
+#endif
         }
     }
 }

--- a/System.IO.Abstractions/FileWrapper.cs
+++ b/System.IO.Abstractions/FileWrapper.cs
@@ -9,12 +9,28 @@ namespace System.IO.Abstractions
     {
         public override void AppendAllLines(string path, IEnumerable<string> contents)
         {
+#if !NET40
+            using (var sw = new StreamWriter(path, append: true))
+            {
+                foreach (var s in contents)
+                    sw.WriteLine(s);
+            }
+#else
             File.AppendAllLines(path, contents);
+#endif
         }
 
         public override void AppendAllLines(string path, IEnumerable<string> contents, Encoding encoding)
         {
+#if !NET40
+            using (var sw = new StreamWriter(path, append: true, encoding: encoding))
+            {
+                foreach (var s in contents)
+                    sw.WriteLine(s);
+            }
+#else
             File.AppendAllLines(path, contents, encoding);
+#endif
         }
 
         public override void AppendAllText(string path, string contents)
@@ -206,12 +222,20 @@ namespace System.IO.Abstractions
 
         public override IEnumerable<string> ReadLines(string path)
         {
+#if !NET40
+            return File.ReadAllLines(path);
+#else
             return File.ReadLines(path);
+#endif
         }
 
         public override IEnumerable<string> ReadLines(string path, Encoding encoding)
         {
+#if !NET40
+            return File.ReadAllLines(path, encoding);
+#else
             return File.ReadLines(path, encoding);
+#endif
         }
 
         public override void Replace(string sourceFileName, string destinationFileName, string destinationBackupFileName)
@@ -333,7 +357,15 @@ namespace System.IO.Abstractions
         /// </remarks>
         public override void WriteAllLines(string path, IEnumerable<string> contents)
         {
+#if !NET40
+            using (var sw = new StreamWriter(path, append: false))
+            {
+                foreach (var s in contents)
+                    sw.WriteLine(s);
+            }
+#else
             File.WriteAllLines(path, contents);
+#endif
         }
 
         /// <summary>
@@ -380,7 +412,15 @@ namespace System.IO.Abstractions
         /// </remarks>
         public override void WriteAllLines(string path, IEnumerable<string> contents, Encoding encoding)
         {
+#if !NET40
+            using (var sw = new StreamWriter(path, append: false, encoding: encoding))
+            {
+                foreach (var s in contents)
+                    sw.WriteLine(s);
+            }
+#else
             File.WriteAllLines(path, contents, encoding);
+#endif
         }
 
         /// <summary>

--- a/System.IO.Abstractions/Lazy.cs
+++ b/System.IO.Abstractions/Lazy.cs
@@ -1,0 +1,80 @@
+﻿#if !NET40
+
+using System;
+using System.Linq;
+
+// From http://stackoverflow.com/questions/3207580/implementation-of-lazyt-for-net-3-5
+namespace System.IO.Abstractions
+{
+    /// <summary>
+    /// Provides support for lazy initialization.
+    /// </summary>
+    /// <typeparam name="T">Specifies the type of object that is being lazily initialized.</typeparam>
+    public sealed class Lazy<T>
+    {
+        private readonly object padlock = new object();
+        private readonly Func<T> createValue;
+        private bool isValueCreated;
+        private T value;
+
+        /// <summary>
+        /// Gets the lazily initialized value of the current Lazy{T} instance.
+        /// </summary>
+        public T Value
+        {
+            get
+            {
+                if (!isValueCreated)
+                {
+                    lock (padlock)
+                    {
+                        if (!isValueCreated)
+                        {
+                            value = createValue();
+                            isValueCreated = true;
+                        }
+                    }
+                }
+                return value;
+            }
+        }
+
+        /// <summary>
+        /// Gets a value that indicates whether a value has been created for this Lazy{T} instance.
+        /// </summary>
+        public bool IsValueCreated
+        {
+            get
+            {
+                lock (padlock)
+                {
+                    return isValueCreated;
+                }
+            }
+        }
+
+
+        /// <summary>
+        /// Initializes a new instance of the Lazy{T} class.
+        /// </summary>
+        /// <param name="createValue">The delegate that produces the value when it is needed.</param>
+        public Lazy(Func<T> createValue)
+        {
+            if (createValue == null) throw new ArgumentNullException("createValue");
+
+            this.createValue = createValue;
+        }
+
+
+        /// <summary>
+        /// Creates and returns a string representation of the Lazy{T}.Value.
+        /// </summary>
+        /// <returns>The string representation of the Lazy{T}.Value property.</returns>
+        public override string ToString()
+        {
+            return Value.ToString();
+        }
+    }
+}
+
+#endif

--- a/System.IO.Abstractions/PathWrapper.cs
+++ b/System.IO.Abstractions/PathWrapper.cs
@@ -36,7 +36,14 @@
 
         public override string Combine(params string[] paths)
         {
+#if !NET40
+            string result = paths[0];
+            for (int i = 1; i < paths.Length; i++)
+                result = Path.Combine(result, paths[i]);
+            return result;
+#else
             return Path.Combine(paths);
+#endif
         }
 
         public override string Combine(string path1, string path2)
@@ -46,12 +53,20 @@
 
         public override string Combine(string path1, string path2, string path3)
         {
+#if !NET40
+            return Path.Combine(Path.Combine(path1, path2), path3);
+#else
             return Path.Combine(path1, path2, path3);
+#endif
         }
 
         public override string Combine(string path1, string path2, string path3, string path4)
         {
+#if !NET40
+            return Path.Combine(Path.Combine(Path.Combine(path1, path2), path3), path4);
+#else
             return Path.Combine(path1, path2, path3, path4);
+#endif
         }
 
         public override string GetDirectoryName(string path)

--- a/System.IO.Abstractions/System.IO.Abstractions.csproj
+++ b/System.IO.Abstractions/System.IO.Abstractions.csproj
@@ -38,7 +38,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NET40</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
@@ -89,6 +89,7 @@
     <Compile Include="IDriveInfoFactory.cs" />
     <Compile Include="IFileInfoFactory.cs" />
     <Compile Include="IFileSystem.cs" />
+    <Compile Include="Lazy.cs" />
     <Compile Include="PathBase.cs" />
     <Compile Include="PathWrapper.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/System.IO.Abstractions/System.IO.Abstractions.nuspec
+++ b/System.IO.Abstractions/System.IO.Abstractions.nuspec
@@ -10,5 +10,15 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Just like System.Web.Abstractions, but for System.IO. Yay for testable IO access! Be sure to check out the System.IO.Abstractions.TestingHelpers package too.</description>
     <tags>testing</tags>
+    <dependencies>
+      <group targetFramework="net20">
+        <dependency id="LinqBridge" version="1.3.0" />
+      </group>
+    </dependencies>
   </metadata>
+  <files>
+    <file src="bin\Debug\System.IO.Abstractions.dll" target="lib\Net40\System.IO.Abstractions.dll" />
+    <file src="..\System.IO.Abstractions35\bin\Debug\System.IO.Abstractions.dll" target="lib\Net35\System.IO.Abstractions.dll" />
+    <file src="..\System.IO.Abstractions20\bin\Debug\System.IO.Abstractions.dll" target="lib\Net20\System.IO.Abstractions.dll" />
+  </files>
 </package>

--- a/System.IO.Abstractions20/Properties/AssemblyInfo.cs
+++ b/System.IO.Abstractions20/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("System.IO.Abstractions20")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("System.IO.Abstractions20")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("fb76b4a8-a645-4348-a8de-c7f5e28ce655")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/System.IO.Abstractions20/System.IO.Abstractions20.csproj
+++ b/System.IO.Abstractions20/System.IO.Abstractions20.csproj
@@ -1,0 +1,130 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{FB76B4A8-A645-4348-A8DE-C7F5E28CE655}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>System.IO.Abstractions</RootNamespace>
+    <AssemblyName>System.IO.Abstractions</AssemblyName>
+    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>TRACE;DEBUG</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="LinqBridge, Version=1.3.0.0, Culture=neutral, PublicKeyToken=c2b14eb747628076, processorArchitecture=MSIL">
+      <HintPath>..\packages\LinqBridge.1.3.0\lib\net20\LinqBridge.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\System.IO.Abstractions\Converters.cs">
+      <Link>Converters.cs</Link>
+    </Compile>
+    <Compile Include="..\System.IO.Abstractions\DirectoryBase.cs">
+      <Link>DirectoryBase.cs</Link>
+    </Compile>
+    <Compile Include="..\System.IO.Abstractions\DirectoryInfoBase.cs">
+      <Link>DirectoryInfoBase.cs</Link>
+    </Compile>
+    <Compile Include="..\System.IO.Abstractions\DirectoryInfoFactory.cs">
+      <Link>DirectoryInfoFactory.cs</Link>
+    </Compile>
+    <Compile Include="..\System.IO.Abstractions\DirectoryInfoWrapper.cs">
+      <Link>DirectoryInfoWrapper.cs</Link>
+    </Compile>
+    <Compile Include="..\System.IO.Abstractions\DirectoryWrapper.cs">
+      <Link>DirectoryWrapper.cs</Link>
+    </Compile>
+    <Compile Include="..\System.IO.Abstractions\DriveInfoBase.cs">
+      <Link>DriveInfoBase.cs</Link>
+    </Compile>
+    <Compile Include="..\System.IO.Abstractions\DriveInfoFactory.cs">
+      <Link>DriveInfoFactory.cs</Link>
+    </Compile>
+    <Compile Include="..\System.IO.Abstractions\DriveInfoWrapper.cs">
+      <Link>DriveInfoWrapper.cs</Link>
+    </Compile>
+    <Compile Include="..\System.IO.Abstractions\FileBase.cs">
+      <Link>FileBase.cs</Link>
+    </Compile>
+    <Compile Include="..\System.IO.Abstractions\FileInfoBase.cs">
+      <Link>FileInfoBase.cs</Link>
+    </Compile>
+    <Compile Include="..\System.IO.Abstractions\FileInfoFactory.cs">
+      <Link>FileInfoFactory.cs</Link>
+    </Compile>
+    <Compile Include="..\System.IO.Abstractions\FileInfoWrapper.cs">
+      <Link>FileInfoWrapper.cs</Link>
+    </Compile>
+    <Compile Include="..\System.IO.Abstractions\FileSystem.cs">
+      <Link>FileSystem.cs</Link>
+    </Compile>
+    <Compile Include="..\System.IO.Abstractions\FileSystemInfoBase.cs">
+      <Link>FileSystemInfoBase.cs</Link>
+    </Compile>
+    <Compile Include="..\System.IO.Abstractions\FileSystemWatcherBase.cs">
+      <Link>FileSystemWatcherBase.cs</Link>
+    </Compile>
+    <Compile Include="..\System.IO.Abstractions\FileSystemWatcherWrapper.cs">
+      <Link>FileSystemWatcherWrapper.cs</Link>
+    </Compile>
+    <Compile Include="..\System.IO.Abstractions\FileWrapper.cs">
+      <Link>FileWrapper.cs</Link>
+    </Compile>
+    <Compile Include="..\System.IO.Abstractions\IDirectoryInfoFactory.cs">
+      <Link>IDirectoryInfoFactory.cs</Link>
+    </Compile>
+    <Compile Include="..\System.IO.Abstractions\IDriveInfoFactory.cs">
+      <Link>IDriveInfoFactory.cs</Link>
+    </Compile>
+    <Compile Include="..\System.IO.Abstractions\IFileInfoFactory.cs">
+      <Link>IFileInfoFactory.cs</Link>
+    </Compile>
+    <Compile Include="..\System.IO.Abstractions\IFileSystem.cs">
+      <Link>IFileSystem.cs</Link>
+    </Compile>
+    <Compile Include="..\System.IO.Abstractions\Lazy.cs">
+      <Link>Lazy.cs</Link>
+    </Compile>
+    <Compile Include="..\System.IO.Abstractions\PathBase.cs">
+      <Link>PathBase.cs</Link>
+    </Compile>
+    <Compile Include="..\System.IO.Abstractions\PathWrapper.cs">
+      <Link>PathWrapper.cs</Link>
+    </Compile>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/System.IO.Abstractions20/packages.config
+++ b/System.IO.Abstractions20/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="LinqBridge" version="1.3.0" targetFramework="net20" />
+</packages>

--- a/System.IO.Abstractions35/System.IO.Abstractions35.csproj
+++ b/System.IO.Abstractions35/System.IO.Abstractions35.csproj
@@ -1,0 +1,128 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{C5B51937-7CC9-4D9D-89A6-CEDAB506CAA7}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>System.IO.Abstractions</RootNamespace>
+    <AssemblyName>System.IO.Abstractions</AssemblyName>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>TRACE;DEBUG</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\System.IO.Abstractions\Converters.cs">
+      <Link>Converters.cs</Link>
+    </Compile>
+    <Compile Include="..\System.IO.Abstractions\DirectoryBase.cs">
+      <Link>DirectoryBase.cs</Link>
+    </Compile>
+    <Compile Include="..\System.IO.Abstractions\DirectoryInfoBase.cs">
+      <Link>DirectoryInfoBase.cs</Link>
+    </Compile>
+    <Compile Include="..\System.IO.Abstractions\DirectoryInfoFactory.cs">
+      <Link>DirectoryInfoFactory.cs</Link>
+    </Compile>
+    <Compile Include="..\System.IO.Abstractions\DirectoryInfoWrapper.cs">
+      <Link>DirectoryInfoWrapper.cs</Link>
+    </Compile>
+    <Compile Include="..\System.IO.Abstractions\DirectoryWrapper.cs">
+      <Link>DirectoryWrapper.cs</Link>
+    </Compile>
+    <Compile Include="..\System.IO.Abstractions\DriveInfoBase.cs">
+      <Link>DriveInfoBase.cs</Link>
+    </Compile>
+    <Compile Include="..\System.IO.Abstractions\DriveInfoFactory.cs">
+      <Link>DriveInfoFactory.cs</Link>
+    </Compile>
+    <Compile Include="..\System.IO.Abstractions\DriveInfoWrapper.cs">
+      <Link>DriveInfoWrapper.cs</Link>
+    </Compile>
+    <Compile Include="..\System.IO.Abstractions\FileBase.cs">
+      <Link>FileBase.cs</Link>
+    </Compile>
+    <Compile Include="..\System.IO.Abstractions\FileInfoBase.cs">
+      <Link>FileInfoBase.cs</Link>
+    </Compile>
+    <Compile Include="..\System.IO.Abstractions\FileInfoFactory.cs">
+      <Link>FileInfoFactory.cs</Link>
+    </Compile>
+    <Compile Include="..\System.IO.Abstractions\FileInfoWrapper.cs">
+      <Link>FileInfoWrapper.cs</Link>
+    </Compile>
+    <Compile Include="..\System.IO.Abstractions\FileSystem.cs">
+      <Link>FileSystem.cs</Link>
+    </Compile>
+    <Compile Include="..\System.IO.Abstractions\FileSystemInfoBase.cs">
+      <Link>FileSystemInfoBase.cs</Link>
+    </Compile>
+    <Compile Include="..\System.IO.Abstractions\FileSystemWatcherBase.cs">
+      <Link>FileSystemWatcherBase.cs</Link>
+    </Compile>
+    <Compile Include="..\System.IO.Abstractions\FileSystemWatcherWrapper.cs">
+      <Link>FileSystemWatcherWrapper.cs</Link>
+    </Compile>
+    <Compile Include="..\System.IO.Abstractions\FileWrapper.cs">
+      <Link>FileWrapper.cs</Link>
+    </Compile>
+    <Compile Include="..\System.IO.Abstractions\IDirectoryInfoFactory.cs">
+      <Link>IDirectoryInfoFactory.cs</Link>
+    </Compile>
+    <Compile Include="..\System.IO.Abstractions\IDriveInfoFactory.cs">
+      <Link>IDriveInfoFactory.cs</Link>
+    </Compile>
+    <Compile Include="..\System.IO.Abstractions\IFileInfoFactory.cs">
+      <Link>IFileInfoFactory.cs</Link>
+    </Compile>
+    <Compile Include="..\System.IO.Abstractions\IFileSystem.cs">
+      <Link>IFileSystem.cs</Link>
+    </Compile>
+    <Compile Include="..\System.IO.Abstractions\Lazy.cs">
+      <Link>Lazy.cs</Link>
+    </Compile>
+    <Compile Include="..\System.IO.Abstractions\PathBase.cs">
+      <Link>PathBase.cs</Link>
+    </Compile>
+    <Compile Include="..\System.IO.Abstractions\PathWrapper.cs">
+      <Link>PathWrapper.cs</Link>
+    </Compile>
+    <Compile Include="..\System.IO.Abstractions\Properties\AssemblyInfo.cs">
+      <Link>Properties\AssemblyInfo.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>


### PR DESCRIPTION
While I love System.IO.Abstractions for the boost it gives to testability, I am in the unfortunate position of having to support some libraries that need to be built for older framework versions. This makes it impossible to incorporate System.IO.Abstractions into them at the moment.

This pull request adds support for 3.5 and 2.0 (for which LinqBridge is also needed). All public APIs are preserved and have the same semantics, but the performance and memory usage characteristics might be somewhat different, because the technique used is to delegate the Enumerate\* methods (which don't exist in older frameworks) back to the Get\* methods, which do.

I updated the nuspec to incorporate all 3 versions, but it should really be changed to use the Release builds rather than the Debug ones, but I don't see to be able to build in Release mode, something to do with the key.
