### PR TITLE
Remove all refs to System.Security.AccessControl from netstandard1.4 version

### DIFF
--- a/System.IO.Abstractions/DirectoryBase.cs
+++ b/System.IO.Abstractions/DirectoryBase.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Generic;
+#if NET40
 using System.Security.AccessControl;
+#endif
 
 namespace System.IO.Abstractions
 {
@@ -13,8 +15,10 @@ namespace System.IO.Abstractions
         public abstract void Delete(string path);
         public abstract void Delete(string path, bool recursive);
         public abstract bool Exists(string path);
+#if NET40
         public abstract DirectorySecurity GetAccessControl(string path);
         public abstract DirectorySecurity GetAccessControl(string path, AccessControlSections includeSections);
+#endif
         public abstract DateTime GetCreationTime(string path);
         public abstract DateTime GetCreationTimeUtc(string path);
         public abstract string GetCurrentDirectory();
@@ -36,7 +40,9 @@ namespace System.IO.Abstractions
 #endif
         public abstract DirectoryInfoBase GetParent(string path);
         public abstract void Move(string sourceDirName, string destDirName);
+#if NET40
         public abstract void SetAccessControl(string path, DirectorySecurity directorySecurity);
+#endif
         public abstract void SetCreationTime(string path, DateTime creationTime);
         public abstract void SetCreationTimeUtc(string path, DateTime creationTimeUtc);
         public abstract void SetCurrentDirectory(string path);

--- a/System.IO.Abstractions/DirectoryInfoBase.cs
+++ b/System.IO.Abstractions/DirectoryInfoBase.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Generic;
+#if NET40
 using System.Security.AccessControl;
+#endif
 
 namespace System.IO.Abstractions
 {
@@ -24,8 +26,10 @@ namespace System.IO.Abstractions
         public abstract IEnumerable<FileSystemInfoBase> EnumerateFileSystemInfos();
         public abstract IEnumerable<FileSystemInfoBase> EnumerateFileSystemInfos(string searchPattern);
         public abstract IEnumerable<FileSystemInfoBase> EnumerateFileSystemInfos(string searchPattern, SearchOption searchOption);
+#if NET40
         public abstract DirectorySecurity GetAccessControl();
         public abstract DirectorySecurity GetAccessControl(AccessControlSections includeSections);
+#endif
         public abstract DirectoryInfoBase[] GetDirectories();
         public abstract DirectoryInfoBase[] GetDirectories(string searchPattern);
         public abstract DirectoryInfoBase[] GetDirectories(string searchPattern, SearchOption searchOption);
@@ -36,7 +40,9 @@ namespace System.IO.Abstractions
         public abstract FileSystemInfoBase[] GetFileSystemInfos(string searchPattern);
         public abstract FileSystemInfoBase[] GetFileSystemInfos(string searchPattern, SearchOption searchOption);
         public abstract void MoveTo(string destDirName);
+#if NET40
         public abstract void SetAccessControl(DirectorySecurity directorySecurity);
+#endif
         public abstract DirectoryInfoBase Parent { get; }
         public abstract DirectoryInfoBase Root { get; }
 

--- a/System.IO.Abstractions/DirectoryInfoWrapper.cs
+++ b/System.IO.Abstractions/DirectoryInfoWrapper.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+#if NET40
 using System.Security.AccessControl;
+#endif
 
 namespace System.IO.Abstractions
 {
@@ -165,6 +167,7 @@ namespace System.IO.Abstractions
             return instance.EnumerateFileSystemInfos(searchPattern, searchOption).WrapFileSystemInfos();
         }
 
+#if NET40
         public override DirectorySecurity GetAccessControl()
         {
             return instance.GetAccessControl();
@@ -174,6 +177,7 @@ namespace System.IO.Abstractions
         {
             return instance.GetAccessControl(includeSections);
         }
+#endif
 
         public override DirectoryInfoBase[] GetDirectories()
         {
@@ -225,10 +229,12 @@ namespace System.IO.Abstractions
             instance.MoveTo(destDirName);
         }
 
+#if NET40
         public override void SetAccessControl(DirectorySecurity directorySecurity)
         {
             instance.SetAccessControl(directorySecurity);
         }
+#endif
 
         public override DirectoryInfoBase Parent
         {

--- a/System.IO.Abstractions/DirectoryWrapper.cs
+++ b/System.IO.Abstractions/DirectoryWrapper.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Generic;
+#if NET40
 using System.Security.AccessControl;
+#endif
 
 namespace System.IO.Abstractions
 {
@@ -32,6 +34,7 @@ namespace System.IO.Abstractions
             return Directory.Exists(path);
         }
 
+#if NET40
         public override DirectorySecurity GetAccessControl(string path)
         {
             return new DirectoryInfo(path).GetAccessControl();
@@ -41,6 +44,7 @@ namespace System.IO.Abstractions
         {
             return new DirectoryInfo(path).GetAccessControl(includeSections);
         }
+#endif
 
         public override DateTime GetCreationTime(string path)
         {
@@ -139,10 +143,12 @@ namespace System.IO.Abstractions
             Directory.Move(sourceDirName, destDirName);
         }
 
+#if NET40
         public override void SetAccessControl(string path, DirectorySecurity directorySecurity)
         {
             new DirectoryInfo(path).SetAccessControl(directorySecurity);
         }
+#endif
 
         public override void SetCreationTime(string path, DateTime creationTime)
         {

--- a/System.IO.Abstractions/FileBase.cs
+++ b/System.IO.Abstractions/FileBase.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Generic;
+#if NET40
 using System.Security.AccessControl;
+#endif
 using System.Text;
 
 namespace System.IO.Abstractions
@@ -57,9 +59,10 @@ namespace System.IO.Abstractions
         /// </para>
         /// </remarks>
         public abstract bool Exists(string path);
+#if NET40
         public abstract FileSecurity GetAccessControl(string path);
         public abstract FileSecurity GetAccessControl(string path, AccessControlSections includeSections);
-
+#endif
         /// <summary>
         /// Gets the <see cref="FileAttributes"/> of the file on the path.
         /// </summary>
@@ -229,7 +232,9 @@ namespace System.IO.Abstractions
         public abstract void Replace(string sourceFileName, string destinationFileName, string destinationBackupFileName);
         public abstract void Replace(string sourceFileName, string destinationFileName, string destinationBackupFileName, bool ignoreMetadataErrors);
 #endif
+#if NET40
         public abstract void SetAccessControl(string path, FileSecurity fileSecurity);
+#endif
         public abstract void SetAttributes(string path, FileAttributes fileAttributes);
         public abstract void SetCreationTime(string path, DateTime creationTime);
         public abstract void SetCreationTimeUtc(string path, DateTime creationTimeUtc);

--- a/System.IO.Abstractions/FileInfoBase.cs
+++ b/System.IO.Abstractions/FileInfoBase.cs
@@ -1,4 +1,6 @@
-﻿using System.Security.AccessControl;
+﻿#if NET40
+using System.Security.AccessControl;
+#endif
 
 namespace System.IO.Abstractions
 {
@@ -13,9 +15,10 @@ namespace System.IO.Abstractions
 #if NET40
         public abstract void Decrypt();
         public abstract void Encrypt();
-#endif
+
         public abstract FileSecurity GetAccessControl();
         public abstract FileSecurity GetAccessControl(AccessControlSections includeSections);
+#endif
         public abstract void MoveTo(string destFileName);
         public abstract Stream Open(FileMode mode);
         public abstract Stream Open(FileMode mode, FileAccess access);
@@ -26,8 +29,9 @@ namespace System.IO.Abstractions
 #if NET40
         public abstract FileInfoBase Replace(string destinationFileName, string destinationBackupFileName);
         public abstract FileInfoBase Replace(string destinationFileName, string destinationBackupFileName, bool ignoreMetadataErrors);
-#endif
+
         public abstract void SetAccessControl(FileSecurity fileSecurity);
+#endif
         public abstract DirectoryInfoBase Directory { get; }
         public abstract string DirectoryName { get; }
         public abstract bool IsReadOnly { get; set; }

--- a/System.IO.Abstractions/FileInfoWrapper.cs
+++ b/System.IO.Abstractions/FileInfoWrapper.cs
@@ -1,4 +1,6 @@
-﻿using System.Security.AccessControl;
+﻿#if NET40
+using System.Security.AccessControl;
+#endif
 
 namespace System.IO.Abstractions
 {
@@ -126,6 +128,7 @@ namespace System.IO.Abstractions
         }
 #endif
 
+#if NET40
         public override FileSecurity GetAccessControl()
         {
             return instance.GetAccessControl();
@@ -135,7 +138,7 @@ namespace System.IO.Abstractions
         {
             return instance.GetAccessControl(includeSections);
         }
-
+#endif
         public override void MoveTo(string destFileName)
         {
             instance.MoveTo(destFileName);
@@ -183,10 +186,12 @@ namespace System.IO.Abstractions
         }
 #endif
 
+#if NET40
         public override void SetAccessControl(FileSecurity fileSecurity)
         {
             instance.SetAccessControl(fileSecurity);
         }
+#endif
 
         public override DirectoryInfoBase Directory
         {

--- a/System.IO.Abstractions/FileWrapper.cs
+++ b/System.IO.Abstractions/FileWrapper.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Generic;
+#if NET40
 using System.Security.AccessControl;
+#endif
 using System.Text;
 using System.IO;
 
@@ -94,6 +96,7 @@ namespace System.IO.Abstractions
             return File.Exists(path);
         }
 
+        #if NET40
         public override FileSecurity GetAccessControl(string path)
         {
             return new FileInfo(path).GetAccessControl();
@@ -103,6 +106,7 @@ namespace System.IO.Abstractions
         {
             return new FileInfo(path).GetAccessControl(includeSections);
         }
+#endif
 
         /// <summary>
         /// Gets the <see cref="FileAttributes"/> of the file on the path.
@@ -233,10 +237,12 @@ namespace System.IO.Abstractions
         }
 #endif
 
+#if NET40
         public override void SetAccessControl(string path, FileSecurity fileSecurity)
         {
             new FileInfo(path).SetAccessControl(fileSecurity);
         }
+#endif
 
         public override void SetAttributes(string path, FileAttributes fileAttributes)
         {

--- a/System.IO.Abstractions/System.IO.Abstractions.csproj
+++ b/System.IO.Abstractions/System.IO.Abstractions.csproj
@@ -22,9 +22,6 @@
     </PropertyGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.4' ">
-        <PackageReference Include="System.IO.FileSystem.AccessControl">
-            <Version>4.3.0</Version>
-        </PackageReference>
         <PackageReference Include="System.IO.FileSystem.DriveInfo">
             <Version>4.3.0</Version>
         </PackageReference>

--- a/TestHelpers.Tests/TestHelpers.Tests.csproj
+++ b/TestHelpers.Tests/TestHelpers.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net40</TargetFrameworks>
-    <Version>0.0.0.1</Version>
+    <Version>0.0.0.2</Version>
     <Description>The unit tests for our pre-built mocks</Description>
     <Company />
     <Product>System.IO.Abstractions</Product>

--- a/TestingHelpers/MockDirectory.cs
+++ b/TestingHelpers/MockDirectory.cs
@@ -2,7 +2,9 @@
 using System.Globalization;
 using System.IO;
 using System.Linq;
+#if NET40
 using System.Security.AccessControl;
+#endif
 using System.Text.RegularExpressions;
 
 namespace System.IO.Abstractions.TestingHelpers
@@ -30,18 +32,31 @@ namespace System.IO.Abstractions.TestingHelpers
             this.fileBase = fileBase;
         }
 
+
         public override DirectoryInfoBase CreateDirectory(string path)
         {
-            return CreateDirectoryInternal(path, new DirectorySecurity());
+            return CreateDirectoryInternal(path
+#if NET40
+                ,
+                new DirectorySecurity()
+#endif
+                );
         }
 
 #if NET40
-        public override DirectoryInfoBase CreateDirectory(string path, DirectorySecurity directorySecurity)
+        public override DirectoryInfoBase CreateDirectory(string path
+            , DirectorySecurity directorySecurity
+            )
         {
             return CreateDirectoryInternal(path, directorySecurity);
         }
 #endif
-        private DirectoryInfoBase CreateDirectoryInternal(string path, DirectorySecurity directorySecurity)
+        private DirectoryInfoBase CreateDirectoryInternal(string path
+#if NET40
+            ,
+            DirectorySecurity directorySecurity
+#endif
+            )
         {
             if (path == null)
             {
@@ -61,9 +76,12 @@ namespace System.IO.Abstractions.TestingHelpers
             }
 
             var created = new MockDirectoryInfo(mockFileDataAccessor, path);
+#if NET40
             created.SetAccessControl(directorySecurity);
+#endif
             return created;
         }
+
 
         public override void Delete(string path)
         {
@@ -103,6 +121,7 @@ namespace System.IO.Abstractions.TestingHelpers
             }
         }
 
+#if NET40
         public override DirectorySecurity GetAccessControl(string path)
         {           
             mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, "path");
@@ -121,6 +140,7 @@ namespace System.IO.Abstractions.TestingHelpers
         {
             return GetAccessControl(path);
         }
+#endif
 
         public override DateTime GetCreationTime(string path)
         {
@@ -376,6 +396,7 @@ namespace System.IO.Abstractions.TestingHelpers
             Delete(fullSourcePath);
         }
 
+#if NET40
         public override void SetAccessControl(string path, DirectorySecurity directorySecurity)
         {
             mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, "path");
@@ -389,6 +410,7 @@ namespace System.IO.Abstractions.TestingHelpers
             var directoryData = (MockDirectoryData)mockFileDataAccessor.GetFile(path);
             directoryData.AccessControl = directorySecurity;
         }
+#endif
 
         public override void SetCreationTime(string path, DateTime creationTime)
         {

--- a/TestingHelpers/MockDirectoryData.cs
+++ b/TestingHelpers/MockDirectoryData.cs
@@ -1,24 +1,29 @@
-﻿using System.Security.AccessControl;
+﻿#if NET40
+using System.Security.AccessControl;
+#endif
 
 namespace System.IO.Abstractions.TestingHelpers
 {
     [Serializable]
     public class MockDirectoryData : MockFileData
     {
+#if NET40
         [NonSerialized]
+
         private DirectorySecurity accessControl = new DirectorySecurity();
-        
+#endif
         public override bool IsDirectory { get { return true; } }
 
         public MockDirectoryData() : base(string.Empty)
         {
             Attributes = FileAttributes.Directory;
         }
-        
+#if NET40
         public new DirectorySecurity AccessControl
         {
             get { return accessControl; }
             set { accessControl = value; }
         }
+#endif
     }
 }

--- a/TestingHelpers/MockDirectoryInfo.cs
+++ b/TestingHelpers/MockDirectoryInfo.cs
@@ -1,7 +1,9 @@
 ﻿using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+#if NET40
 using System.Security.AccessControl;
+#endif
 
 namespace System.IO.Abstractions.TestingHelpers
 {
@@ -200,15 +202,18 @@ namespace System.IO.Abstractions.TestingHelpers
             return GetFileSystemInfos(searchPattern, searchOption);
         }
 
+#if NET40
         public override DirectorySecurity GetAccessControl()
         {
             return mockFileDataAccessor.Directory.GetAccessControl(directoryPath);
         }
 
+
         public override DirectorySecurity GetAccessControl(AccessControlSections includeSections)
         {
             return mockFileDataAccessor.Directory.GetAccessControl(directoryPath, includeSections);
         }
+#endif
 
         public override DirectoryInfoBase[] GetDirectories()
         {
@@ -275,10 +280,12 @@ namespace System.IO.Abstractions.TestingHelpers
             mockFileDataAccessor.Directory.Move(directoryPath, destDirName);
         }
 
+#if NET40
         public override void SetAccessControl(DirectorySecurity directorySecurity)
         {
             mockFileDataAccessor.Directory.SetAccessControl(directoryPath, directorySecurity);
         }
+#endif
 
         public override DirectoryInfoBase Parent
         {

--- a/TestingHelpers/MockFile.cs
+++ b/TestingHelpers/MockFile.cs
@@ -1,7 +1,9 @@
 ﻿using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+#if NET40
 using System.Security.AccessControl;
+#endif
 using System.Text;
 
 namespace System.IO.Abstractions.TestingHelpers
@@ -197,6 +199,7 @@ namespace System.IO.Abstractions.TestingHelpers
             return mockFileDataAccessor.FileExists(path) && !mockFileDataAccessor.AllDirectories.Any(d => d.Equals(path, StringComparison.OrdinalIgnoreCase));
         }
 
+#if NET40
         public override FileSecurity GetAccessControl(string path)
         {
             mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, "path");
@@ -214,6 +217,7 @@ namespace System.IO.Abstractions.TestingHelpers
         {
             return GetAccessControl(path);
         }
+#endif
 
         /// <summary>
         /// Gets the <see cref="FileAttributes"/> of the file on the path.
@@ -507,6 +511,7 @@ namespace System.IO.Abstractions.TestingHelpers
         }
 #endif
 
+#if NET40
         public override void SetAccessControl(string path, FileSecurity fileSecurity)
         {
             mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, "path");
@@ -519,6 +524,7 @@ namespace System.IO.Abstractions.TestingHelpers
             var fileData = mockFileDataAccessor.GetFile(path);
             fileData.AccessControl = fileSecurity;
         }
+#endif
 
         public override void SetAttributes(string path, FileAttributes fileAttributes)
         {

--- a/TestingHelpers/MockFileData.cs
+++ b/TestingHelpers/MockFileData.cs
@@ -1,5 +1,7 @@
 ﻿using System.Linq;
+#if NET40
 using System.Security.AccessControl;
+#endif
 using System.Text;
 
 namespace System.IO.Abstractions.TestingHelpers
@@ -56,11 +58,13 @@ namespace System.IO.Abstractions.TestingHelpers
         /// </summary>
         private FileAttributes attributes = FileAttributes.Normal;
 
+#if NET40
         /// <summary>
         /// The access control of the <see cref="MockFileData"/>.
         /// </summary>
         [NonSerialized]
         private FileSecurity accessControl = new FileSecurity();
+#endif
 
         /// <summary>
         /// Gets a value indicating whether the <see cref="MockFileData"/> is a directory or not.
@@ -176,6 +180,7 @@ namespace System.IO.Abstractions.TestingHelpers
             set { attributes = value; }
         }
 
+#if NET40
         /// <summary>
         /// Gets or sets <see cref="FileSecurity"/> of the <see cref="MockFileData"/>. This is the object that is returned for this <see cref="MockFileData"/> when calling <see cref="FileBase.GetAccessControl(string)"/>.
         /// </summary>
@@ -184,5 +189,6 @@ namespace System.IO.Abstractions.TestingHelpers
             get { return accessControl; }
             set { accessControl = value; }
         }
+#endif
     }
 }

--- a/TestingHelpers/MockFileInfo.cs
+++ b/TestingHelpers/MockFileInfo.cs
@@ -1,4 +1,6 @@
-﻿using System.Security.AccessControl;
+﻿#if NET40
+using System.Security.AccessControl;
+#endif
 
 namespace System.IO.Abstractions.TestingHelpers
 {
@@ -199,6 +201,7 @@ namespace System.IO.Abstractions.TestingHelpers
         }
 #endif
 
+#if NET40
         public override FileSecurity GetAccessControl()
         {
             throw new NotImplementedException(StringResources.Manager.GetString("NOT_IMPLEMENTED_EXCEPTION"));
@@ -208,6 +211,7 @@ namespace System.IO.Abstractions.TestingHelpers
         {
             throw new NotImplementedException(StringResources.Manager.GetString("NOT_IMPLEMENTED_EXCEPTION"));
         }
+#endif
 
         public override void MoveTo(string destFileName)
         {
@@ -258,11 +262,12 @@ namespace System.IO.Abstractions.TestingHelpers
             throw new NotImplementedException(StringResources.Manager.GetString("NOT_IMPLEMENTED_EXCEPTION"));
         }
 #endif
-
+#if NET40
         public override void SetAccessControl(FileSecurity fileSecurity)
         {
             throw new NotImplementedException(StringResources.Manager.GetString("NOT_IMPLEMENTED_EXCEPTION"));
         }
+#endif
 
         public override DirectoryInfoBase Directory
         {

--- a/TestingHelpers/TestingHelpers.csproj
+++ b/TestingHelpers/TestingHelpers.csproj
@@ -34,6 +34,5 @@
     <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.4'">
         <PackageReference Include="System.Diagnostics.Contracts" Version="4.3.0" />
         <PackageReference Include="System.Runtime.Serialization.Formatters" Version="4.3.0" />
-        <PackageReference Include="System.Security.AccessControl" Version="4.3.0" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
With these changes, this will install in a Xamarin project.

That said, I am not an expert in this area whatsoever. It is possible that I removed the refs from too many environments.