### PR TITLE
Implementing MockDirectoryInfo.CreationTime

### DIFF
--- a/TestHelpers.Tests/MockDirectoryInfoTests.cs
+++ b/TestHelpers.Tests/MockDirectoryInfoTests.cs
@@ -348,7 +348,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             Assert.AreEqual(currentTime.ToUniversalTime(), fileSystem.DirectoryInfo.FromDirectoryName(directoryPath).CreationTimeUtc);
         }
 
-        [Test]
+        [Test, Ignore("Failing because MockDirectoryInfo adds trailing slash")]
         public void MockDirectoryInfo_CreationTime_ShouldWorkIfPathIsActuallyAFile()
         {
             // Arrange

--- a/TestHelpers.Tests/MockDirectoryInfoTests.cs
+++ b/TestHelpers.Tests/MockDirectoryInfoTests.cs
@@ -283,5 +283,85 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             // Assert
             Assert.AreEqual(directoryPath, str);
         }
+
+        [Test]
+        public void MockDirectoryInfo_CreationTime_ShouldBeAssignableAndRetainedUtc()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            var directoryPath = XFS.Path(@"c:\temp\folder\folder");
+            var currentTimeUtc = DateTime.UtcNow;
+
+            // Act
+            var directoryInfo = fileSystem.Directory.CreateDirectory(directoryPath);
+            directoryInfo.CreationTimeUtc = currentTimeUtc;
+
+            // Assert
+            Assert.AreEqual(currentTimeUtc, fileSystem.DirectoryInfo.FromDirectoryName(directoryPath).CreationTimeUtc);
+        }
+
+        [Test]
+        public void MockDirectoryInfo_CreationTime_ShouldBeAssignableAndRetainedLocal()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            var directoryPath = XFS.Path(@"c:\temp\folder\folder");
+            var currentTime = DateTime.Now;
+
+            // Act
+            var directoryInfo = fileSystem.Directory.CreateDirectory(directoryPath);
+            directoryInfo.CreationTime = currentTime;
+
+            // Assert
+            Assert.AreEqual(currentTime, fileSystem.DirectoryInfo.FromDirectoryName(directoryPath).CreationTime);
+        }
+
+        [Test]
+        public void MockDirectoryInfo_CreationTime_ShouldBeTranslatedFromUtcToLocal()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            var directoryPath = XFS.Path(@"c:\temp\folder\folder");
+            var currentTimeUtc = DateTime.UtcNow;
+
+            // Act
+            var directoryInfo = fileSystem.Directory.CreateDirectory(directoryPath);
+            directoryInfo.CreationTimeUtc = currentTimeUtc;
+
+            // Assert
+            Assert.AreEqual(currentTimeUtc.ToLocalTime(), fileSystem.DirectoryInfo.FromDirectoryName(directoryPath).CreationTime);
+        }
+
+        [Test]
+        public void MockDirectoryInfo_CreationTime_ShouldBeTranslatedFromLocalToUtc()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            var directoryPath = XFS.Path(@"c:\temp\folder\folder");
+            var currentTime = DateTime.Now;
+
+            // Act
+            var directoryInfo = fileSystem.Directory.CreateDirectory(directoryPath);
+            directoryInfo.CreationTime = currentTime;
+
+            // Assert
+            Assert.AreEqual(currentTime.ToUniversalTime(), fileSystem.DirectoryInfo.FromDirectoryName(directoryPath).CreationTimeUtc);
+        }
+
+        [Test]
+        public void MockDirectoryInfo_CreationTime_ShouldWorkIfPathIsActuallyAFile()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            var path = fileSystem.Path.GetTempFileName();
+            var currentTimeUtc = DateTime.UtcNow;
+
+            // Act
+            var directoryInfo = fileSystem.DirectoryInfo.FromDirectoryName(path);
+            directoryInfo.CreationTimeUtc = currentTimeUtc;
+
+            // Assert
+            Assert.AreEqual(currentTimeUtc, directoryInfo.CreationTimeUtc);
+        }
     }
 }

--- a/TestingHelpers/MockDirectoryInfo.cs
+++ b/TestingHelpers/MockDirectoryInfo.cs
@@ -53,14 +53,14 @@ namespace System.IO.Abstractions.TestingHelpers
 
         public override DateTime CreationTime
         {
-            get { throw new NotImplementedException(StringResources.Manager.GetString("NOT_IMPLEMENTED_EXCEPTION")); }
-            set { throw new NotImplementedException(StringResources.Manager.GetString("NOT_IMPLEMENTED_EXCEPTION")); }
+            get { return MockFileData.CreationTime.LocalDateTime; }
+            set { MockFileData.CreationTime = new DateTimeOffset(value); }
         }
 
         public override DateTime CreationTimeUtc
         {
-            get { throw new NotImplementedException(StringResources.Manager.GetString("NOT_IMPLEMENTED_EXCEPTION")); }
-            set { throw new NotImplementedException(StringResources.Manager.GetString("NOT_IMPLEMENTED_EXCEPTION")); }
+            get { return MockFileData.CreationTime.UtcDateTime; }
+            set { MockFileData.CreationTime = new DateTimeOffset(value, TimeSpan.FromHours(0)); }
         }
 
         public override bool Exists


### PR DESCRIPTION
Implemented `MockDirectoryInfo.CreationTime` by having the property look up the `MockFileData` for the directory on the instance field `mockFileDataAccessor`, like other properties and methods in the same class do.

Added unit tests to confirm date is assignable, retained and correctly translates between local time and UTC, so it can be assigned in either time zone and retrieved in either time zone and stay accurate.

**Potential Bug Identified**

The test `MockDirectoryInfo_CreationTime_ShouldWorkIfPathIsActuallyAFile` is currently failing. In the BCL, it is possible to create a `new DirectoryInfo` for a path to a file and the `CreationTime` is accessible and accurate, even though it's a `DirectoryInfo` pointing to a file (on Windows in .NET Framework anyway).

I wrote a sanity test to confirm the BCL exhibits this behavior:

```csharp
[Test]
public void WorksInBCL()
{
    var temp = Path.GetTempFileName();
    Console.WriteLine(temp); // "C:\Users\username\AppData\Local\Temp\tmpE451.tmp"
    Console.WriteLine();
    var dir = new DirectoryInfo(temp);
    Console.WriteLine(dir.FullName); // "C:\Users\username\AppData\Local\Temp\tmpE451.tmp"
    Console.WriteLine(dir.CreationTime); // shows approx the current time
}
```

This doesn't work in System.IO.Abstractions because the `MockFileSystem` disambiguates file and directory paths by looking for a trailing slash. `MockDirectoryInfo` adds a ensures there is a trailing slash on the path so `MockFileSystem` can make this distinction.

A separate issue can be opened for this if we want to deal with it. The test currently has the `Ignore` attribute. We could leave it there as a reminder or just remove it.