### PR TITLE
Implement File.Replace, FileInfo.Replace for TestHelpers

### DIFF
--- a/TestHelpers.Tests/MockFileInfoTests.cs
+++ b/TestHelpers.Tests/MockFileInfoTests.cs
@@ -464,5 +464,78 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             Assert.Throws<FileNotFoundException>(action);
         }
+
+#if NET40
+        [Test]
+        public void MockFileInfo_Replace_ShouldReplaceFileContents()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddFile(XFS.Path(@"c:\temp\file1.txt"), new MockFileData(@"line 1\r\nline 2"));
+            fileSystem.AddFile(XFS.Path(@"c:\temp\file2.txt"), new MockFileData(@"line 3\r\nline 4"));
+            var fileInfo1 = fileSystem.FileInfo.FromFileName(XFS.Path(@"c:\temp\file1.txt"));
+            var fileInfo2 = fileSystem.FileInfo.FromFileName(XFS.Path(@"c:\temp\file2.txt"));
+
+            // Act
+            fileInfo1.Replace(XFS.Path(@"c:\temp\file2.txt"), null);
+
+            Assert.AreEqual(@"line 1\r\nline 2", fileInfo2.OpenText().ReadToEnd());
+        }
+
+        [Test]
+        public void MockFileInfo_Replace_ShouldCreateBackup()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddFile(XFS.Path(@"c:\temp\file1.txt"), new MockFileData(@"line 1\r\nline 2"));
+            fileSystem.AddFile(XFS.Path(@"c:\temp\file2.txt"), new MockFileData(@"line 3\r\nline 4"));
+            var fileInfo1 = fileSystem.FileInfo.FromFileName(XFS.Path(@"c:\temp\file1.txt"));
+            var fileInfo2 = fileSystem.FileInfo.FromFileName(XFS.Path(@"c:\temp\file2.txt"));
+            var fileInfo3 = fileSystem.FileInfo.FromFileName(XFS.Path(@"c:\temp\file3.txt"));
+
+            // Act
+            fileInfo1.Replace(XFS.Path(@"c:\temp\file2.txt"), XFS.Path(@"c:\temp\file3.txt"));
+
+            Assert.AreEqual(@"line 3\r\nline 4", fileInfo3.OpenText().ReadToEnd());
+        }
+
+        [Test]
+        public void MockFileInfo_Replace_ShouldReturnDestinationFileInfo()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddFile(XFS.Path(@"c:\temp\file1.txt"), new MockFileData(@"line 1\r\nline 2"));
+            fileSystem.AddFile(XFS.Path(@"c:\temp\file2.txt"), new MockFileData(@"line 3\r\nline 4"));
+            var fileInfo1 = fileSystem.FileInfo.FromFileName(XFS.Path(@"c:\temp\file1.txt"));
+            var fileInfo2 = fileSystem.FileInfo.FromFileName(XFS.Path(@"c:\temp\file2.txt"));
+
+            // Act
+            var result = fileInfo1.Replace(XFS.Path(@"c:\temp\file2.txt"), null);
+
+            Assert.AreEqual(fileInfo2.FullName, result.FullName);
+        }
+
+        [Test]
+        public void MockFileInfo_Replace_ShouldThrowIfSourceFileDoesNotExist()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddFile(XFS.Path(@"c:\temp\file2.txt"), new MockFileData(@"line 3\r\nline 4"));
+            var fileInfo = fileSystem.FileInfo.FromFileName(XFS.Path(@"c:\temp\file1.txt"));
+
+            Assert.Throws<FileNotFoundException>(() => fileInfo.Replace(XFS.Path(@"c:\temp\file2.txt"), null));
+        }
+
+        [Test]
+        public void MockFileInfo_Replace_ShouldThrowIfDestinationFileDoesNotExist()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddFile(XFS.Path(@"c:\temp\file1.txt"), new MockFileData(@"line 1\r\nline 2"));
+            var fileInfo = fileSystem.FileInfo.FromFileName(XFS.Path(@"c:\temp\file1.txt"));
+
+            Assert.Throws<FileNotFoundException>(() => fileInfo.Replace(XFS.Path(@"c:\temp\file2.txt"), null));
+        }
+#endif
     }
 }

--- a/TestHelpers.Tests/MockFileTests.cs
+++ b/TestHelpers.Tests/MockFileTests.cs
@@ -649,5 +649,55 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             Assert.AreNotEqual(FileAttributes.Encrypted, attributes & FileAttributes.Encrypted);
         }
 #endif
+
+#if NET40
+        [Test]
+        public void MockFile_Replace_ShouldReplaceFileContents()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddFile(XFS.Path(@"c:\temp\file1.txt"), new MockFileData(@"line 1\r\nline 2"));
+            fileSystem.AddFile(XFS.Path(@"c:\temp\file2.txt"), new MockFileData(@"line 3\r\nline 4"));
+
+            // Act
+            fileSystem.File.Replace(XFS.Path(@"c:\temp\file1.txt"), XFS.Path(@"c:\temp\file2.txt"), null);
+
+            Assert.AreEqual(@"line 1\r\nline 2", fileSystem.File.ReadAllText(XFS.Path(@"c:\temp\file2.txt")));
+        }
+
+        [Test]
+        public void MockFile_Replace_ShouldCreateBackup()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddFile(XFS.Path(@"c:\temp\file1.txt"), new MockFileData(@"line 1\r\nline 2"));
+            fileSystem.AddFile(XFS.Path(@"c:\temp\file2.txt"), new MockFileData(@"line 3\r\nline 4"));
+
+            // Act
+            fileSystem.File.Replace(XFS.Path(@"c:\temp\file1.txt"), XFS.Path(@"c:\temp\file2.txt"), XFS.Path(@"c:\temp\file3.txt"));
+
+            Assert.AreEqual(@"line 3\r\nline 4", fileSystem.File.ReadAllText(XFS.Path(@"c:\temp\file3.txt")));
+        }
+
+        [Test]
+        public void MockFile_Replace_ShouldThrowIfSourceFileDoesNotExist()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddFile(XFS.Path(@"c:\temp\file2.txt"), new MockFileData(@"line 3\r\nline 4"));
+
+            Assert.Throws<FileNotFoundException>(() => fileSystem.File.Replace(XFS.Path(@"c:\temp\file1.txt"), XFS.Path(@"c:\temp\file2.txt"), null));
+        }
+
+        [Test]
+        public void MockFile_Replace_ShouldThrowIfDestinationFileDoesNotExist()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddFile(XFS.Path(@"c:\temp\file1.txt"), new MockFileData(@"line 1\r\nline 2"));
+
+            Assert.Throws<FileNotFoundException>(() => fileSystem.File.Replace(XFS.Path(@"c:\temp\file1.txt"), XFS.Path(@"c:\temp\file2.txt"), null));
+        }
+#endif
     }
 }

--- a/TestingHelpers/IMockFileDataAccessor.cs
+++ b/TestingHelpers/IMockFileDataAccessor.cs
@@ -52,6 +52,7 @@ namespace System.IO.Abstractions.TestingHelpers
         /// </summary>
         IEnumerable<string> AllDirectories { get; }
 
+        FileBase File { get; }
         DirectoryBase Directory { get; }
         IFileInfoFactory FileInfo {get; }
         PathBase Path { get; }

--- a/TestingHelpers/MockFile.cs
+++ b/TestingHelpers/MockFile.cs
@@ -525,12 +525,30 @@ namespace System.IO.Abstractions.TestingHelpers
 #if NET40
         public override void Replace(string sourceFileName, string destinationFileName, string destinationBackupFileName)
         {
-            throw new NotImplementedException(StringResources.Manager.GetString("NOT_IMPLEMENTED_EXCEPTION"));
+            Replace(sourceFileName, destinationFileName, destinationBackupFileName, false);
         }
 
         public override void Replace(string sourceFileName, string destinationFileName, string destinationBackupFileName, bool ignoreMetadataErrors)
         {
-            throw new NotImplementedException(StringResources.Manager.GetString("NOT_IMPLEMENTED_EXCEPTION"));
+            if (!File.Exists(sourceFileName))
+            {
+                throw new FileNotFoundException(string.Format(CultureInfo.InvariantCulture, StringResources.Manager.GetString("COULD_NOT_FIND_FILE_EXCEPTION"), sourceFileName));
+            }
+
+            if (!File.Exists(destinationFileName))
+            {
+                throw new FileNotFoundException(string.Format(CultureInfo.InvariantCulture, StringResources.Manager.GetString("COULD_NOT_FIND_FILE_EXCEPTION"), destinationFileName));
+            }
+
+            var mockFile = new MockFile(mockFileDataAccessor);
+
+            if (destinationBackupFileName != null)
+            {
+                mockFile.Copy(destinationFileName, destinationBackupFileName, true);
+            }
+
+            mockFile.Delete(destinationFileName);
+            mockFile.Move(sourceFileName, destinationFileName);
         }
 #endif
 

--- a/TestingHelpers/MockFile.cs
+++ b/TestingHelpers/MockFile.cs
@@ -530,12 +530,12 @@ namespace System.IO.Abstractions.TestingHelpers
 
         public override void Replace(string sourceFileName, string destinationFileName, string destinationBackupFileName, bool ignoreMetadataErrors)
         {
-            if (!File.Exists(sourceFileName))
+            if (!mockFileDataAccessor.FileExists(sourceFileName))
             {
                 throw new FileNotFoundException(string.Format(CultureInfo.InvariantCulture, StringResources.Manager.GetString("COULD_NOT_FIND_FILE_EXCEPTION"), sourceFileName));
             }
 
-            if (!File.Exists(destinationFileName))
+            if (!mockFileDataAccessor.FileExists(destinationFileName))
             {
                 throw new FileNotFoundException(string.Format(CultureInfo.InvariantCulture, StringResources.Manager.GetString("COULD_NOT_FIND_FILE_EXCEPTION"), destinationFileName));
             }

--- a/TestingHelpers/MockFileInfo.cs
+++ b/TestingHelpers/MockFileInfo.cs
@@ -266,12 +266,13 @@ namespace System.IO.Abstractions.TestingHelpers
 #if NET40
         public override FileInfoBase Replace(string destinationFileName, string destinationBackupFileName)
         {
-            throw new NotImplementedException(StringResources.Manager.GetString("NOT_IMPLEMENTED_EXCEPTION"));
+            return Replace(destinationFileName, destinationBackupFileName, false);
         }
 
         public override FileInfoBase Replace(string destinationFileName, string destinationBackupFileName, bool ignoreMetadataErrors)
         {
-            throw new NotImplementedException(StringResources.Manager.GetString("NOT_IMPLEMENTED_EXCEPTION"));
+            mockFileSystem.File.Replace(path, destinationFileName, destinationBackupFileName, ignoreMetadataErrors);
+            return new FileInfo(destinationFileName);
         }
 #endif
 


### PR DESCRIPTION
Replaces #164.

This implements the 2 overloads of `Replace` in each of `MockFile` and `MockFileInfo`, which previously threw exceptions.

Added 9 unit tests, 4 for `File.Replace`, 5 for `FileInfo.Replace`.

Incidentally, also added a `File` property to `IMockFileDataAccessor` so the `FileBase` would be accessible. Didn't need to implement the property as it already existed on `MockFileSystem`.

Implementation is surrounded with `#if NET40 ... #endif` as the `Replace` methods apparently don't exist in .NET Standard.

I'm going to copy my comment from the other PR in case it preempts any questions which held it up:

---

According to the [docs for System.IO.File.Replace](https://msdn.microsoft.com/en-us/library/system.io.file.replace(v=vs.110).aspx), it looks like a backup is part of the functionality. (EDIT: and, yes, it's also supposed to delete the source file. I confirmed this behavior by testing `System.IO.File.Replace`)

You can see [in the reference source](https://referencesource.microsoft.com/#mscorlib/system/io/file.cs,d4b8da02b41f19a4), it also mentions a backup path, although the actual operation is in native code.

This PR should probably also implement the test helper for File.Replace and implement FileInfo.Replace in terms of that, as [seen in the reference source](https://referencesource.microsoft.com/#mscorlib/system/io/fileinfo.cs,c41f2d5cbd26ee89).

---