### PR TITLE
Fix/disable tests that fail on Unix

### DIFF
--- a/TestHelpers.Tests/MockDirectoryGetAccessControlTests.cs
+++ b/TestHelpers.Tests/MockDirectoryGetAccessControlTests.cs
@@ -16,6 +16,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         [TestCase("   ")]
         public void MockDirectory_GetAccessControl_ShouldThrowArgumentExceptionIfPathContainsOnlyWhitespaces(string path)
         {
+            if (MockUnixSupport.IsUnixPlatform()) 
+            {
+                Assert.Inconclusive("Unix does not support ACLs.");
+            }
+
             // Arrange
             var fileSystem = new MockFileSystem();
 
@@ -30,6 +35,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         [Test]
         public void MockDirectory_GetAccessControl_ShouldThrowDirectoryNotFoundExceptionIfDirectoryDoesNotExistInMockData()
         {
+            if (MockUnixSupport.IsUnixPlatform()) 
+            {
+                Assert.Inconclusive("Unix does not support ACLs.");
+            }
+
             // Arrange
             var fileSystem = new MockFileSystem();
             var expectedDirectoryName = XFS.Path(@"c:\a");
@@ -44,6 +54,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         [Test]
         public void MockDirectory_GetAccessControl_ShouldReturnAccessControlOfDirectoryData()
         {
+            if (MockUnixSupport.IsUnixPlatform()) 
+            {
+                Assert.Inconclusive("Unix does not support ACLs.");
+            }
+            
             // Arrange
             var expectedDirectorySecurity = new DirectorySecurity();
             expectedDirectorySecurity.SetAccessRuleProtection(false, false);

--- a/TestHelpers.Tests/MockDirectoryInfoTests.cs
+++ b/TestHelpers.Tests/MockDirectoryInfoTests.cs
@@ -202,8 +202,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 yield return new object[] { XFS.Path(@"c:\temp\\folder"), XFS.Path(@"c:\temp\folder") };
                 yield return new object[] { XFS.Path(@"c:\temp//folder"), XFS.Path(@"c:\temp\folder") };
                 yield return new object[] { XFS.Path(@"c:\temp//\\///folder"), XFS.Path(@"c:\temp\folder") };
-                yield return new object[] { XFS.Path(@"\\unc\folder"), XFS.Path(@"\\unc\folder") };
-                yield return new object[] { XFS.Path(@"\\unc/folder\\foo"), XFS.Path(@"\\unc\folder\foo") };
+                if (!MockUnixSupport.IsUnixPlatform())
+                {
+                    yield return new object[] { XFS.Path(@"\\unc\folder"), XFS.Path(@"\\unc\folder") };
+                    yield return new object[] { XFS.Path(@"\\unc/folder\\foo"), XFS.Path(@"\\unc\folder\foo") };
+                }
             }
         }
 

--- a/TestHelpers.Tests/MockDirectorySetAccessControlTests.cs
+++ b/TestHelpers.Tests/MockDirectorySetAccessControlTests.cs
@@ -16,6 +16,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         [TestCase("   ")]
         public void MockDirectory_SetAccessControl_ShouldThrowArgumentExceptionIfPathContainsOnlyWhitespaces(string path)
         {
+            if (MockUnixSupport.IsUnixPlatform()) 
+            {
+                Assert.Inconclusive("Unix does not support ACLs.");
+            }
+
             // Arrange
             var fileSystem = new MockFileSystem();
             var directorySecurity = new DirectorySecurity();
@@ -31,6 +36,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         [Test]
         public void MockDirectory_SetAccessControl_ShouldThrowDirectoryNotFoundExceptionIfDirectoryDoesNotExistInMockData()
         {
+            if (MockUnixSupport.IsUnixPlatform()) 
+            {
+                Assert.Inconclusive("Unix does not support ACLs.");
+            }
+            
             // Arrange
             var fileSystem = new MockFileSystem();
             var expectedFileName = XFS.Path(@"c:\a\");
@@ -46,6 +56,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         [Test]
         public void MockDirectory_SetAccessControl_ShouldReturnAccessControlOfDirectoryData()
         {
+            if (MockUnixSupport.IsUnixPlatform()) 
+            {
+                Assert.Inconclusive("Unix does not support ACLs.");
+            }
+            
             // Arrange
             var filePath = XFS.Path(@"c:\a\");
             var fileData = new MockDirectoryData();

--- a/TestHelpers.Tests/MockDriveInfoFactoryTests.cs
+++ b/TestHelpers.Tests/MockDriveInfoFactoryTests.cs
@@ -11,6 +11,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         [Test]
         public void MockDriveInfoFactory_GetDrives_ShouldReturnDrives()
         {
+            if (MockUnixSupport.IsUnixPlatform())
+            {
+                Assert.Inconclusive("Unix does not have the concept of drives.");
+            }
+            
             // Arrange
             var fileSystem = new MockFileSystem();
             fileSystem.AddDirectory(XFS.Path(@"C:\Test"));
@@ -30,6 +35,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         [Test]
         public void MockDriveInfoFactory_GetDrives_ShouldReturnDrivesWithNoDuplicates()
         {
+            if (MockUnixSupport.IsUnixPlatform())
+            {
+                Assert.Inconclusive("Unix does not have the concept of drives.");
+            }
+
             // Arrange
             var fileSystem = new MockFileSystem();
             fileSystem.AddDirectory(XFS.Path(@"C:\Test"));
@@ -51,6 +61,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         [Test]
         public void MockDriveInfoFactory_GetDrives_ShouldReturnOnlyLocalDrives()
         {
+            if (MockUnixSupport.IsUnixPlatform())
+            {
+                Assert.Inconclusive("Unix does not have the concept of drives.");
+            }
+
             // Arrange
             var fileSystem = new MockFileSystem();
             fileSystem.AddDirectory(XFS.Path(@"C:\Test"));

--- a/TestHelpers.Tests/MockDriveInfoTests.cs
+++ b/TestHelpers.Tests/MockDriveInfoTests.cs
@@ -11,6 +11,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         [TestCase(@"c:\")]
         public void MockDriveInfo_Constructor_ShouldInitializeLocalWindowsDrives(string driveName)
         {
+            if (XFS.IsUnixPlatform())
+            {
+                Assert.Inconclusive("Unix does not have the concept of drives.");
+            }
+
             // Arrange
             var fileSystem = new MockFileSystem();
             fileSystem.AddDirectory(XFS.Path(@"c:\Test"));
@@ -46,6 +51,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         [TestCase(@"\\unctoo")]
         public void MockDriveInfo_Constructor_ShouldThrowExceptionIfUncPath(string driveName)
         {
+            if (XFS.IsUnixPlatform())
+            {
+                Assert.Inconclusive("Unix does not have the concept of drives.");
+            }
+
             // Arrange
             var fileSystem = new MockFileSystem();
 
@@ -59,6 +69,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         [Test]
         public void MockDriveInfo_RootDirectory_ShouldReturnTheDirectoryBase()
         {
+            if (XFS.IsUnixPlatform())
+            {
+                Assert.Inconclusive("Unix does not have the concept of drives.");
+            }
+            
             // Arrange
             var fileSystem = new MockFileSystem();
             fileSystem.AddDirectory(XFS.Path(@"c:\Test"));

--- a/TestHelpers.Tests/MockFileAppendAllLinesTests.cs
+++ b/TestHelpers.Tests/MockFileAppendAllLinesTests.cs
@@ -80,6 +80,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         [TestCase("|")]
         public void MockFile_AppendAllLines_ShouldThrowArgumentExceptionIfPathContainsInvalidChar(string path)
         {
+            if (MockUnixSupport.IsUnixPlatform()) 
+            {
+                Assert.Inconclusive("Unix does not have these restrictions.");
+            }
+            
             // Arrange
             var fileSystem = new MockFileSystem();
 

--- a/TestHelpers.Tests/MockFileAppendAllTextTests.cs
+++ b/TestHelpers.Tests/MockFileAppendAllTextTests.cs
@@ -78,8 +78,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         {
             // Arrange
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>());
-            const string path = @"c:\something\demo3.txt";
-            fileSystem.AddDirectory(@"c:\something\");
+            var path = XFS.Path(@"c:\something\demo3.txt");
+            fileSystem.AddDirectory(XFS.Path(@"c:\something\"));
 
             // Act
             fileSystem.File.AppendAllText(path, "AA", Encoding.UTF32);
@@ -138,17 +138,6 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 101, 110, 116, 0, 43, 0, 32, 0, 115, 0, 111, 0, 109, 0, 101,
                 0, 32, 0, 116, 0, 101, 0, 120, 0, 116
             };
-
-            if (XFS.IsUnixPlatform())
-            {
-                // Remove EOF on mono
-                expected = new byte[]
-                {
-                    68, 101, 109, 111, 32, 116, 101, 120, 116, 32, 99, 111, 110, 116,
-                    101, 110, 0, 43, 0, 32, 0, 115, 0, 111, 0, 109, 0, 101,
-                    0, 32, 0, 116, 0, 101, 0, 120, 0, 116
-                };
-            }
 
             CollectionAssert.AreEqual(
                 expected,

--- a/TestHelpers.Tests/MockFileCreateTests.cs
+++ b/TestHelpers.Tests/MockFileCreateTests.cs
@@ -18,7 +18,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         {
             string fullPath = XFS.Path(@"c:\something\demo.txt");
             var fileSystem = new MockFileSystem();
-            fileSystem.AddDirectory(@"c:\something");
+            fileSystem.AddDirectory(XFS.Path(@"c:\something"));
 
             var sut = new MockFile(fileSystem);
 
@@ -34,7 +34,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         {
             string fullPath = XFS.Path(@"c:\something\demo.txt");
             var fileSystem = new MockFileSystem();
-            fileSystem.AddDirectory(@"c:\something");
+            fileSystem.AddDirectory(XFS.Path(@"c:\something"));
             var data = new UTF8Encoding(false).GetBytes("Test string");
 
             var sut = new MockFile(fileSystem);
@@ -54,7 +54,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         {
             string path = XFS.Path(@"c:\some\file.txt");
             var fileSystem = new MockFileSystem();
-            fileSystem.AddDirectory(@"c:\some");
+            fileSystem.AddDirectory(XFS.Path(@"c:\some"));
 
             var mockFile = new MockFile(fileSystem);
 
@@ -112,6 +112,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         [TestCase("|")]
         public void MockFile_Create_ShouldThrowArgumentNullExceptionIfPathIsNull1(string path)
         {
+            if (MockUnixSupport.IsUnixPlatform()) 
+            {
+                Assert.Inconclusive("Unix does not have these restrictions.");
+            }
+
             // Arrange
             var fileSystem = new MockFileSystem();
 

--- a/TestHelpers.Tests/MockFileGetAccessControlTests.cs
+++ b/TestHelpers.Tests/MockFileGetAccessControlTests.cs
@@ -16,6 +16,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         [TestCase("   ")]
         public void MockFile_GetAccessControl_ShouldThrowArgumentExceptionIfPathContainsOnlyWhitespaces(string path)
         {
+            if (MockUnixSupport.IsUnixPlatform()) 
+            {
+                Assert.Inconclusive("Unix does not support ACLs.");
+            }
+            
             // Arrange
             var fileSystem = new MockFileSystem();
 
@@ -30,6 +35,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         [Test]
         public void MockFile_GetAccessControl_ShouldThrowFileNotFoundExceptionIfFileDoesNotExistInMockData()
         {
+            if (MockUnixSupport.IsUnixPlatform()) 
+            {
+                Assert.Inconclusive("Unix does not support ACLs.");
+            }
+            
             // Arrange
             var fileSystem = new MockFileSystem();
             var expectedFileName = XFS.Path(@"c:\a.txt");
@@ -45,6 +55,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         [Test]
         public void MockFile_GetAccessControl_ShouldReturnAccessControlOfFileData()
         {
+            if (MockUnixSupport.IsUnixPlatform()) 
+            {
+                Assert.Inconclusive("Unix does not support ACLs.");
+            }
+            
             // Arrange
             var expectedFileSecurity = new FileSecurity();
             expectedFileSecurity.SetAccessRuleProtection(false, false);

--- a/TestHelpers.Tests/MockFileInfoTests.cs
+++ b/TestHelpers.Tests/MockFileInfoTests.cs
@@ -217,7 +217,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 newcontents = newfile.ReadToEnd();
 
             // Assert
-            Assert.AreEqual("Demo text contentThis should be at the end\r\n", newcontents);
+            Assert.AreEqual($"Demo text contentThis should be at the end{Environment.NewLine}", newcontents);
         }
 
         [Test]

--- a/TestHelpers.Tests/MockFileOpenTests.cs
+++ b/TestHelpers.Tests/MockFileOpenTests.cs
@@ -42,7 +42,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         {
             string filepath = XFS.Path(@"c:\something\doesnt\exist.txt");
             var filesystem = new MockFileSystem(new Dictionary<string, MockFileData>());
-            filesystem.AddDirectory(@"c:\something\doesnt");
+            filesystem.AddDirectory(XFS.Path(@"c:\something\doesnt"));
 
             var stream = filesystem.File.Open(filepath, FileMode.Create);
 
@@ -56,7 +56,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         {
             string filepath = XFS.Path(@"c:\something\doesnt\exist.txt");
             var filesystem = new MockFileSystem(new Dictionary<string, MockFileData>());
-            filesystem.AddDirectory(@"c:\something\doesnt");
+            filesystem.AddDirectory(XFS.Path(@"c:\something\doesnt"));
 
             var stream = filesystem.File.Open(filepath, FileMode.CreateNew);
 
@@ -155,7 +155,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         {
             string filepath = XFS.Path(@"c:\something\doesnt\exist.txt");
             var filesystem = new MockFileSystem(new Dictionary<string, MockFileData>());
-            filesystem.AddDirectory(@"c:\something\doesnt");
+            filesystem.AddDirectory(XFS.Path(@"c:\something\doesnt"));
 
             var stream = filesystem.File.Open(filepath, FileMode.OpenOrCreate);
 

--- a/TestHelpers.Tests/MockFileSetAccessControlTests.cs
+++ b/TestHelpers.Tests/MockFileSetAccessControlTests.cs
@@ -16,6 +16,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         [TestCase("   ")]
         public void MockFile_SetAccessControl_ShouldThrowArgumentExceptionIfPathContainsOnlyWhitespaces(string path)
         {
+            if (MockUnixSupport.IsUnixPlatform()) 
+            {
+                Assert.Inconclusive("Unix does not support ACLs.");
+            }
+            
             // Arrange
             var fileSystem = new MockFileSystem();
             var fileSecurity = new FileSecurity();
@@ -31,6 +36,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         [Test]
         public void MockFile_SetAccessControl_ShouldThrowFileNotFoundExceptionIfFileDoesNotExistInMockData()
         {
+            if (MockUnixSupport.IsUnixPlatform()) 
+            {
+                Assert.Inconclusive("Unix does not support ACLs.");
+            }
+
             // Arrange
             var fileSystem = new MockFileSystem();
             var expectedFileName = XFS.Path(@"c:\a.txt");
@@ -47,6 +57,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         [Test]
         public void MockFile_SetAccessControl_ShouldReturnAccessControlOfFileData()
         {
+            if (MockUnixSupport.IsUnixPlatform()) 
+            {
+                Assert.Inconclusive("Unix does not support ACLs.");
+            }
+
             // Arrange
             var filePath = XFS.Path(@"c:\a.txt");
             var fileData = new MockFileData("Test content");

--- a/TestHelpers.Tests/MockFileSystemTests.cs
+++ b/TestHelpers.Tests/MockFileSystemTests.cs
@@ -153,16 +153,16 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.AddDirectory(MockUnixSupport.Path(@"C:\LOUD"));
 
             // Act
-            fileSystem.AddFile(@"C:\test\file.txt", "foo");
-            fileSystem.AddFile(@"C:\LOUD\file.txt", "foo");
-            fileSystem.AddDirectory(@"C:\test\SUBDirectory");
-            fileSystem.AddDirectory(@"C:\LOUD\SUBDirectory");
+            fileSystem.AddFile(MockUnixSupport.Path(@"C:\test\file.txt"), "foo");
+            fileSystem.AddFile(MockUnixSupport.Path(@"C:\LOUD\file.txt"), "foo");
+            fileSystem.AddDirectory(MockUnixSupport.Path(@"C:\test\SUBDirectory"));
+            fileSystem.AddDirectory(MockUnixSupport.Path(@"C:\LOUD\SUBDirectory"));
 
             // Assert
-            Assert.Contains(@"C:\test\file.txt", fileSystem.AllFiles.ToList());
-            Assert.Contains(@"C:\LOUD\file.txt", fileSystem.AllFiles.ToList());
-            Assert.Contains(@"C:\test\SUBDirectory\", fileSystem.AllDirectories.ToList());
-            Assert.Contains(@"C:\LOUD\SUBDirectory\", fileSystem.AllDirectories.ToList());
+            Assert.Contains(MockUnixSupport.Path(@"C:\test\file.txt"), fileSystem.AllFiles.ToList());
+            Assert.Contains(MockUnixSupport.Path(@"C:\LOUD\file.txt"), fileSystem.AllFiles.ToList());
+            Assert.Contains(MockUnixSupport.Path(@"C:\test\SUBDirectory\"), fileSystem.AllDirectories.ToList());
+            Assert.Contains(MockUnixSupport.Path(@"C:\LOUD\SUBDirectory\"), fileSystem.AllDirectories.ToList());
         }
 
         [Test]
@@ -174,16 +174,16 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.AddDirectory(MockUnixSupport.Path(@"C:\LOUD\SUBLOUD"));
 
             // Act
-            fileSystem.AddFile(@"C:\test\SUBTEST\file.txt", "foo");
-            fileSystem.AddFile(@"C:\LOUD\subloud\file.txt", "foo");
-            fileSystem.AddDirectory(@"C:\test\SUBTEST\SUBDirectory");
-            fileSystem.AddDirectory(@"C:\LOUD\subloud\SUBDirectory");
+            fileSystem.AddFile(MockUnixSupport.Path(@"C:\test\SUBTEST\file.txt"), "foo");
+            fileSystem.AddFile(MockUnixSupport.Path(@"C:\LOUD\subloud\file.txt"), "foo");
+            fileSystem.AddDirectory(MockUnixSupport.Path(@"C:\test\SUBTEST\SUBDirectory"));
+            fileSystem.AddDirectory(MockUnixSupport.Path(@"C:\LOUD\subloud\SUBDirectory"));
 
             // Assert
-            Assert.Contains(@"C:\test\subtest\file.txt", fileSystem.AllFiles.ToList());
-            Assert.Contains(@"C:\LOUD\SUBLOUD\file.txt", fileSystem.AllFiles.ToList());
-            Assert.Contains(@"C:\test\subtest\SUBDirectory\", fileSystem.AllDirectories.ToList());
-            Assert.Contains(@"C:\LOUD\SUBLOUD\SUBDirectory\", fileSystem.AllDirectories.ToList());
+            Assert.Contains(MockUnixSupport.Path(@"C:\test\subtest\file.txt"), fileSystem.AllFiles.ToList());
+            Assert.Contains(MockUnixSupport.Path(@"C:\LOUD\SUBLOUD\file.txt"), fileSystem.AllFiles.ToList());
+            Assert.Contains(MockUnixSupport.Path(@"C:\test\subtest\SUBDirectory\"), fileSystem.AllDirectories.ToList());
+            Assert.Contains(MockUnixSupport.Path(@"C:\LOUD\SUBLOUD\SUBDirectory\"), fileSystem.AllDirectories.ToList());
         }
 
         [Test]
@@ -195,16 +195,16 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.AddDirectory(MockUnixSupport.Path(@"C:\LOUD\SUBLOUD"));
 
             // Act
-            fileSystem.AddFile(@"C:\test\SUBTEST\new\file.txt", "foo");
-            fileSystem.AddFile(@"C:\LOUD\subloud\new\file.txt", "foo");
-            fileSystem.AddDirectory(@"C:\test\SUBTEST\new\SUBDirectory");
-            fileSystem.AddDirectory(@"C:\LOUD\subloud\new\SUBDirectory");
+            fileSystem.AddFile(MockUnixSupport.Path(@"C:\test\SUBTEST\new\file.txt"), "foo");
+            fileSystem.AddFile(MockUnixSupport.Path(@"C:\LOUD\subloud\new\file.txt"), "foo");
+            fileSystem.AddDirectory(MockUnixSupport.Path(@"C:\test\SUBTEST\new\SUBDirectory"));
+            fileSystem.AddDirectory(MockUnixSupport.Path(@"C:\LOUD\subloud\new\SUBDirectory"));
 
             // Assert
-            Assert.Contains(@"C:\test\subtest\new\file.txt", fileSystem.AllFiles.ToList());
-            Assert.Contains(@"C:\LOUD\SUBLOUD\new\file.txt", fileSystem.AllFiles.ToList());
-            Assert.Contains(@"C:\test\subtest\new\SUBDirectory\", fileSystem.AllDirectories.ToList());
-            Assert.Contains(@"C:\LOUD\SUBLOUD\new\SUBDirectory\", fileSystem.AllDirectories.ToList());
+            Assert.Contains(MockUnixSupport.Path(@"C:\test\subtest\new\file.txt"), fileSystem.AllFiles.ToList());
+            Assert.Contains(MockUnixSupport.Path(@"C:\LOUD\SUBLOUD\new\file.txt"), fileSystem.AllFiles.ToList());
+            Assert.Contains(MockUnixSupport.Path(@"C:\test\subtest\new\SUBDirectory\"), fileSystem.AllDirectories.ToList());
+            Assert.Contains(MockUnixSupport.Path(@"C:\LOUD\SUBLOUD\new\SUBDirectory\"), fileSystem.AllDirectories.ToList());
         }
 
         [Test]
@@ -214,8 +214,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var fileSystem = new MockFileSystem();
 
             // Act
-            fileSystem.AddFileFromEmbeddedResource(@"C:\TestFile.txt", Assembly.GetExecutingAssembly(), "System.IO.Abstractions.TestingHelpers.Tests.TestFiles.TestFile.txt");
-            var result = fileSystem.GetFile(@"C:\TestFile.txt");
+            fileSystem.AddFileFromEmbeddedResource(MockUnixSupport.Path(@"C:\TestFile.txt"), Assembly.GetExecutingAssembly(), "System.IO.Abstractions.TestingHelpers.Tests.TestFiles.TestFile.txt");
+            var result = fileSystem.GetFile(MockUnixSupport.Path(@"C:\TestFile.txt"));
 
             // Assert
             Assert.AreEqual(new UTF8Encoding().GetBytes("This is a test file."), result.Contents);
@@ -228,10 +228,10 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var fileSystem = new MockFileSystem();
 
             //Act
-            fileSystem.AddFilesFromEmbeddedNamespace(@"C:\", Assembly.GetExecutingAssembly(), "System.IO.Abstractions.TestingHelpers.Tests.TestFiles");
+            fileSystem.AddFilesFromEmbeddedNamespace(MockUnixSupport.Path(@"C:\"), Assembly.GetExecutingAssembly(), "System.IO.Abstractions.TestingHelpers.Tests.TestFiles");
 
-            Assert.Contains(@"C:\TestFile.txt", fileSystem.AllFiles.ToList());
-            Assert.Contains(@"C:\SecondTestFile.txt", fileSystem.AllFiles.ToList());
+            Assert.Contains(MockUnixSupport.Path(@"C:\TestFile.txt"), fileSystem.AllFiles.ToList());
+            Assert.Contains(MockUnixSupport.Path(@"C:\SecondTestFile.txt"), fileSystem.AllFiles.ToList());
         }
     }
 }

--- a/TestHelpers.Tests/MockFileTests.cs
+++ b/TestHelpers.Tests/MockFileTests.cs
@@ -246,6 +246,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         [Test]
         public void MockFile_GetAttributeOfExistingUncDirectory_ShouldReturnCorrectValue()
         {
+            if (MockUnixSupport.IsUnixPlatform())
+            {
+                Assert.Inconclusive("Unix does not have the concept of UNC paths.");
+            }
+
             var filedata = new MockFileData("test");
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
             {
@@ -435,7 +440,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             string path = XFS.Path(@"c:\something\demo.txt");
             var fileSystem = new MockFileSystem();
             var fileContent = new byte[] { 1, 2, 3, 4 };
-            fileSystem.AddDirectory(@"c:\something");
+            fileSystem.AddDirectory(XFS.Path(@"c:\something"));
 
             // Act
             fileSystem.File.WriteAllBytes(path, fileContent);
@@ -540,7 +545,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         {
             string filepath = XFS.Path(@"c:\something\doesnt\exist.txt");
             var filesystem = new MockFileSystem(new Dictionary<string, MockFileData>());
-            filesystem.AddDirectory(@"c:\something\doesnt");
+            filesystem.AddDirectory(XFS.Path(@"c:\something\doesnt"));
 
             var stream = filesystem.File.AppendText(filepath);
 

--- a/TestHelpers.Tests/MockFileWriteAllBytesTests.cs
+++ b/TestHelpers.Tests/MockFileWriteAllBytesTests.cs
@@ -29,7 +29,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             string path = XFS.Path(@"c:\something\demo.txt");
             var fileSystem = new MockFileSystem();
             var fileContent = new byte[] { 1, 2, 3, 4 };
-            fileSystem.AddDirectory(@"c:\something");
+            fileSystem.AddDirectory(XFS.Path(@"c:\something"));
 
             // Act
             fileSystem.File.WriteAllBytes(path, fileContent);

--- a/TestHelpers.Tests/MockFileWriteAllLinesTests.cs
+++ b/TestHelpers.Tests/MockFileWriteAllLinesTests.cs
@@ -18,7 +18,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 get
                 {
                     var fileSystem = new MockFileSystem();
-                    fileSystem.AddDirectory(@"c:\something");
+                    fileSystem.AddDirectory(XFS.Path(@"c:\something"));
                     var fileContentEnumerable = new List<string> { "first line", "second line", "third line", "fourth and last line" };
                     var fileContentArray = fileContentEnumerable.ToArray();
                     Action writeEnumberable = () => fileSystem.File.WriteAllLines(Path, fileContentEnumerable);
@@ -169,7 +169,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                     var path = XFS.Path(@"c:\something\file.txt");
                     var mockFileData = new MockFileData(string.Empty);
                     mockFileData.Attributes = FileAttributes.ReadOnly;
-                    fileSystem.AddDirectory(@"c:\something");
+                    fileSystem.AddDirectory(XFS.Path(@"c:\something"));
                     fileSystem.AddFile(path, mockFileData);
                     List<string> fileContentEnumerable = null;
                     string[] fileContentArray = null;
@@ -243,6 +243,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         [TestCaseSource(typeof(TestDataForWriteAllLines), "ForIllegalPath")]
         public void MockFile_WriteAllLinesGeneric_ShouldThrowAnArgumentExceptionIfPathContainsIllegalCharacters(TestDelegate action)
         {
+            if (MockUnixSupport.IsUnixPlatform()) 
+            {
+                Assert.Inconclusive("Unix does not have these restrictions.");
+            }
+            
             // Arrange
             // is done in the test case source
 

--- a/TestHelpers.Tests/MockFileWriteAllTextTests.cs
+++ b/TestHelpers.Tests/MockFileWriteAllTextTests.cs
@@ -16,7 +16,7 @@
             string path = XFS.Path(@"c:\something\demo.txt");
             string fileContent = "Hello there!";
             var fileSystem = new MockFileSystem();
-            fileSystem.AddDirectory(@"c:\something");
+            fileSystem.AddDirectory(XFS.Path(@"c:\something"));
 
             // Act
             fileSystem.File.WriteAllText(path, fileContent);
@@ -35,7 +35,7 @@
             // Arrange
             string path = XFS.Path(@"c:\something\demo.txt");
             var fileSystem = new MockFileSystem();
-            fileSystem.AddDirectory(@"c:\something");
+            fileSystem.AddDirectory(XFS.Path(@"c:\something"));
 
             // Act
             fileSystem.File.WriteAllText(path, "foo");
@@ -192,7 +192,7 @@
             byte[] expectedBytes = encodingsWithContents.Value;
             Encoding encoding = encodingsWithContents.Key;
             var fileSystem = new MockFileSystem();
-            fileSystem.AddDirectory(@"c:\something");
+            fileSystem.AddDirectory(XFS.Path(@"c:\something"));
 
             // Act
             fileSystem.File.WriteAllText(path, FileContent, encoding);
@@ -212,7 +212,7 @@
             var expected = "Hello there!" + Environment.NewLine + "Second line!" + Environment.NewLine;
 
             var fileSystem = new MockFileSystem();
-            fileSystem.AddDirectory(@"c:\something");
+            fileSystem.AddDirectory(XFS.Path(@"c:\something"));
 
             // Act
             fileSystem.File.WriteAllLines(path, fileContent);

--- a/TestingHelpers/MockDirectory.cs
+++ b/TestingHelpers/MockDirectory.cs
@@ -61,6 +61,7 @@ namespace System.IO.Abstractions.TestingHelpers
             }
 
             var created = new MockDirectoryInfo(mockFileDataAccessor, path);
+
             if (directorySecurity != null)
             {
                 created.SetAccessControl(directorySecurity);
@@ -95,8 +96,14 @@ namespace System.IO.Abstractions.TestingHelpers
 
         public override bool Exists(string path)
         {
+            if (path == "/" && XFS.IsUnixPlatform()) 
+            {
+                return true;
+            }
+
             try
             {
+
                 path = EnsurePathEndsWithDirectorySeparator(path);
                 path = mockFileDataAccessor.Path.GetFullPath(path);
                 return mockFileDataAccessor.AllDirectories.Any(p => p.Equals(path, StringComparison.OrdinalIgnoreCase));

--- a/TestingHelpers/MockDirectoryInfo.cs
+++ b/TestingHelpers/MockDirectoryInfo.cs
@@ -123,7 +123,7 @@ namespace System.IO.Abstractions.TestingHelpers
 
         public override string Name
         {
-            get { return new MockPath(mockFileDataAccessor).GetFileName(directoryPath.TrimEnd('\\')); }
+            get { return new MockPath(mockFileDataAccessor).GetFileName(directoryPath.TrimEnd(mockFileDataAccessor.Path.DirectorySeparatorChar)); }
         }
 
         public override void Create()


### PR DESCRIPTION
This MR makes the Travis build green, by either
* fixing tests that were buggy (e.g. by not using MockUnixSupport consistently)
* fixing implementation issues
* ignoring tests that don't make sense on Unix (mostly ACL, UNC paths, character limitations in paths)