### PR TITLE
TestingHelpers: Lazily create File|DirectorySecurity for better suppo…

### DIFF
--- a/TestingHelpers/MockDirectory.cs
+++ b/TestingHelpers/MockDirectory.cs
@@ -32,7 +32,7 @@ namespace System.IO.Abstractions.TestingHelpers
 
         public override DirectoryInfoBase CreateDirectory(string path)
         {
-            return CreateDirectoryInternal(path, new DirectorySecurity());
+            return CreateDirectoryInternal(path, null);
         }
 
 #if NET40
@@ -61,7 +61,10 @@ namespace System.IO.Abstractions.TestingHelpers
             }
 
             var created = new MockDirectoryInfo(mockFileDataAccessor, path);
-            created.SetAccessControl(directorySecurity);
+            if(directorySecurity != null)
+            {
+                created.SetAccessControl(directorySecurity);
+            }
             return created;
         }
 

--- a/TestingHelpers/MockDirectoryData.cs
+++ b/TestingHelpers/MockDirectoryData.cs
@@ -5,8 +5,8 @@ namespace System.IO.Abstractions.TestingHelpers
     [Serializable]
     public class MockDirectoryData : MockFileData
     {
-        [NonSerialized]
-        private DirectorySecurity accessControl = new DirectorySecurity();
+        [NonSerialized] 
+        private DirectorySecurity accessControl;
         
         public override bool IsDirectory { get { return true; } }
 
@@ -17,7 +17,7 @@ namespace System.IO.Abstractions.TestingHelpers
         
         public new DirectorySecurity AccessControl
         {
-            get { return accessControl; }
+            get { return accessControl ?? (accessControl = new DirectorySecurity()); }
             set { accessControl = value; }
         }
     }

--- a/TestingHelpers/MockFileData.cs
+++ b/TestingHelpers/MockFileData.cs
@@ -60,7 +60,7 @@ namespace System.IO.Abstractions.TestingHelpers
         /// The access control of the <see cref="MockFileData"/>.
         /// </summary>
         [NonSerialized]
-        private FileSecurity accessControl = new FileSecurity();
+        private FileSecurity accessControl;
 
         /// <summary>
         /// Gets a value indicating whether the <see cref="MockFileData"/> is a directory or not.
@@ -181,7 +181,7 @@ namespace System.IO.Abstractions.TestingHelpers
         /// </summary>
         public FileSecurity AccessControl
         {
-            get { return accessControl; }
+            get { return accessControl ?? (accessControl = new FileSecurity()); }
             set { accessControl = value; }
         }
     }

--- a/TestingHelpers/TestingHelpers.csproj
+++ b/TestingHelpers/TestingHelpers.csproj
@@ -23,10 +23,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.1.2-alpha" />
-    </ItemGroup>
-
-    <ItemGroup>
         <ProjectReference Include="..\System.IO.Abstractions\System.IO.Abstractions.csproj" />
     </ItemGroup>
 

--- a/TestingHelpers/TestingHelpers.csproj
+++ b/TestingHelpers/TestingHelpers.csproj
@@ -23,6 +23,10 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.1.2-alpha" />
+    </ItemGroup>
+
+    <ItemGroup>
         <ProjectReference Include="..\System.IO.Abstractions\System.IO.Abstractions.csproj" />
     </ItemGroup>
 


### PR DESCRIPTION
…rt on non-Windows OSes

Both FileSecurity and DirectorySecurity are not supported on non-Windows OSes and will throw PlatformNotSupportedException when called. MockDirectoryData & FileDirectoryData create instances of them when they are created. This makes them unusable on non-Windows OSes even if the actual *Security functionality is not used.

This change delays their creation to the point where they are actually necessary. That makes them usable again as long as *Security functioanlity is not used.

Fixes #272