### PR TITLE
Set the encrypted attribute when Encrypt or Decrypt are called

### DIFF
--- a/TestHelpers.Tests/MockFileTests.cs
+++ b/TestHelpers.Tests/MockFileTests.cs
@@ -618,6 +618,25 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
+        public void MockFile_Encrypt_ShouldSetEncryptedAttribute()
+        {
+            // Arrange
+            var fileData = new MockFileData("Demo text content");
+            var filePath = XFS.Path(@"c:\a.txt");
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                {filePath, fileData }
+            });
+
+            // Act
+            fileSystem.File.Encrypt(filePath);
+            var attributes = fileSystem.File.GetAttributes(filePath);
+
+            // Assert
+            Assert.AreEqual(FileAttributes.Encrypted, attributes & FileAttributes.Encrypted);
+        }
+
+        [Test]
         public void MockFile_Decrypt_ShouldDecryptTheFile()
         {
             // Arrange
@@ -628,6 +647,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             {
                 {filePath, fileData }
             });
+            fileSystem.File.Encrypt(filePath);
 
             // Act
             fileSystem.File.Decrypt(filePath);
@@ -639,7 +659,28 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             }
 
             // Assert
-            Assert.AreNotEqual(Content, newcontents);
+            Assert.AreEqual(Content, newcontents);
+        }
+
+        [Test]
+        public void MockFile_Decrypt_ShouldRemoveEncryptedAttribute()
+        {
+            // Arrange
+            const string Content = "Demo text content";
+            var fileData = new MockFileData(Content);
+            var filePath = XFS.Path(@"c:\a.txt");
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                {filePath, fileData }
+            });
+            fileSystem.File.Encrypt(filePath);
+
+            // Act
+            fileSystem.File.Decrypt(filePath);
+            var attributes = fileSystem.File.GetAttributes(filePath);
+
+            // Assert
+            Assert.AreNotEqual(FileAttributes.Encrypted, attributes & FileAttributes.Encrypted);
         }
 #endif
     }

--- a/TestingHelpers/MockFileInfo.cs
+++ b/TestingHelpers/MockFileInfo.cs
@@ -37,8 +37,7 @@ namespace System.IO.Abstractions.TestingHelpers
         {
             get
             {
-                if (MockFileData == null)
-                    throw new FileNotFoundException("File not found", path);
+                if (MockFileData == null) throw new FileNotFoundException("File not found", path);
                 return MockFileData.Attributes;
             }
             set { MockFileData.Attributes = value; }
@@ -148,7 +147,8 @@ namespace System.IO.Abstractions.TestingHelpers
             }
         }
 
-        public override string Name {
+        public override string Name
+        {
             get { return new MockPath(mockFileSystem).GetFileName(path); }
         }
 
@@ -185,17 +185,23 @@ namespace System.IO.Abstractions.TestingHelpers
         public override void Decrypt()
         {
             if (MockFileData == null) throw new FileNotFoundException("File not found", path);
+
             var contents = MockFileData.Contents;
             for (var i = 0; i < contents.Length; i++)
                 contents[i] ^= (byte)(i % 256);
+
+            MockFileData.Attributes &= ~FileAttributes.Encrypted;
         }
 
         public override void Encrypt()
         {
             if (MockFileData == null) throw new FileNotFoundException("File not found", path);
+
             var contents = MockFileData.Contents;
             for(var i = 0; i < contents.Length; i++)
                 contents[i] ^= (byte) (i % 256);
+
+            MockFileData.Attributes |= FileAttributes.Encrypted;
         }
 #endif
 


### PR DESCRIPTION
- Sets the Encrypt attribute when .Encrypt() is called.
- Removes the Encrypt attribute when .Decrypt() is called.
- Fixes the MockFile_Decrypt_ShouldDecryptTheFile() test. Was checking NotEqual and was not called Encrypt before executing Decrypt.