### PR TITLE
MockDirectory.Enumerate can search relative to current directory

### DIFF
--- a/TestHelpers.Tests/MockDirectoryTests.cs
+++ b/TestHelpers.Tests/MockDirectoryTests.cs
@@ -1335,6 +1335,57 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
+        public void MockDirectory_EnumerateFiles_WhenFilterIsUnRooted_ShouldFindFilesInCurrentDirectory()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\a.txt"), MockFileData.NullObject },
+                { XFS.Path(@"c:\a\a.txt"), MockFileData.NullObject },
+                { XFS.Path(@"c:\a\b\b.txt"), MockFileData.NullObject },
+                { XFS.Path(@"c:\a\c\c.txt"), MockFileData.NullObject },
+            });
+
+            var expected = new[]
+            {
+                XFS.Path(@"c:\a\b\b.txt"),
+            };
+
+            fileSystem.Directory.SetCurrentDirectory(XFS.Path(@"c:\a"));
+
+            // Act
+            var result = fileSystem.Directory.EnumerateFiles(XFS.Path("b"));
+
+            // Assert
+            Assert.That(result, Is.EquivalentTo(expected));
+        }
+
+        [Test]
+        public void MockDirectory_EnumerateFiles_WhenFilterIsUnRooted_ShouldNotFindFilesInPathOutsideCurrentDirectory()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\a.txt"), MockFileData.NullObject },
+                { XFS.Path(@"c:\a\b\b.txt"), MockFileData.NullObject },
+                { XFS.Path(@"c:\c\b\b.txt"), MockFileData.NullObject },
+            });
+
+            var expected = new[]
+            {
+                XFS.Path(@"c:\a\b\b.txt"),
+            };
+
+            fileSystem.Directory.SetCurrentDirectory(XFS.Path(@"c:\a"));
+
+            // Act
+            var result = fileSystem.Directory.EnumerateFiles(XFS.Path("b"));
+
+            // Assert
+            Assert.That(result, Is.EquivalentTo(expected));
+        }
+
+        [Test]
         public void MockDirectory_EnumerateFileSystemEntries_ShouldReturnAllFilesBelowPathWhenPatternIsWildcardAndSearchOptionIsAllDirectories()
         {
             // Arrange

--- a/TestingHelpers/MockDirectory.cs
+++ b/TestingHelpers/MockDirectory.cs
@@ -186,6 +186,7 @@ namespace System.IO.Abstractions.TestingHelpers
         {
             CheckSearchPattern(searchPattern);
             path = EnsurePathEndsWithDirectorySeparator(path);
+            path = EnsureAbsolutePath(path);
 
             bool isUnix = XFS.IsUnixPlatform();
 
@@ -496,6 +497,13 @@ namespace System.IO.Abstractions.TestingHelpers
             if (!path.EndsWith(string.Format(CultureInfo.InvariantCulture, "{0}", Path.DirectorySeparatorChar), StringComparison.OrdinalIgnoreCase))
                 path += Path.DirectorySeparatorChar;
             return path;
+        }
+
+        private string EnsureAbsolutePath(string path)
+        {
+            return Path.IsPathRooted(path)
+                ? path
+                : Path.Combine(GetCurrentDirectory(), path);
         }
 
         static void CheckSearchPattern(string searchPattern)


### PR DESCRIPTION
Fix for #264: `System.IO.Directory.Enumerate*` will find files matching the search path inside the current directory, when the search path is not rooted.  This commit makes `MockDirectory.Enumerate*` emulate that same behaviour.