### PR TITLE
Updates the Mock File System to throw DirectoryNotFound if creating a…

### DIFF
--- a/TestHelpers.Tests/MockFileCreateTests.cs
+++ b/TestHelpers.Tests/MockFileCreateTests.cs
@@ -18,6 +18,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         {
             string fullPath = XFS.Path(@"c:\something\demo.txt");
             var fileSystem = new MockFileSystem();
+            fileSystem.AddDirectory(@"c:\something");
 
             var sut = new MockFile(fileSystem);
 
@@ -33,6 +34,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         {
             string fullPath = XFS.Path(@"c:\something\demo.txt");
             var fileSystem = new MockFileSystem();
+            fileSystem.AddDirectory(@"c:\something");
             var data = new UTF8Encoding(false).GetBytes("Test string");
 
             var sut = new MockFile(fileSystem);
@@ -52,6 +54,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         {
             string path = XFS.Path(@"c:\some\file.txt");
             var fileSystem = new MockFileSystem();
+            fileSystem.AddDirectory(@"c:\some");
 
             var mockFile = new MockFile(fileSystem);
 
@@ -145,6 +148,21 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             // Assert
             var exception = Assert.Throws<ArgumentNullException>(action);
             Assert.That(exception.Message, Does.StartWith("Path cannot be null."));
+        }
+
+        [Test]
+        public void MockFile_Create_ShouldThrowDirectoryNotFoundExceptionIfCreatingAndParentPathDoesNotExist()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+
+            // Act
+            TestDelegate action = () => fileSystem.File.Create("C:\\Path\\NotFound.ext");
+
+            // Assert
+            Assert.IsFalse(fileSystem.Directory.Exists("C:\\path"));
+            var exception = Assert.Throws<DirectoryNotFoundException>(action);
+            Assert.That(exception.Message, Does.StartWith("Could not find a part of the path"));
         }
     }
 }

--- a/TestHelpers.Tests/MockFileOpenTests.cs
+++ b/TestHelpers.Tests/MockFileOpenTests.cs
@@ -42,6 +42,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         {
             string filepath = XFS.Path(@"c:\something\doesnt\exist.txt");
             var filesystem = new MockFileSystem(new Dictionary<string, MockFileData>());
+            filesystem.AddDirectory(@"c:\something\doesnt");
 
             var stream = filesystem.File.Open(filepath, FileMode.Create);
 
@@ -55,6 +56,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         {
             string filepath = XFS.Path(@"c:\something\doesnt\exist.txt");
             var filesystem = new MockFileSystem(new Dictionary<string, MockFileData>());
+            filesystem.AddDirectory(@"c:\something\doesnt");
 
             var stream = filesystem.File.Open(filepath, FileMode.CreateNew);
 
@@ -153,6 +155,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         {
             string filepath = XFS.Path(@"c:\something\doesnt\exist.txt");
             var filesystem = new MockFileSystem(new Dictionary<string, MockFileData>());
+            filesystem.AddDirectory(@"c:\something\doesnt");
 
             var stream = filesystem.File.Open(filepath, FileMode.OpenOrCreate);
 
@@ -239,6 +242,21 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             // Assert
             Assert.AreEqual(creationTime, fs.FileInfo.FromFileName(filepath).CreationTime);
+        }
+
+        [Test]
+        public void MockFile_Open_ShouldThrowDirectoryNotFoundExceptionIfFileModeCreateAndParentPathDoesNotExist()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+
+            // Act
+            TestDelegate action = () => fileSystem.File.Open("C:\\Path\\NotFound.ext", FileMode.Create);
+
+            // Assert
+            Assert.IsFalse(fileSystem.Directory.Exists("C:\\path"));
+            var exception = Assert.Throws<DirectoryNotFoundException>(action);
+            Assert.That(exception.Message, Does.StartWith("Could not find a part of the path"));
         }
     }
 }

--- a/TestHelpers.Tests/MockFileTests.cs
+++ b/TestHelpers.Tests/MockFileTests.cs
@@ -540,6 +540,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         {
             string filepath = XFS.Path(@"c:\something\doesnt\exist.txt");
             var filesystem = new MockFileSystem(new Dictionary<string, MockFileData>());
+            filesystem.AddDirectory(@"c:\something\doesnt");
 
             var stream = filesystem.File.AppendText(filepath);
 

--- a/TestingHelpers/MockFile.cs
+++ b/TestingHelpers/MockFile.cs
@@ -141,6 +141,9 @@ namespace System.IO.Abstractions.TestingHelpers
             }
             mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, "path");
 
+            if (!mockFileDataAccessor.Directory.Exists(Path.GetDirectoryName(path)))
+                throw new DirectoryNotFoundException($"Could not find a part of the path '{path}'.");
+
             mockFileDataAccessor.AddFile(path, new MockFileData(new byte[0]));
             var stream = OpenWrite(path);
             return stream;


### PR DESCRIPTION
… file in a directory that does not exist.

When creating a file in a real file system on Windows, if the filename is in a directory that does not exist, a DirectoryNotFoundException would be thrown. This change, causes the MockFile to behave in the same way.

Additionally some other tests had to be updated. These tests did not tell the mock filesystem that the directory existed before attempting the create.