### PR TITLE
WriteAllBytes Should Throw Exception on Illegal Characters

### DIFF
--- a/TestHelpers.Tests/MockFileWriteAllBytesTests.cs
+++ b/TestHelpers.Tests/MockFileWriteAllBytesTests.cs
@@ -57,7 +57,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
-        public void MockFile_WriteAllBytes_ShouldThrowAnArgumentNullExceptionIfContainsIllegalCharacters()
+        public void MockFile_WriteAllBytes_ShouldThrowAnArgumentNullExceptionIfPathIsNull()
         {
             var fileSystem = new MockFileSystem();
 
@@ -67,7 +67,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
-        public void MockFile_WriteAllBytes_ShouldThrowAnArgumentNullExceptionIfContainsIllegalCharacters2()
+        public void MockFile_WriteAllBytes_ShouldThrowAnArgumentExceptionIfContainsIllegalCharacters()
         {
             var fileSystem = new MockFileSystem();
             fileSystem.AddDirectory(@"C:\");

--- a/TestHelpers.Tests/MockFileWriteAllBytesTests.cs
+++ b/TestHelpers.Tests/MockFileWriteAllBytesTests.cs
@@ -49,13 +49,15 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         [Test]
         public void MockFile_WriteAllBytes_ShouldThrowAnArgumentExceptionIfContainsIllegalCharacters()
         {
-            string path = XFS.Path(@"c:\a/b.txt");
-            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            if (MockUnixSupport.IsUnixPlatform())
             {
-                { path, "" }
-            });
+                Assert.Inconclusive("Unix only disallows NULL characters.");
+            }
 
-            TestDelegate action = () => fileSystem.File.WriteAllBytes(path, new byte[] { 123 });
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddDirectory(XFS.Path(@"C:"));
+
+            TestDelegate action = () => fileSystem.File.WriteAllBytes(XFS.Path(@"C:\a<b.txt"), new byte[] { 123 });
 
             Assert.Throws<ArgumentException>(action);
         }

--- a/TestHelpers.Tests/MockFileWriteAllBytesTests.cs
+++ b/TestHelpers.Tests/MockFileWriteAllBytesTests.cs
@@ -50,8 +50,9 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         public void MockFile_WriteAllBytes_ShouldThrowAnArgumentExceptionIfContainsIllegalCharacters()
         {
             var fileSystem = new MockFileSystem();
+            fileSystem.AddDirectory(XFS.Path(@"C:\"));
 
-            TestDelegate action = () => fileSystem.File.WriteAllBytes("<<<", new byte[] { 123 });
+            TestDelegate action = () => fileSystem.File.WriteAllBytes(@"C:\*.txt", new byte[] { 123 });
 
             Assert.Throws<ArgumentException>(action);
         }
@@ -64,17 +65,6 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             TestDelegate action = () => fileSystem.File.WriteAllBytes(null, new byte[] { 123 });
 
             Assert.Throws<ArgumentNullException>(action);
-        }
-
-        [Test]
-        public void MockFile_WriteAllBytes_ShouldThrowAnArgumentExceptionIfContainsIllegalCharacters()
-        {
-            var fileSystem = new MockFileSystem();
-            fileSystem.AddDirectory(@"C:\");
-
-            TestDelegate action = () => fileSystem.File.WriteAllBytes(@"c:\ab*cde.txt", new byte[100]);
-
-            var exception = Assert.Throws<ArgumentException>(action);
         }
 
         [Test]

--- a/TestHelpers.Tests/MockFileWriteAllBytesTests.cs
+++ b/TestHelpers.Tests/MockFileWriteAllBytesTests.cs
@@ -49,10 +49,13 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         [Test]
         public void MockFile_WriteAllBytes_ShouldThrowAnArgumentExceptionIfContainsIllegalCharacters()
         {
-            var fileSystem = new MockFileSystem();
-            fileSystem.AddDirectory(XFS.Path(@"C:\"));
+            string path = XFS.Path(@"c:\*.txt");
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { path, "" }
+            });
 
-            TestDelegate action = () => fileSystem.File.WriteAllBytes(@"C:\*.txt", new byte[] { 123 });
+            TestDelegate action = () => fileSystem.File.WriteAllBytes(path, new byte[] { 123 });
 
             Assert.Throws<ArgumentException>(action);
         }

--- a/TestHelpers.Tests/MockFileWriteAllBytesTests.cs
+++ b/TestHelpers.Tests/MockFileWriteAllBytesTests.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-
 using NUnit.Framework;
 using XFS = System.IO.Abstractions.TestingHelpers.MockUnixSupport;
 
@@ -10,95 +9,82 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         [Test]
         public void MockFile_WriteAllBytes_ShouldThrowDirectoryNotFoundExceptionIfPathDoesNotExists()
         {
-            // Arrange
             var fileSystem = new MockFileSystem();
             string path = XFS.Path(@"c:\something\file.txt");
             var fileContent = new byte[] { 1, 2, 3, 4 };
 
-            // Act
             TestDelegate action = () => fileSystem.File.WriteAllBytes(path, fileContent);
 
-            // Assert
             Assert.Throws<DirectoryNotFoundException>(action);
         }
 
         [Test]
         public void MockFile_WriteAllBytes_ShouldWriteDataToMemoryFileSystem()
         {
-            // Arrange
             string path = XFS.Path(@"c:\something\demo.txt");
             var fileSystem = new MockFileSystem();
             var fileContent = new byte[] { 1, 2, 3, 4 };
             fileSystem.AddDirectory(XFS.Path(@"c:\something"));
 
-            // Act
             fileSystem.File.WriteAllBytes(path, fileContent);
 
-            // Assert
-            Assert.AreEqual(
-                fileContent,
-                fileSystem.GetFile(path).Contents);
+            Assert.AreEqual(fileContent, fileSystem.GetFile(path).Contents);
         }
 
         [Test]
         public void MockFile_WriteAllBytes_ShouldThrowAnUnauthorizedAccessExceptionIfFileIsHidden()
         {
-            // Arrange
             string path = XFS.Path(@"c:\something\demo.txt");
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
-                {
-                    { path, new MockFileData("this is hidden") },
-                });
+            {
+                { path, new MockFileData("this is hidden") },
+            });
             fileSystem.File.SetAttributes(path, FileAttributes.Hidden);
 
-            // Act
             TestDelegate action = () => fileSystem.File.WriteAllBytes(path, new byte[] { 123 });
 
-            // Assert
             Assert.Throws<UnauthorizedAccessException>(action, "Access to the path '{0}' is denied.", path);
         }
 
-#if NET40
         [Test]
-#endif
         public void MockFile_WriteAllBytes_ShouldThrowAnArgumentExceptionIfContainsIllegalCharacters()
         {
-            // Arrange
             var fileSystem = new MockFileSystem();
 
-            // Act
             TestDelegate action = () => fileSystem.File.WriteAllBytes("<<<", new byte[] { 123 });
 
-            // Assert
             Assert.Throws<ArgumentException>(action);
         }
 
         [Test]
         public void MockFile_WriteAllBytes_ShouldThrowAnArgumentNullExceptionIfContainsIllegalCharacters()
         {
-            // Arrange
             var fileSystem = new MockFileSystem();
 
-            // Act
             TestDelegate action = () => fileSystem.File.WriteAllBytes(null, new byte[] { 123 });
 
-            // Assert
-            var exception = Assert.Throws<ArgumentNullException>(action);
-            Assert.That(exception.Message, Does.StartWith("Path cannot be null."));
-            Assert.That(exception.ParamName, Is.EqualTo("path"));
+            Assert.Throws<ArgumentNullException>(action);
+        }
+
+        [Test]
+        public void MockFile_WriteAllBytes_ShouldThrowAnArgumentNullExceptionIfContainsIllegalCharacters2()
+        {
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddDirectory(@"C:\");
+
+            TestDelegate action = () => fileSystem.File.WriteAllBytes(@"c:\ab*cde.txt", new byte[100]);
+
+            var exception = Assert.Throws<ArgumentException>(action);
         }
 
         [Test]
         public void MockFile_WriteAllBytes_ShouldThrowAnArgumentNullExceptionIfBytesAreNull()
         {
-            // Arrange
             var fileSystem = new MockFileSystem();
             string path = XFS.Path(@"c:\something\demo.txt");
 
-            // Act
             TestDelegate action = () => fileSystem.File.WriteAllBytes(path, null);
 
-            // Assert
             var exception = Assert.Throws<ArgumentNullException>(action);
             Assert.That(exception.Message, Does.StartWith("Value cannot be null."));
             Assert.That(exception.ParamName, Is.EqualTo("bytes"));

--- a/TestHelpers.Tests/MockFileWriteAllBytesTests.cs
+++ b/TestHelpers.Tests/MockFileWriteAllBytesTests.cs
@@ -49,7 +49,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         [Test]
         public void MockFile_WriteAllBytes_ShouldThrowAnArgumentExceptionIfContainsIllegalCharacters()
         {
-            string path = XFS.Path(@"c:\*.txt");
+            string path = XFS.Path(@"c:\a/b.txt");
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
             {
                 { path, "" }

--- a/TestingHelpers/MockFile.cs
+++ b/TestingHelpers/MockFile.cs
@@ -618,13 +618,9 @@ namespace System.IO.Abstractions.TestingHelpers
         /// </remarks>
         public override void WriteAllBytes(string path, byte[] bytes)
         {
-            if (path == null)
-            {
-                throw new ArgumentNullException("path", "Path cannot be null.");
-            }
-
             VerifyValueIsNotNull(bytes, "bytes");
 
+            mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, "path");
             VerifyDirectoryExists(path);
 
             mockFileDataAccessor.AddFile(path, new MockFileData(bytes));


### PR DESCRIPTION
For #235.

Looks like the test we had for this case was actually failing on the directory, rather than the WriteAllBytes method. So it looked like the test was passing for this case, but it really wasn't.

I also added the IsUnixPlatform check to this, and removed the NET40 check for consistency with our other tests. 

I would like to leverage NUnit categories (https://github.com/nunit/docs/wiki/Category-Attribute) eventually, instead of this check.

Linux does have "illegal characters", but from what I can tell, only NULL (\u0000) which seems like an extreme edge case. This was also confirmed by running a quick core project in a linux container, calling Path.GetInvalidPathChars()

![image](https://user-images.githubusercontent.com/6980197/42416140-bf203cfc-8234-11e8-8705-db06e9e86d1f.png)
