### PR TITLE
Add support for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: csharp
 mono: none
 dotnet: 2.1.4
-install:
-  - dotnet restore
 script:
-  - dotnet build
-  - dotnet test
+  - dotnet build System.IO.Abstractions --framework netstandard1.4
+  - dotnet build TestingHelpers --framework netstandard1.4
+  - dotnet test TestHelpers.Tests --framework netcoreapp2.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: csharp
+solution: System.IO.Abstractions.sln
+install:
+  - dotnet restore
+script:
+  - dotnet build
+  - dotnet test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: csharp
-solution: System.IO.Abstractions.sln
+mono: none
+dotnet: 2.1.4
 install:
   - dotnet restore
 script:

--- a/TestHelpers.Tests/MockDirectoryTests.cs
+++ b/TestHelpers.Tests/MockDirectoryTests.cs
@@ -784,10 +784,10 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             Assert.That(actualResult, Is.EquivalentTo(new [] { testPath }));
         }
 
-        [TestCase(@"""")]
 #if NET40
-        [TestCase("aa\t")]
+        [TestCase(@"""")]
 #endif
+        [TestCase("aa\t")]
         public void MockDirectory_GetFiles_ShouldThrowAnArgumentException_IfSearchPatternHasIllegalCharacters(string searchPattern)
         {
             // Arrange

--- a/TestHelpers.Tests/MockDirectoryTests.cs
+++ b/TestHelpers.Tests/MockDirectoryTests.cs
@@ -785,7 +785,9 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [TestCase(@"""")]
+#if NET40
         [TestCase("aa\t")]
+#endif
         public void MockDirectory_GetFiles_ShouldThrowAnArgumentException_IfSearchPatternHasIllegalCharacters(string searchPattern)
         {
             // Arrange

--- a/TestHelpers.Tests/MockFileWriteAllBytesTests.cs
+++ b/TestHelpers.Tests/MockFileWriteAllBytesTests.cs
@@ -58,7 +58,9 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             Assert.Throws<UnauthorizedAccessException>(action, "Access to the path '{0}' is denied.", path);
         }
 
+#if NET40
         [Test]
+#endif
         public void MockFile_WriteAllBytes_ShouldThrowAnArgumentExceptionIfContainsIllegalCharacters()
         {
             // Arrange

--- a/TestHelpers.Tests/TestHelpers.Tests.csproj
+++ b/TestHelpers.Tests/TestHelpers.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net40</TargetFrameworks>
+    <TargetFrameworks>net40;netcoreapp2.0</TargetFrameworks>
     <Version>0.0.0.1</Version>
     <Description>The unit tests for our pre-built mocks</Description>
     <Company />
@@ -39,6 +39,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" 
+                      Version="15.0.0"
+                      Condition="'$(TargetFramework)' != 'net40'" />
     <PackageReference Include="nunit" Version="3.8.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
   </ItemGroup>

--- a/TestingHelpers/MockFileSystem.cs
+++ b/TestingHelpers/MockFileSystem.cs
@@ -256,7 +256,7 @@ namespace System.IO.Abstractions.TestingHelpers
         {
             get
             {
-                lock (file)
+                lock (files)
                     return files.Where(f => !f.Value.IsDirectory).Select(f => f.Key).ToArray();
             }
         }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,4 @@
-image:
-- Visual Studio 2017
-- Ubuntu
+image: Visual Studio 2017
 
 configuration: Release
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,7 @@
-image: Visual Studio 2017
+image:
+- Visual Studio 2017
+- Ubuntu
+
 configuration: Release
 
 skip_branch_with_pr: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ dotnet_csproj:
   package_version: '{version}'
 
 before_build:
-- nuget restore
+- cmd: nuget restore
 
 build:
   publish_nuget: true


### PR DESCRIPTION
This adds support for running tests on Travis CI (on Unix-based systems). 

To make the tests runnable on Unix I added a .NET Core 2.0 target to the test project (the existing .NET Framework 4.0 target and the other projects are unchanged).