### PR TITLE
MockFile.Copy now throws a FileNotFoundException when the source file doesn't exist.

### DIFF
--- a/TestHelpers.Tests/MockFileCopyTests.cs
+++ b/TestHelpers.Tests/MockFileCopyTests.cs
@@ -271,5 +271,29 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             Assert.That(exception.Message, Is.StringStarting("Empty file name is not legal."));
         }
+
+        [Test]
+        public void MockFile_Copy_ShouldThrowFileNotFoundExceptionWhenSourceFileDoesNotExist_Message()
+        {
+            var sourceFileName = XFS.Path(@"c:\source\demo.txt");
+            var destFileName = XFS.Path(@"c:\destination\demo.txt");
+            var fileSystem = new MockFileSystem();
+            // The "real" System.IO.File throws a FileNotFoundException before checking if that the destination folder exists, therefore there is no need to create it.
+
+            var exception = Assert.Throws<FileNotFoundException>(() => fileSystem.File.Copy(sourceFileName, destFileName));
+            Assert.That(exception.Message, Is.EqualTo(XFS.Path(@"Could not find file 'c:\source\demo.txt'.")));
+        }
+
+        [Test]
+        public void MockFile_Copy_ShouldThrowFileNotFoundExceptionWhenSourceFileDoesNotExist_FileName()
+        {
+            var sourceFileName = XFS.Path(@"c:\source\demo.txt");
+            var destFileName = XFS.Path(@"c:\destination\demo.txt");
+            var fileSystem = new MockFileSystem();
+            // The "real" System.IO.File throws a FileNotFoundException before checking if that the destination folder exists, therefore there is no need to create it.
+
+            var exception = Assert.Throws<FileNotFoundException>(() => fileSystem.File.Copy(sourceFileName, destFileName));
+            Assert.That(exception.FileName, Is.EqualTo(sourceFileName));
+        }
     }
 }

--- a/TestHelpers.Tests/MockFileInfoTests.cs
+++ b/TestHelpers.Tests/MockFileInfoTests.cs
@@ -476,5 +476,39 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             Assert.AreEqual(fileInfo.DirectoryName, destinationFolder);
             Assert.AreEqual(fileInfo.FullName, destination);
         }
+
+        [Test]
+        public void MockFileInfo_CopyTo_ShouldThrowFileNotFoundExceptionWhenSourceFileDoesNotExist_Message()
+        {
+            //Arrange
+            var sourceFileName = XFS.Path(@"c:\source\demo.txt");
+            var destFileName = XFS.Path(@"c:\destination\demo.txt");
+
+            var fileSystem = new MockFileSystem();
+            var fileInfo = fileSystem.FileInfo.FromFileName(sourceFileName);
+            // The "real" FileInfo throws a FileNotFoundException before checking if that the destination folder exists, therefore there is no need to create it.
+
+            //Act
+            var exception = Assert.Throws<FileNotFoundException>(() => fileInfo.CopyTo(destFileName));
+
+            Assert.That(exception.Message, Is.EqualTo(XFS.Path(@"Could not find file 'c:\source\demo.txt'.")));
+        }
+
+        [Test]
+        public void MockFileInfo_CopyTo_ShouldThrowFileNotFoundExceptionWhenSourceFileDoesNotExist_FileName()
+        {
+            //Arrange
+            var sourceFileName = XFS.Path(@"c:\source\demo.txt");
+            var destFileName = XFS.Path(@"c:\destination\demo.txt");
+
+            var fileSystem = new MockFileSystem();
+            var fileInfo = fileSystem.FileInfo.FromFileName(sourceFileName);
+            // The "real" FileInfo throws a FileNotFoundException before checking if that the destination folder exists, therefore there is no need to create it.
+
+            //Act
+            var exception = Assert.Throws<FileNotFoundException>(() => fileInfo.CopyTo(destFileName));
+
+            Assert.That(exception.FileName, Is.EqualTo(sourceFileName));
+        }
     }
 }

--- a/TestingHelpers/MockFile.cs
+++ b/TestingHelpers/MockFile.cs
@@ -112,14 +112,20 @@ namespace System.IO.Abstractions.TestingHelpers
             mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(sourceFileName, "sourceFileName");
             mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(destFileName, "destFileName");
 
+            var sourceFileExists = mockFileDataAccessor.FileExists(sourceFileName);
+            if (!sourceFileExists)
+            {
+                throw new FileNotFoundException(string.Format(CultureInfo.InvariantCulture, Properties.Resources.COULD_NOT_FIND_FILE_EXCEPTION, sourceFileName), sourceFileName);
+            }
+
             var directoryNameOfDestination = mockPath.GetDirectoryName(destFileName);
             if (!mockFileDataAccessor.Directory.Exists(directoryNameOfDestination))
             {
                 throw new DirectoryNotFoundException(string.Format(CultureInfo.InvariantCulture, Properties.Resources.COULD_NOT_FIND_PART_OF_PATH_EXCEPTION, destFileName));
             }
 
-            var fileExists = mockFileDataAccessor.FileExists(destFileName);
-            if (fileExists)
+            var destFileExists = mockFileDataAccessor.FileExists(destFileName);
+            if (destFileExists)
             {
                 if (!overwrite)
                 {

--- a/TestingHelpers/Properties/Resources.Designer.cs
+++ b/TestingHelpers/Properties/Resources.Designer.cs
@@ -70,6 +70,15 @@ namespace System.IO.Abstractions.TestingHelpers.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Could not find file &apos;{0}&apos;..
+        /// </summary>
+        internal static string COULD_NOT_FIND_FILE_EXCEPTION {
+            get {
+                return ResourceManager.GetString("COULD_NOT_FIND_FILE_EXCEPTION", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Could not find a part of the path &apos;{0}&apos;..
         /// </summary>
         internal static string COULD_NOT_FIND_PART_OF_PATH_EXCEPTION {

--- a/TestingHelpers/Properties/Resources.resx
+++ b/TestingHelpers/Properties/Resources.resx
@@ -141,4 +141,7 @@
   <data name="FILENAME_CANNOT_BE_NULL" xml:space="preserve">
     <value>File name cannot be null.</value>
   </data>
+  <data name="COULD_NOT_FIND_FILE_EXCEPTION" xml:space="preserve">
+    <value>Could not find file '{0}'.</value>
+  </data>
 </root>


### PR DESCRIPTION
Previously no exception was thrown and it appeared to work, but later requests to some MockFileSystem methods would then fail with NullReferenceException's.  

The fix mimics System.IO.File's Copy and Move methods.