### PR TITLE
Remove XOR when encrypting/decrypting files

### DIFF
--- a/TestHelpers.Tests/MockFileInfoTests.cs
+++ b/TestHelpers.Tests/MockFileInfoTests.cs
@@ -217,7 +217,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 #if NET40
         [Test]
-        public void MockFileInfo_Encrypt_ShouldReturnXorOfFileInMemoryFileSystem()
+        public void MockFileInfo_Encrypt_ShouldSetEncryptedAttributeOfFileInMemoryFileSystem()
         {
             var fileData = new MockFileData("Demo text content");
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -227,17 +227,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var fileInfo = new MockFileInfo(fileSystem, XFS.Path(@"c:\a.txt"));
 
             fileInfo.Encrypt();
-            string newcontents;
-            using (var newfile = fileInfo.OpenText())
-            {
-                newcontents = newfile.ReadToEnd();
-            }
 
-            Assert.AreNotEqual("Demo text content", newcontents);
+            Assert.AreEqual(FileAttributes.Encrypted, fileData.Attributes & FileAttributes.Encrypted);
         }
 
         [Test]
-        public void MockFileInfo_Decrypt_ShouldReturnCorrectContentsFileInMemoryFileSystem()
+        public void MockFileInfo_Decrypt_ShouldUnsetEncryptedAttributeOfFileInMemoryFileSystem()
         {
             var fileData = new MockFileData("Demo text content");
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -249,13 +244,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             fileInfo.Decrypt();
 
-            string newcontents;
-            using (var newfile = fileInfo.OpenText())
-            {
-                newcontents = newfile.ReadToEnd();
-            }
-
-            Assert.AreEqual("Demo text content", newcontents);
+            Assert.AreNotEqual(FileAttributes.Encrypted, fileData.Attributes & FileAttributes.Encrypted);
         }
 #endif
 

--- a/TestHelpers.Tests/MockFileTests.cs
+++ b/TestHelpers.Tests/MockFileTests.cs
@@ -559,31 +559,6 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
 #if NET40
         [Test]
-        public void MockFile_Encrypt_ShouldEncryptTheFile()
-        {
-            // Arrange
-            const string Content = "Demo text content";
-            var fileData = new MockFileData(Content);
-            var filePath = XFS.Path(@"c:\a.txt");
-            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
-            {
-                {filePath, fileData }
-            });
-
-            // Act
-            fileSystem.File.Encrypt(filePath);
-
-            string newcontents;
-            using (var newfile = fileSystem.File.OpenText(filePath))
-            {
-                newcontents = newfile.ReadToEnd();
-            }
-
-            // Assert
-            Assert.AreNotEqual(Content, newcontents);
-        }
-
-        [Test]
         public void MockFile_Encrypt_ShouldSetEncryptedAttribute()
         {
             // Arrange
@@ -600,32 +575,6 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             // Assert
             Assert.AreEqual(FileAttributes.Encrypted, attributes & FileAttributes.Encrypted);
-        }
-
-        [Test]
-        public void MockFile_Decrypt_ShouldDecryptTheFile()
-        {
-            // Arrange
-            const string Content = "Demo text content";
-            var fileData = new MockFileData(Content);
-            var filePath = XFS.Path(@"c:\a.txt");
-            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
-            {
-                {filePath, fileData }
-            });
-            fileSystem.File.Encrypt(filePath);
-
-            // Act
-            fileSystem.File.Decrypt(filePath);
-
-            string newcontents;
-            using (var newfile = fileSystem.File.OpenText(filePath))
-            {
-                newcontents = newfile.ReadToEnd();
-            }
-
-            // Assert
-            Assert.AreEqual(Content, newcontents);
         }
 
         [Test]

--- a/TestingHelpers/MockFileInfo.cs
+++ b/TestingHelpers/MockFileInfo.cs
@@ -192,20 +192,12 @@ namespace System.IO.Abstractions.TestingHelpers
         {
             if (MockFileData == null) throw new FileNotFoundException("File not found", path);
 
-            var contents = MockFileData.Contents;
-            for (var i = 0; i < contents.Length; i++)
-                contents[i] ^= (byte)(i % 256);
-
             MockFileData.Attributes &= ~FileAttributes.Encrypted;
         }
 
         public override void Encrypt()
         {
             if (MockFileData == null) throw new FileNotFoundException("File not found", path);
-
-            var contents = MockFileData.Contents;
-            for(var i = 0; i < contents.Length; i++)
-                contents[i] ^= (byte) (i % 256);
 
             MockFileData.Attributes |= FileAttributes.Encrypted;
         }


### PR DESCRIPTION
Fixes #304 by removing XOR of the in-memory data when encrypting/decrypting files with the MockFileSystem.