### PR TITLE
181 moving a file to itself will no longer throw an exception

### DIFF
--- a/TestHelpers.Tests/MockFileCopyTests.cs
+++ b/TestHelpers.Tests/MockFileCopyTests.cs
@@ -271,5 +271,25 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             Assert.That(exception.Message, Is.StringStarting("Empty file name is not legal."));
         }
+
+        [Test]
+        [ExpectedException(typeof(FileNotFoundException))]
+        public void MockFile_Copy_ShouldThrowExceptionWhenSourceDoesNotExist()
+        {
+            string sourceFilePath = XFS.Path(@"c:\something\demo.txt");
+            var fileSystem = new MockFileSystem();
+
+            fileSystem.File.Copy(sourceFilePath, XFS.Path(@"c:\something\demo2.txt"));
+        }
+
+        [Test]
+        [ExpectedException(typeof(FileNotFoundException))]
+        public void MockFile_Copy_ShouldThrowExceptionWhenSourceDoesNotExist_EvenWhenCopyingToItself()
+        {
+            string sourceFilePath = XFS.Path(@"c:\something\demo.txt");
+            var fileSystem = new MockFileSystem();
+
+            fileSystem.File.Copy(sourceFilePath, XFS.Path(@"c:\something\demo.txt"));
+        }
     }
 }

--- a/TestHelpers.Tests/MockFileInfoTests.cs
+++ b/TestHelpers.Tests/MockFileInfoTests.cs
@@ -490,6 +490,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileInfo.MoveTo(destination);
 
             Assert.AreEqual(fileInfo.FullName, destination);
+            Assert.True(fileInfo.Exists);
         }
 
         [Test]

--- a/TestHelpers.Tests/MockFileInfoTests.cs
+++ b/TestHelpers.Tests/MockFileInfoTests.cs
@@ -491,5 +491,50 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             Assert.AreEqual(fileInfo.FullName, destination);
         }
+
+        [Test]
+        [ExpectedException(typeof(FileNotFoundException))]
+        public void MockFileInfo_MoveTo_SameSourceAndTargetThrowsExceptionIfSourceDoesntExist()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            var fileInfo = fileSystem.FileInfo.FromFileName(XFS.Path(@"c:\temp\file.txt"));
+
+            // Act
+            string destination = XFS.Path(XFS.Path(@"c:\temp\file.txt"));
+            fileInfo.MoveTo(destination);
+
+            Assert.AreEqual(fileInfo.FullName, destination);
+        }
+
+        [Test]
+        [ExpectedException(typeof(FileNotFoundException))]
+        public void MockFileInfo_MoveTo_ThrowsExceptionIfSourceDoesntExist()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            var fileInfo = fileSystem.FileInfo.FromFileName(XFS.Path(@"c:\temp\file.txt"));
+
+            // Act
+            string destination = XFS.Path(XFS.Path(@"c:\temp\file2.txt"));
+            fileInfo.MoveTo(destination);
+
+            Assert.AreEqual(fileInfo.FullName, destination);
+        }
+
+        [Test]
+        [ExpectedException(typeof(FileNotFoundException))]
+        public void MockFileInfo_CopyTo_ThrowsExceptionIfSourceDoesntExist()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            var fileInfo = fileSystem.FileInfo.FromFileName(XFS.Path(@"c:\temp\file.txt"));
+
+            // Act
+            string destination = XFS.Path(XFS.Path(@"c:\temp\file2.txt"));
+            fileInfo.CopyTo(destination);
+
+            Assert.AreEqual(fileInfo.FullName, destination);
+        }
     }
 }

--- a/TestHelpers.Tests/MockFileInfoTests.cs
+++ b/TestHelpers.Tests/MockFileInfoTests.cs
@@ -476,5 +476,20 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             Assert.AreEqual(fileInfo.DirectoryName, destinationFolder);
             Assert.AreEqual(fileInfo.FullName, destination);
         }
+
+        [Test]
+        public void MockFileInfo_MoveTo_SameSourceAndTargetIsANoOp()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddFile(XFS.Path(@"c:\temp\file.txt"), new MockFileData(@"line 1\r\nline 2"));
+            var fileInfo = fileSystem.FileInfo.FromFileName(XFS.Path(@"c:\temp\file.txt"));
+
+            // Act
+            string destination = XFS.Path(XFS.Path(@"c:\temp\file.txt"));
+            fileInfo.MoveTo(destination);
+
+            Assert.AreEqual(fileInfo.FullName, destination);
+        }
     }
 }

--- a/TestHelpers.Tests/MockFileMoveTests.cs
+++ b/TestHelpers.Tests/MockFileMoveTests.cs
@@ -30,6 +30,25 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
+        public void MockFile_Move_SameSourceAndTargetIsANoOp()
+        {
+            string sourceFilePath = XFS.Path(@"c:\something\demo.txt");
+            string sourceFileContent = "this is some content";
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                {sourceFilePath, new MockFileData(sourceFileContent)},
+                {XFS.Path(@"c:\somethingelse\dummy.txt"), new MockFileData(new byte[] {0})}
+            });
+
+            string destFilePath = XFS.Path(@"c:\somethingelse\demo.txt");
+
+            fileSystem.File.Move(sourceFilePath, destFilePath);
+
+            Assert.That(fileSystem.FileExists(destFilePath), Is.True);
+            Assert.That(fileSystem.GetFile(destFilePath).TextContents, Is.EqualTo(sourceFileContent));
+        }
+
+        [Test]
         public void MockFile_Move_ShouldThrowIOExceptionWhenTargetAlreadyExists()
         {
             string sourceFilePath = XFS.Path(@"c:\something\demo.txt");

--- a/TestHelpers.Tests/MockFileMoveTests.cs
+++ b/TestHelpers.Tests/MockFileMoveTests.cs
@@ -305,5 +305,25 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             Assert.That(() => fileSystem.File.Move(sourceFilePath, destFilePath),
                 Throws.InstanceOf<DirectoryNotFoundException>().With.Message.StartsWith(@"Could not find a part of the path"));
         }
+
+        [Test]
+        [ExpectedException(typeof(FileNotFoundException))]
+        public void MockFile_Move_ShouldThrowExceptionWhenSourceDoesNotExist()
+        {
+            string sourceFilePath = XFS.Path(@"c:\something\demo.txt");
+            var fileSystem = new MockFileSystem();
+
+            fileSystem.File.Move(sourceFilePath, XFS.Path(@"c:\something\demo2.txt"));
+        }
+
+        [Test]
+        [ExpectedException(typeof(FileNotFoundException))]
+        public void MockFile_Move_ShouldThrowExceptionWhenSourceDoesNotExist_EvenWhenCopyingToItself()
+        {
+            string sourceFilePath = XFS.Path(@"c:\something\demo.txt");
+            var fileSystem = new MockFileSystem();
+
+            fileSystem.File.Move(sourceFilePath, XFS.Path(@"c:\something\demo.txt"));
+        }
     }
 }

--- a/TestHelpers.Tests/MockFileStreamTests.cs
+++ b/TestHelpers.Tests/MockFileStreamTests.cs
@@ -15,7 +15,7 @@
             // Arrange
             var filepath = XFS.Path(@"c:\something\foo.txt");
             var filesystem = new MockFileSystem(new Dictionary<string, MockFileData>());
-            var cut = new MockFileStream(filesystem, filepath);
+            var cut = new MockFileStream(filesystem, filepath, MockFileStream.StreamType.WRITE);
 
             // Act
             cut.WriteByte(255);
@@ -43,6 +43,20 @@
             Assert.AreEqual(1, fileCount1, "File should have existed");
             Assert.AreEqual(0, fileCount2, "File should have been deleted");
             Assert.AreEqual(0, fileCount3, "Disposing stream should not have resurrected the file");
+        }
+
+        [Test]
+        [ExpectedException(typeof(FileNotFoundException))]
+        public void MockFileStream_Constructor_Reading_Nonexistent_File_Throws_Exception()
+        {
+            // Arrange
+            var nonexistentFilePath = XFS.Path(@"c:\something\foo.txt");
+            var filesystem = new MockFileSystem(new Dictionary<string, MockFileData>());         
+
+            // Act
+            var illegalFileStream = new MockFileStream(filesystem, nonexistentFilePath, MockFileStream.StreamType.READ);
+
+            // Assert - expect an exception
         }
     }
 }

--- a/TestingHelpers/MockFile.cs
+++ b/TestingHelpers/MockFile.cs
@@ -99,10 +99,7 @@ namespace System.IO.Abstractions.TestingHelpers
 
         public override void Copy(string sourceFileName, string destFileName, bool overwrite)
         {
-            if (!Exists(sourceFileName))
-            {
-                throw new FileNotFoundException();
-            }
+            //This is the order that checks are executed in MSCORLIB.
             if (sourceFileName == null)
             {
                 throw new ArgumentNullException("sourceFileName", Properties.Resources.FILENAME_CANNOT_BE_NULL);
@@ -112,9 +109,12 @@ namespace System.IO.Abstractions.TestingHelpers
             {
                 throw new ArgumentNullException("destFileName", Properties.Resources.FILENAME_CANNOT_BE_NULL);
             }
-
             mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(sourceFileName, "sourceFileName");
             mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(destFileName, "destFileName");
+            if (!Exists(sourceFileName))
+            {
+                throw new FileNotFoundException();
+            }
 
             var directoryNameOfDestination = mockPath.GetDirectoryName(destFileName);
             if (!mockFileDataAccessor.Directory.Exists(directoryNameOfDestination))

--- a/TestingHelpers/MockFile.cs
+++ b/TestingHelpers/MockFile.cs
@@ -99,6 +99,9 @@ namespace System.IO.Abstractions.TestingHelpers
 
         public override void Copy(string sourceFileName, string destFileName, bool overwrite)
         {
+            if (!Exists(sourceFileName))
+            {
+            }
             if (sourceFileName == null)
             {
                 throw new ArgumentNullException("sourceFileName", Properties.Resources.FILENAME_CANNOT_BE_NULL);

--- a/TestingHelpers/MockFile.cs
+++ b/TestingHelpers/MockFile.cs
@@ -101,6 +101,7 @@ namespace System.IO.Abstractions.TestingHelpers
         {
             if (!Exists(sourceFileName))
             {
+                throw new FileNotFoundException();
             }
             if (sourceFileName == null)
             {

--- a/TestingHelpers/MockFile.cs
+++ b/TestingHelpers/MockFile.cs
@@ -399,7 +399,7 @@ namespace System.IO.Abstractions.TestingHelpers
         {
             mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, "path");
 
-            return new MockFileStream(mockFileDataAccessor, path);
+            return new MockFileStream(mockFileDataAccessor, path, MockFileStream.StreamType.WRITE);
         }
 
         public override byte[] ReadAllBytes(string path)

--- a/TestingHelpers/MockFile.cs
+++ b/TestingHelpers/MockFile.cs
@@ -323,7 +323,16 @@ namespace System.IO.Abstractions.TestingHelpers
             mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(destFileName, "destFileName");
 
             if (mockFileDataAccessor.GetFile(destFileName) != null)
-                throw new IOException("A file can not be created if it already exists.");
+            {
+                if (destFileName.Equals(sourceFileName))
+                {
+                    return;
+                } else
+                {
+                    throw new IOException("A file can not be created if it already exists.");
+                }
+            }
+                
 
             var sourceFile = mockFileDataAccessor.GetFile(sourceFileName);
 

--- a/TestingHelpers/MockFileInfo.cs
+++ b/TestingHelpers/MockFileInfo.cs
@@ -217,6 +217,10 @@ namespace System.IO.Abstractions.TestingHelpers
         public override void MoveTo(string destFileName)
         {
             var movedFileInfo = CopyTo(destFileName);
+            if (destFileName == FullName)
+            {
+                return;
+            }
             Delete();
             path = movedFileInfo.FullName;
         }

--- a/TestingHelpers/MockFileInfo.cs
+++ b/TestingHelpers/MockFileInfo.cs
@@ -161,12 +161,19 @@ namespace System.IO.Abstractions.TestingHelpers
 
         public override FileInfoBase CopyTo(string destFileName)
         {
-            new MockFile(mockFileSystem).Copy(FullName, destFileName);
-            return mockFileSystem.FileInfo.FromFileName(destFileName);
+            return CopyTo(destFileName, false);
         }
 
         public override FileInfoBase CopyTo(string destFileName, bool overwrite)
         {
+            if (!Exists)
+            {
+                throw new FileNotFoundException("The file does not exist and can't be moved or copied.", FullName);
+            }
+            if (destFileName == FullName)
+            {
+                return this;
+            }
             new MockFile(mockFileSystem).Copy(FullName, destFileName, overwrite);
             return mockFileSystem.FileInfo.FromFileName(destFileName);
         }
@@ -209,10 +216,6 @@ namespace System.IO.Abstractions.TestingHelpers
 
         public override void MoveTo(string destFileName)
         {
-            if (destFileName == FullName)
-            {
-                return;
-            }
             var movedFileInfo = CopyTo(destFileName);
             Delete();
             path = movedFileInfo.FullName;

--- a/TestingHelpers/MockFileInfo.cs
+++ b/TestingHelpers/MockFileInfo.cs
@@ -209,7 +209,11 @@ namespace System.IO.Abstractions.TestingHelpers
 
         public override void MoveTo(string destFileName)
         {
-            var movedFileInfo = CopyTo(destFileName, true);
+            if (destFileName == FullName)
+            {
+                return;
+            }
+            var movedFileInfo = CopyTo(destFileName);
             Delete();
             path = movedFileInfo.FullName;
         }

--- a/TestingHelpers/MockFileInfo.cs
+++ b/TestingHelpers/MockFileInfo.cs
@@ -155,7 +155,7 @@ namespace System.IO.Abstractions.TestingHelpers
         public override StreamWriter AppendText()
         {
             if (MockFileData == null) throw new FileNotFoundException("File not found", path);
-            return new StreamWriter(new MockFileStream(mockFileSystem, FullName, true));
+            return new StreamWriter(new MockFileStream(mockFileSystem, FullName, MockFileStream.StreamType.APPEND));
             //return ((MockFileDataModifier) MockFileData).AppendText();
         }
 
@@ -231,7 +231,8 @@ namespace System.IO.Abstractions.TestingHelpers
 
         public override Stream OpenRead()
         {
-            return new MockFileStream(mockFileSystem, path);
+            if (MockFileData == null) throw new FileNotFoundException("File not found", path);
+            return new MockFileStream(mockFileSystem, path, MockFileStream.StreamType.READ);
         }
 
         public override StreamReader OpenText()
@@ -241,7 +242,7 @@ namespace System.IO.Abstractions.TestingHelpers
 
         public override Stream OpenWrite()
         {
-            return new MockFileStream(mockFileSystem, path);
+            return new MockFileStream(mockFileSystem, path, MockFileStream.StreamType.WRITE);
         }
 
         public override FileInfoBase Replace(string destinationFileName, string destinationBackupFileName)

--- a/TestingHelpers/MockFileInfo.cs
+++ b/TestingHelpers/MockFileInfo.cs
@@ -209,7 +209,7 @@ namespace System.IO.Abstractions.TestingHelpers
 
         public override void MoveTo(string destFileName)
         {
-            var movedFileInfo = CopyTo(destFileName);
+            var movedFileInfo = CopyTo(destFileName, true);
             Delete();
             path = movedFileInfo.FullName;
         }

--- a/TestingHelpers/MockFileStream.cs
+++ b/TestingHelpers/MockFileStream.cs
@@ -6,7 +6,14 @@
         private readonly IMockFileDataAccessor mockFileDataAccessor;
         private readonly string path;
 
-        public MockFileStream(IMockFileDataAccessor mockFileDataAccessor, string path, bool forAppend = false)
+        public enum StreamType
+        {
+            READ,
+            WRITE,
+            APPEND
+        }
+
+        public MockFileStream(IMockFileDataAccessor mockFileDataAccessor, string path, StreamType streamType)
         {
             if (mockFileDataAccessor == null)
             {
@@ -23,13 +30,17 @@
                 if (data != null && data.Length > 0)
                 {
                     Write(data, 0, data.Length);
-                    Seek(0, forAppend
+                    Seek(0, StreamType.APPEND.Equals(streamType)
                         ? SeekOrigin.End
                         : SeekOrigin.Begin);
                 }
             }
             else
             {
+                if (StreamType.READ.Equals(streamType))
+                {
+                    throw new FileNotFoundException("File not found.", path);
+                }
                 mockFileDataAccessor.AddFile(path, new MockFileData(new byte[] { }));
             }
         }


### PR DESCRIPTION
See http://stackoverflow.com/questions/40722205/should-mscorlibs-fileinfo-moveto-throw-an-exception-if-trying-to-move-a-file