### PR TITLE
Remove stale packages.config

### DIFF
--- a/TestHelpers.Tests/TestHelpers.Tests.csproj
+++ b/TestHelpers.Tests/TestHelpers.Tests.csproj
@@ -38,10 +38,11 @@
     <ProjectReference Include="../TestingHelpers/TestingHelpers.csproj" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' != 'net40'">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+  </ItemGroup>
+
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" 
-                      Version="15.0.0"
-                      Condition="'$(TargetFramework)' != 'net40'" />
     <PackageReference Include="nunit" Version="3.8.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
   </ItemGroup>

--- a/TestHelpers.Tests/packages.config
+++ b/TestHelpers.Tests/packages.config
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="NUnit" version="2.6.4" targetFramework="net40" />
-  <package id="NUnitTestAdapter" version="1.2" targetFramework="net40" />
-</packages>


### PR DESCRIPTION
This seems to be a leftover from before nestandard build migration. It's ignored by normal build process, but is confusing to some other tooling.