### PR TITLE
Add FileVersionInfo support to FileInfo.

### DIFF
--- a/System.IO.Abstractions/FileInfoBase.cs
+++ b/System.IO.Abstractions/FileInfoBase.cs
@@ -14,6 +14,7 @@ namespace System.IO.Abstractions
         public abstract void Encrypt();
         public abstract FileSecurity GetAccessControl();
         public abstract FileSecurity GetAccessControl(AccessControlSections includeSections);
+        public abstract FileVersionInfoBase GetVersion();
         public abstract void MoveTo(string destFileName);
         public abstract Stream Open(FileMode mode);
         public abstract Stream Open(FileMode mode, FileAccess access);

--- a/System.IO.Abstractions/FileInfoWrapper.cs
+++ b/System.IO.Abstractions/FileInfoWrapper.cs
@@ -1,4 +1,5 @@
-﻿using System.Security.AccessControl;
+﻿using System.Diagnostics;
+using System.Security.AccessControl;
 
 namespace System.IO.Abstractions
 {
@@ -182,6 +183,11 @@ namespace System.IO.Abstractions
         public override void SetAccessControl(FileSecurity fileSecurity)
         {
             instance.SetAccessControl(fileSecurity);
+        }
+
+        public override FileVersionInfoBase GetVersion()
+        {
+            return FileVersionInfo.GetVersionInfo(FullName);
         }
 
         public override DirectoryInfoBase Directory

--- a/System.IO.Abstractions/FileVersionInfoBase.cs
+++ b/System.IO.Abstractions/FileVersionInfoBase.cs
@@ -1,0 +1,89 @@
+﻿namespace System.IO.Abstractions
+{
+    using System.Diagnostics;
+
+    /// <summary>
+    /// Abstraction around System.Diagnostics.FileVersionInfo.
+    ///
+    /// You can get the File Version Info from the normal File Info of the IFileSystem:
+    ///   filesystem.FileInfo.FromFileName(path).GetVersion();
+    /// 
+    /// When testing, MockFileData's VersionInfo property is a MockFileVersionInfo, which
+    /// allows setting the various properties as desired:
+    ///   mockFileSystem.AddFile(@"c:\file.dll", new MockFileData("content")
+    ///   {
+    ///       VersionInfo = new MockFileVersionInfo
+    ///       {
+    ///           FileMajorPart = 93,
+    ///           FileMinorPart = 10,
+    ///       },
+    ///   });
+    /// </summary>
+    [Serializable]
+    public abstract class FileVersionInfoBase
+    {
+        public static implicit operator FileVersionInfoBase(FileVersionInfo instance)
+        {
+            if (instance == null)
+            {
+                throw new ArgumentNullException("instance");
+            }
+
+            return new FileVersionInfoWrapper(instance);
+        }
+
+        public abstract bool IsPrivateBuild { get; }
+
+        public abstract int ProductPrivatePart { get; }
+
+        public abstract string ProductName { get; }
+
+        public abstract int ProductMinorPart { get; }
+
+        public abstract int ProductMajorPart { get; }
+
+        public abstract int ProductBuildPart { get; }
+
+        public abstract string PrivateBuild { get; }
+
+        public abstract string OriginalFilename { get; }
+
+        public abstract string LegalTrademarks { get; }
+
+        public abstract string LegalCopyright { get; }
+
+        public abstract string Language { get; }
+
+        public abstract bool IsSpecialBuild { get; }
+
+        public abstract bool IsPreRelease { get; }
+
+        public abstract string ProductVersion { get; }
+
+        public abstract string SpecialBuild { get; }
+
+        public abstract bool IsDebug { get; }
+
+        public abstract string InternalName { get; }
+
+        public abstract string FileVersion { get; }
+
+        public abstract int FilePrivatePart { get; }
+
+        public abstract string FileName { get; }
+
+        public abstract int FileMinorPart { get; }
+
+        public abstract int FileMajorPart { get; }
+
+        public abstract string FileDescription { get; }
+
+        public abstract int FileBuildPart { get; }
+
+        public abstract string CompanyName { get; }
+
+        public abstract string Comments { get; }
+
+        public abstract bool IsPatched { get; }
+    }
+}

--- a/System.IO.Abstractions/FileVersionInfoWrapper.cs
+++ b/System.IO.Abstractions/FileVersionInfoWrapper.cs
@@ -1,0 +1,149 @@
+﻿namespace System.IO.Abstractions
+{
+    using System.Diagnostics;
+
+    internal class FileVersionInfoWrapper : FileVersionInfoBase
+    {
+        private FileVersionInfo versionInfo;
+
+        public FileVersionInfoWrapper(FileVersionInfo versionInfo)
+        {
+            this.versionInfo = versionInfo;
+        }
+
+        public override bool IsPrivateBuild
+        {
+            get { return versionInfo.IsPrivateBuild; }
+        }
+
+        public override int ProductPrivatePart
+        {
+            get { return versionInfo.ProductPrivatePart; }
+        }
+
+        public override string ProductName
+        {
+            get { return versionInfo.ProductName; }
+        }
+
+        public override int ProductMinorPart
+        {
+            get { return versionInfo.ProductMinorPart; }
+        }
+
+        public override int ProductMajorPart
+        {
+            get { return versionInfo.ProductMajorPart; }
+        }
+
+        public override int ProductBuildPart
+        {
+            get { return versionInfo.ProductBuildPart; }
+        }
+
+        public override string PrivateBuild
+        {
+            get { return versionInfo.PrivateBuild; }
+        }
+
+        public override string OriginalFilename
+        {
+            get { return versionInfo.OriginalFilename; }
+        }
+
+        public override string LegalTrademarks
+        {
+            get { return versionInfo.LegalTrademarks; }
+        }
+
+        public override string LegalCopyright
+        {
+            get { return versionInfo.LegalCopyright; }
+        }
+
+        public override string Language
+        {
+            get { return versionInfo.Language; }
+        }
+
+        public override bool IsSpecialBuild
+        {
+            get { return versionInfo.IsSpecialBuild; }
+        }
+
+        public override bool IsPreRelease
+        {
+            get { return versionInfo.IsPreRelease; }
+        }
+
+        public override string ProductVersion
+        {
+            get { return versionInfo.ProductVersion; }
+        }
+
+        public override string SpecialBuild
+        {
+            get { return versionInfo.SpecialBuild; }
+        }
+
+        public override bool IsDebug
+        {
+            get { return versionInfo.IsDebug; }
+        }
+
+        public override string InternalName
+        {
+            get { return versionInfo.InternalName; }
+        }
+
+        public override string FileVersion
+        {
+            get { return versionInfo.FileVersion; }
+        }
+
+        public override int FilePrivatePart
+        {
+            get { return versionInfo.FilePrivatePart; }
+        }
+
+        public override string FileName
+        {
+            get { return versionInfo.FileName; }
+        }
+
+        public override int FileMinorPart
+        {
+            get { return versionInfo.FileMinorPart; }
+        }
+
+        public override int FileMajorPart
+        {
+            get { return versionInfo.FileMajorPart; }
+        }
+
+        public override string FileDescription
+        {
+            get { return versionInfo.FileDescription; }
+        }
+
+        public override int FileBuildPart
+        {
+            get { return versionInfo.FileBuildPart; }
+        }
+
+        public override string CompanyName
+        {
+            get { return versionInfo.CompanyName; }
+        }
+
+        public override string Comments
+        {
+            get { return versionInfo.Comments; }
+        }
+
+        public override bool IsPatched
+        {
+            get { return versionInfo.IsPatched; }
+        }
+    }
+}

--- a/System.IO.Abstractions/System.IO.Abstractions.csproj
+++ b/System.IO.Abstractions/System.IO.Abstractions.csproj
@@ -83,6 +83,8 @@
     <Compile Include="FileSystemInfoBase.cs" />
     <Compile Include="FileSystemWatcherBase.cs" />
     <Compile Include="FileSystemWatcherWrapper.cs" />
+    <Compile Include="FileVersionInfoBase.cs" />
+    <Compile Include="FileVersionInfoWrapper.cs" />
     <Compile Include="FileWrapper.cs" />
     <Compile Include="FileBase.cs" />
     <Compile Include="IDirectoryInfoFactory.cs" />

--- a/TestHelpers.Tests/MockFileGetVersionInfoTests.cs
+++ b/TestHelpers.Tests/MockFileGetVersionInfoTests.cs
@@ -1,0 +1,54 @@
+﻿namespace System.IO.Abstractions.TestingHelpers.Tests
+{
+    using System.Diagnostics;
+    using System.Reflection;
+    using NUnit.Framework;
+
+    internal class MockFileGetVersionInfoTests
+    {
+        [Test]
+        public void MockFileVersionInfo_ToString_ShouldReturnMajorMinorBuildPrivate()
+        {
+            var version = new MockFileVersionInfo { FileMajorPart = 1, FileMinorPart = 2, FileBuildPart = 3, FilePrivatePart = 4 };
+            Assert.AreEqual("1.2.3.4", version.FileVersion);
+        }
+
+        [Test]
+        public void MockFileInfo_VersionInfo_ShouldBeAbleToSetMockVersionInfo()
+        {
+            var version = new MockFileVersionInfo { ProductName = "Testing MockFileVersionInfo" };
+            var fileData = new MockFileData("Demo text content") { VersionInfo = version };
+            Assert.AreSame(fileData.VersionInfo, version);
+        }
+
+        [Test]
+        public void MockFileInfo_VersionInfo_ShouldReadFromDll()
+        {
+            var fs = new FileSystem();
+            var path = Assembly.GetExecutingAssembly().Location;
+            var abstractInfo = fs.FileInfo.FromFileName(path);
+            var realVersionInfo = FileVersionInfo.GetVersionInfo(path);
+            Assert.AreEqual(realVersionInfo.FileVersion, abstractInfo.GetVersion().FileVersion);
+        }
+
+        [Test]
+        public void MockFileVersionInfo_CanBeCastFromFileVersionInfo()
+        {
+            var path = Assembly.GetExecutingAssembly().Location;
+            FileVersionInfoBase abstractInfo = FileVersionInfo.GetVersionInfo(path);
+            Assert.NotNull(abstractInfo);
+        }
+
+        [Test]
+        public void FileInfoVersionWrapper_ConstructedWithNull_ShouldThrow()
+        {
+            TestDelegate wrapped = () => 
+            {
+                FileVersionInfoBase abstraction = (FileVersionInfo)null;
+            };
+
+            var exception = Assert.Throws<ArgumentNullException>(wrapped);
+            Assert.AreEqual("instance", exception.ParamName);
+        }
+    }
+}

--- a/TestHelpers.Tests/MockFileInfoTests.cs
+++ b/TestHelpers.Tests/MockFileInfoTests.cs
@@ -372,6 +372,20 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
+        public void MockFileSystem_VersionInfo_ShouldReturnVersionInfoOfFileInMemory()
+        {
+            var version = new MockFileVersionInfo { ProductName = "Testing MockFileVersionInfo" };
+            var fileData = new MockFileData("Demo text content") { VersionInfo = version };
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\a.txt"), fileData }
+            });
+
+            var actual = fileSystem.FileInfo.FromFileName(@"c:\a.txt").GetVersion();
+            Assert.AreSame(version, actual);
+        }
+
+        [Test]
         public void MockFileInfo_GetExtension_ShouldReturnExtension()
         {
             // Arrange

--- a/TestHelpers.Tests/TestHelpers.Tests.csproj
+++ b/TestHelpers.Tests/TestHelpers.Tests.csproj
@@ -99,6 +99,7 @@
     <Compile Include="MockFileGetLastAccessTimeTests.cs" />
     <Compile Include="MockFileGetCreationTimeUtcTests.cs" />
     <Compile Include="MockFileGetCreationTimeTests.cs" />
+    <Compile Include="MockFileGetVersionInfoTests.cs" />
     <Compile Include="MockFileInfoFactoryTests.cs" />
     <Compile Include="MockFileInfoTests.cs" />
     <Compile Include="MockFileMoveTests.cs" />

--- a/TestingHelpers/MockFileData.cs
+++ b/TestingHelpers/MockFileData.cs
@@ -184,5 +184,7 @@ namespace System.IO.Abstractions.TestingHelpers
             get { return accessControl; }
             set { accessControl = value; }
         }
+
+        public MockFileVersionInfo VersionInfo { get; internal set; }
     }
 }

--- a/TestingHelpers/MockFileInfo.cs
+++ b/TestingHelpers/MockFileInfo.cs
@@ -260,6 +260,11 @@ namespace System.IO.Abstractions.TestingHelpers
             throw new NotImplementedException(Properties.Resources.NOT_IMPLEMENTED_EXCEPTION);
         }
 
+        public override FileVersionInfoBase GetVersion()
+        {
+            return MockFileData.VersionInfo;
+        }
+
         public override DirectoryInfoBase Directory
         {
             get

--- a/TestingHelpers/MockFileVersionInfo.cs
+++ b/TestingHelpers/MockFileVersionInfo.cs
@@ -1,0 +1,193 @@
+﻿namespace System.IO.Abstractions.TestingHelpers
+{
+    [Serializable]
+    public class MockFileVersionInfo : MockFileVersionInfoMutableAdapter
+    {
+        public override bool IsPrivateBuild_
+        {
+            get { return IsPrivateBuild; }
+        }
+
+        public new bool IsPrivateBuild { get; set; }
+
+        public override int ProductPrivatePart_
+        {
+            get { return ProductPrivatePart; }
+        }
+
+        public new int ProductPrivatePart { get; set; }
+
+        public override string ProductName_
+        {
+            get { return ProductName; }
+        }
+
+        public new string ProductName { get; set; }
+
+        public override int ProductMinorPart_
+        {
+            get { return ProductMinorPart; }
+        }
+
+        public new int ProductMinorPart { get; set; }
+
+        public override int ProductMajorPart_
+        {
+            get { return ProductMajorPart; }
+        }
+
+        public new int ProductMajorPart { get; set; }
+
+        public override int ProductBuildPart_
+        {
+            get { return ProductBuildPart; }
+        }
+
+        public new int ProductBuildPart { get; set; }
+
+        public override string PrivateBuild_
+        {
+            get { return PrivateBuild; }
+        }
+
+        public new string PrivateBuild { get; set; }
+
+        public override string OriginalFilename_
+        {
+            get { return OriginalFilename; }
+        }
+
+        public new string OriginalFilename { get; set; }
+
+        public override string LegalTrademarks_
+        {
+            get { return LegalTrademarks; }
+        }
+
+        public new string LegalTrademarks { get; set; }
+
+        public override string LegalCopyright_
+        {
+            get { return LegalCopyright; }
+        }
+
+        public new string LegalCopyright { get; set; }
+
+        public override string Language_
+        {
+            get { return Language; }
+        }
+
+        public new string Language { get; set; }
+
+        public override bool IsSpecialBuild_
+        {
+            get { return IsSpecialBuild; }
+        }
+
+        public new bool IsSpecialBuild { get; set; }
+
+        public override bool IsPreRelease_
+        {
+            get { return IsPreRelease; }
+        }
+
+        public new bool IsPreRelease { get; set; }
+
+        public override string ProductVersion_
+        {
+            get { return ProductVersion; }
+        }
+
+        public new string ProductVersion { get; set; }
+
+        public override string SpecialBuild_
+        {
+            get { return SpecialBuild; }
+        }
+
+        public new string SpecialBuild { get; set; }
+
+        public override bool IsDebug_
+        {
+            get { return IsDebug; }
+        }
+
+        public new bool IsDebug { get; set; }
+
+        public override string InternalName_
+        {
+            get { return InternalName; }
+        }
+
+        public new string InternalName { get; set; }
+
+        public override string FileVersion
+        {
+            get { return string.Format("{0}.{1}.{2}.{3}", FileMajorPart, FileMinorPart, FileBuildPart, FilePrivatePart); }
+        }
+
+        public override int FilePrivatePart_
+        {
+            get { return FilePrivatePart; }
+        }
+
+        public new int FilePrivatePart { get; set; }
+
+        public override string FileName_
+        {
+            get { return FileName; }
+        }
+
+        public new string FileName { get; set; }
+
+        public override int FileMinorPart_
+        {
+            get { return FileMinorPart; }
+        }
+
+        public new int FileMinorPart { get; set; }
+
+        public override int FileMajorPart_
+        {
+            get { return FileMajorPart; }
+        }
+
+        public new int FileMajorPart { get; set; }
+
+        public override string FileDescription_
+        {
+            get { return FileDescription; }
+        }
+
+        public new string FileDescription { get; set; }
+
+        public override int FileBuildPart_
+        {
+            get { return FileBuildPart; }
+        }
+
+        public new int FileBuildPart { get; set; }
+
+        public override string CompanyName_
+        {
+            get { return CompanyName; }
+        }
+
+        public new string CompanyName { get; set; }
+
+        public override string Comments_
+        {
+            get { return Comments; }
+        }
+
+        public new string Comments { get; set; }
+
+        public override bool IsPatched_
+        {
+            get { return IsPatched; }
+        }
+
+        public new bool IsPatched { get; set; }
+    }
+}

--- a/TestingHelpers/MockFileVersionInfoMutableAdapter.cs
+++ b/TestingHelpers/MockFileVersionInfoMutableAdapter.cs
@@ -1,0 +1,212 @@
+﻿namespace System.IO.Abstractions.TestingHelpers
+{
+    using System.IO.Abstractions;
+
+    // The underlying FileVersionInfo class is immutable which means that our
+    // abstraction should be immutable as well.  If we use an abstract class
+    // to model the basic structure, we have to define properties as
+    // get-only:
+    //   public abstract int FileMajorVersion { get; }
+    //
+    // Because these are abstract definitions it becomes messy to implement the
+    // Mock class that allows these fields to be publicly settable.  We either
+    // have to insert a Writeable class in between the abstract base and  the
+    // concrete Mock, solely to shadow the get-only properties of the base and
+    // allow get-set versions in the mock.  Or have a set of SetX methods that
+    // provide mutation of the property backers.
+    //
+    // Modelling the abstraction using an interface would alleviate this,
+    // however it would break the existing semantics of implicit conversion
+    // between System.Diagnostics.FileVersionInfo and
+    // System.IO.Abstractions.FileVersionInfoBase.
+    //
+    // As libraries should hide the ugly stuff from clients, it is better to
+    // have this mutable adapter class that shadows the get-only properties and
+    // allows MockFileVersionInfo to look like it simply adds setters to the
+    // abstract base.
+    [Serializable]
+    public abstract class MockFileVersionInfoMutableAdapter : FileVersionInfoBase
+    {
+        public abstract bool IsPrivateBuild_ { get; }
+
+        public sealed override bool IsPrivateBuild
+        {
+            get { return IsPrivateBuild_; }
+        }
+
+        public abstract int ProductPrivatePart_ { get; }
+
+        public sealed override int ProductPrivatePart
+        {
+            get { return ProductPrivatePart_; }
+        }
+
+        public abstract string ProductName_ { get; }
+
+        public sealed override string ProductName
+        {
+            get { return ProductName_; }
+        }
+
+        public abstract int ProductMinorPart_ { get; }
+
+        public sealed override int ProductMinorPart
+        {
+            get { return ProductMinorPart_; }
+        }
+
+        public abstract int ProductMajorPart_ { get; }
+
+        public sealed override int ProductMajorPart
+        {
+            get { return ProductMajorPart_; }
+        }
+
+        public abstract int ProductBuildPart_ { get; }
+
+        public sealed override int ProductBuildPart
+        {
+            get { return ProductBuildPart_; }
+        }
+
+        public abstract string PrivateBuild_ { get; }
+
+        public sealed override string PrivateBuild
+        {
+            get { return PrivateBuild_; }
+        }
+
+        public abstract string OriginalFilename_ { get; }
+
+        public sealed override string OriginalFilename
+        {
+            get { return OriginalFilename_; }
+        }
+
+        public abstract string LegalTrademarks_ { get; }
+
+        public sealed override string LegalTrademarks
+        {
+            get { return LegalTrademarks_; }
+        }
+
+        public abstract string LegalCopyright_ { get; }
+
+        public sealed override string LegalCopyright
+        {
+            get { return LegalCopyright_; }
+        }
+
+        public abstract string Language_ { get; }
+
+        public sealed override string Language
+        {
+            get { return Language_; }
+        }
+
+        public abstract bool IsSpecialBuild_ { get; }
+
+        public sealed override bool IsSpecialBuild
+        {
+            get { return IsSpecialBuild_; }
+        }
+
+        public abstract bool IsPreRelease_ { get; }
+
+        public sealed override bool IsPreRelease
+        {
+            get { return IsPreRelease_; }
+        }
+
+        public abstract string ProductVersion_ { get; }
+
+        public sealed override string ProductVersion
+        {
+            get { return ProductVersion_; }
+        }
+
+        public abstract string SpecialBuild_ { get; }
+
+        public sealed override string SpecialBuild
+        {
+            get { return SpecialBuild_; }
+        }
+
+        public abstract bool IsDebug_ { get; }
+
+        public sealed override bool IsDebug
+        {
+            get { return IsDebug_; }
+        }
+
+        public abstract string InternalName_ { get; }
+
+        public sealed override string InternalName
+        {
+            get { return InternalName_; }
+        }
+
+        public abstract int FilePrivatePart_ { get; }
+
+        public sealed override int FilePrivatePart
+        {
+            get { return FilePrivatePart_; }
+        }
+
+        public abstract string FileName_ { get; }
+
+        public sealed override string FileName
+        {
+            get { return FileName_; }
+        }
+
+        public abstract int FileMinorPart_ { get; }
+
+        public sealed override int FileMinorPart
+        {
+            get { return FileMinorPart_; }
+        }
+
+        public abstract int FileMajorPart_ { get; }
+
+        public sealed override int FileMajorPart
+        {
+            get { return FileMajorPart_; }
+        }
+
+        public abstract string FileDescription_ { get; }
+
+        public sealed override string FileDescription
+        {
+            get { return FileDescription_; }
+        }
+
+        public abstract int FileBuildPart_ { get; }
+
+        public sealed override int FileBuildPart
+        {
+            get { return FileBuildPart_; }
+        }
+
+        public abstract string CompanyName_ { get; }
+
+        public sealed override string CompanyName
+        {
+            get { return CompanyName_; }
+        }
+
+        public abstract string Comments_ { get; }
+
+        public sealed override string Comments
+        {
+            get { return Comments_; }
+        }
+
+        public abstract bool IsPatched_ { get; }
+
+        public override sealed bool IsPatched
+        {
+            get { return IsPatched_; }
+        }
+    }
+}

--- a/TestingHelpers/TestingHelpers.csproj
+++ b/TestingHelpers/TestingHelpers.csproj
@@ -77,6 +77,8 @@
     <Compile Include="MockFileInfoFactory.cs" />
     <Compile Include="MockFileStream.cs" />
     <Compile Include="MockFileSystem.cs" />
+    <Compile Include="MockFileVersionInfo.cs" />
+    <Compile Include="MockFileVersionInfoMutableAdapter.cs" />
     <Compile Include="MockPath.cs" />
     <Compile Include="PathVerifier.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
`System.Diagnostics.FileVersionInfo` can only be created by its static
`GetVersionInfo()` method, so is an ideal candidate for an abstraction.

This commit adds `GetVersion()` to `IFileInfoFactory` so that it is possible
to call
`  var version = filesystem.FileInfo.FromFileName(path).GetVersion();
`

All properties of the new `FileVersionInfoBase `class are read-only as
`System.Diagnostics.FileVersionInfo` is immutable.  `MockFileVersionInfo`,
however, allows all the properties to be set.