### PR TITLE
Fix runtime issues on non-Windows platforms (notable example is Xamarin)

### DIFF
--- a/TestingHelpers/MockDirectory.cs
+++ b/TestingHelpers/MockDirectory.cs
@@ -32,7 +32,7 @@ namespace System.IO.Abstractions.TestingHelpers
 
         public override DirectoryInfoBase CreateDirectory(string path)
         {
-            return CreateDirectoryInternal(path, new DirectorySecurity());
+            return CreateDirectoryInternal(path, null);
         }
 
 #if NET40
@@ -61,7 +61,11 @@ namespace System.IO.Abstractions.TestingHelpers
             }
 
             var created = new MockDirectoryInfo(mockFileDataAccessor, path);
-            created.SetAccessControl(directorySecurity);
+            if (directorySecurity != null)
+            {
+                created.SetAccessControl(directorySecurity);
+            }
+
             return created;
         }
 

--- a/TestingHelpers/MockDirectoryData.cs
+++ b/TestingHelpers/MockDirectoryData.cs
@@ -6,7 +6,7 @@ namespace System.IO.Abstractions.TestingHelpers
     public class MockDirectoryData : MockFileData
     {
         [NonSerialized]
-        private DirectorySecurity accessControl = new DirectorySecurity();
+        private DirectorySecurity accessControl;
         
         public override bool IsDirectory { get { return true; } }
 
@@ -14,10 +14,15 @@ namespace System.IO.Abstractions.TestingHelpers
         {
             Attributes = FileAttributes.Directory;
         }
-        
+
         public new DirectorySecurity AccessControl
         {
-            get { return accessControl; }
+            get
+            {
+                // DirectorySecurity's constructor will throw PlatformNotSupportedException on non-Windows platform, so we initialize it in lazy way.
+                // This let's us use this class as long as we don't use AccessControl property.
+                return accessControl ?? (accessControl = new DirectorySecurity());
+            }
             set { accessControl = value; }
         }
     }

--- a/TestingHelpers/MockFileData.cs
+++ b/TestingHelpers/MockFileData.cs
@@ -60,7 +60,7 @@ namespace System.IO.Abstractions.TestingHelpers
         /// The access control of the <see cref="MockFileData"/>.
         /// </summary>
         [NonSerialized]
-        private FileSecurity accessControl = new FileSecurity();
+        private FileSecurity accessControl;
 
         /// <summary>
         /// Gets a value indicating whether the <see cref="MockFileData"/> is a directory or not.
@@ -181,7 +181,12 @@ namespace System.IO.Abstractions.TestingHelpers
         /// </summary>
         public FileSecurity AccessControl
         {
-            get { return accessControl; }
+            get
+            {
+                // FileSecurity's constructor will throw PlatformNotSupportedException on non-Windows platform, so we initialize it in lazy way.
+                // This let's us use this class as long as we don't use AccessControl property.
+                return accessControl ?? (accessControl = new FileSecurity());
+            }
             set { accessControl = value; }
         }
     }


### PR DESCRIPTION
Don't use AccessControl's constructor until it is really needed as it throws PlatformNotSupported on non-Windows frameworks (Xamarin, Mono, etc.)