### PR TITLE
#245: Add comments via inheritdoc

### DIFF
--- a/System.IO.Abstractions/DirectoryBase.cs
+++ b/System.IO.Abstractions/DirectoryBase.cs
@@ -3,55 +3,141 @@ using System.Security.AccessControl;
 
 namespace System.IO.Abstractions
 {
+    /// <inheritdoc cref="Directory"/>
     [Serializable]
     public abstract class DirectoryBase
     {
+        /// <inheritdoc cref="Directory.CreateDirectory(string)"/>
         public abstract DirectoryInfoBase CreateDirectory(string path);
+
 #if NET40
+        /// <inheritdoc cref="Directory.CreateDirectory(string,DirectorySecurity)"/>
         public abstract DirectoryInfoBase CreateDirectory(string path, DirectorySecurity directorySecurity);
 #endif
+
+        /// <inheritdoc cref="Directory.Delete(string)"/>
         public abstract void Delete(string path);
+
+        /// <inheritdoc cref="Directory.Delete(string,bool)"/>
         public abstract void Delete(string path, bool recursive);
+
+        /// <inheritdoc cref="Directory.Exists"/>
         public abstract bool Exists(string path);
+
+        /// <inheritdoc cref="Directory.GetAccessControl(string)"/>
         public abstract DirectorySecurity GetAccessControl(string path);
+
+        /// <inheritdoc cref="Directory.GetAccessControl(string,AccessControlSections)"/>
         public abstract DirectorySecurity GetAccessControl(string path, AccessControlSections includeSections);
+
+        /// <inheritdoc cref="Directory.GetCreationTime"/>
         public abstract DateTime GetCreationTime(string path);
+
+        /// <inheritdoc cref="Directory.GetCreationTimeUtc"/>
         public abstract DateTime GetCreationTimeUtc(string path);
+
+        /// <inheritdoc cref="Directory.GetCurrentDirectory"/>
         public abstract string GetCurrentDirectory();
+
+        /// <inheritdoc cref="Directory.GetDirectories(string)"/>
         public abstract string[] GetDirectories(string path);
+
+        /// <inheritdoc cref="Directory.GetDirectories(string,string)"/>
         public abstract string[] GetDirectories(string path, string searchPattern);
+
+        /// <inheritdoc cref="Directory.GetDirectories(string,string,SearchOption)"/>
         public abstract string[] GetDirectories(string path, string searchPattern, SearchOption searchOption);
+
+        /// <inheritdoc cref="Directory.GetDirectoryRoot"/>
         public abstract string GetDirectoryRoot(string path);
+
+        /// <inheritdoc cref="Directory.GetFiles(string)"/>
         public abstract string[] GetFiles(string path);
+
+        /// <inheritdoc cref="Directory.GetFiles(string,string)"/>
         public abstract string[] GetFiles(string path, string searchPattern);
+
+        /// <inheritdoc cref="Directory.GetFiles(string,string,SearchOption)"/>
         public abstract string[] GetFiles(string path, string searchPattern, SearchOption searchOption);
+
+        /// <inheritdoc cref="Directory.GetFileSystemEntries(string)"/>
         public abstract string[] GetFileSystemEntries(string path);
+
+        /// <inheritdoc cref="Directory.GetFileSystemEntries(string,string)"/>
         public abstract string[] GetFileSystemEntries(string path, string searchPattern);
+
+        /// <inheritdoc cref="Directory.GetLastAccessTime"/>
         public abstract DateTime GetLastAccessTime(string path);
+
+        /// <inheritdoc cref="Directory.GetLastAccessTimeUtc"/>
         public abstract DateTime GetLastAccessTimeUtc(string path);
+
+        /// <inheritdoc cref="Directory.GetLastWriteTime"/>
         public abstract DateTime GetLastWriteTime(string path);
+
+        /// <inheritdoc cref="Directory.GetLastWriteTimeUtc"/>
         public abstract DateTime GetLastWriteTimeUtc(string path);
+
 #if NET40
+        /// <inheritdoc cref="Directory.GetLogicalDrives"/>
         public abstract string[] GetLogicalDrives();
 #endif
+
+        /// <inheritdoc cref="Directory.GetParent"/>
         public abstract DirectoryInfoBase GetParent(string path);
+
+        /// <inheritdoc cref="Directory.Move"/>
         public abstract void Move(string sourceDirName, string destDirName);
+
+        /// <inheritdoc cref="Directory.SetAccessControl"/>
         public abstract void SetAccessControl(string path, DirectorySecurity directorySecurity);
+
+        /// <inheritdoc cref="Directory.SetCreationTime"/>
         public abstract void SetCreationTime(string path, DateTime creationTime);
+
+        /// <inheritdoc cref="Directory.SetCreationTimeUtc"/>
         public abstract void SetCreationTimeUtc(string path, DateTime creationTimeUtc);
+
+        /// <inheritdoc cref="Directory.SetCurrentDirectory"/>
         public abstract void SetCurrentDirectory(string path);
+
+        /// <inheritdoc cref="Directory.SetLastAccessTime"/>
         public abstract void SetLastAccessTime(string path, DateTime lastAccessTime);
+
+        /// <inheritdoc cref="Directory.SetLastAccessTimeUtc"/>
         public abstract void SetLastAccessTimeUtc(string path, DateTime lastAccessTimeUtc);
+
+        /// <inheritdoc cref="Directory.SetLastWriteTime"/>
         public abstract void SetLastWriteTime(string path, DateTime lastWriteTime);
+
+        /// <inheritdoc cref="Directory.SetLastWriteTimeUtc"/>
         public abstract void SetLastWriteTimeUtc(string path, DateTime lastWriteTimeUtc);
+
+        /// <inheritdoc cref="Directory.EnumerateDirectories(string)"/>
         public abstract IEnumerable<String> EnumerateDirectories(String path);
+
+        /// <inheritdoc cref="Directory.EnumerateDirectories(string,string)"/>
         public abstract IEnumerable<String> EnumerateDirectories(String path, String searchPattern);
+
+        /// <inheritdoc cref="Directory.EnumerateDirectories(string,string,SearchOption)"/>
         public abstract IEnumerable<String> EnumerateDirectories(String path, String searchPattern, SearchOption searchOption);
+
+        /// <inheritdoc cref="Directory.EnumerateFiles(string)"/>
         public abstract IEnumerable<string> EnumerateFiles(string path);
+
+        /// <inheritdoc cref="Directory.EnumerateFiles(string,string)"/>
         public abstract IEnumerable<string> EnumerateFiles(string path, string searchPattern);
+
+        /// <inheritdoc cref="Directory.EnumerateFiles(string,string,SearchOption)"/>
         public abstract IEnumerable<string> EnumerateFiles(string path, string searchPattern, SearchOption searchOption);
+
+        /// <inheritdoc cref="Directory.EnumerateFileSystemEntries(string)"/>
         public abstract IEnumerable<string> EnumerateFileSystemEntries(string path);
+
+        /// <inheritdoc cref="Directory.EnumerateFileSystemEntries(string,string)"/>
         public abstract IEnumerable<string> EnumerateFileSystemEntries(string path, string searchPattern);
+
+        /// <inheritdoc cref="Directory.EnumerateFileSystemEntries(string,string,SearchOption)"/>
         public abstract IEnumerable<string> EnumerateFileSystemEntries(string path, string searchPattern, SearchOption searchOption);
     }
 }

--- a/System.IO.Abstractions/DirectoryInfoBase.cs
+++ b/System.IO.Abstractions/DirectoryInfoBase.cs
@@ -3,6 +3,7 @@ using System.Security.AccessControl;
 
 namespace System.IO.Abstractions
 {
+    /// <inheritdoc cref="DirectoryInfo"/>
     [Serializable]
     public abstract class DirectoryInfoBase : FileSystemInfoBase
     {

--- a/System.IO.Abstractions/DirectoryInfoBase.cs
+++ b/System.IO.Abstractions/DirectoryInfoBase.cs
@@ -7,38 +7,95 @@ namespace System.IO.Abstractions
     [Serializable]
     public abstract class DirectoryInfoBase : FileSystemInfoBase
     {
+        /// <inheritdoc cref="DirectoryInfo.Create()"/>
         public abstract void Create();
 #if NET40
+
+        /// <inheritdoc cref="DirectoryInfo.Create(DirectorySecurity)"/>
         public abstract void Create(DirectorySecurity directorySecurity);
 #endif
+
+        /// <inheritdoc cref="DirectoryInfo.CreateSubdirectory(string)"/>
         public abstract DirectoryInfoBase CreateSubdirectory(string path);
 #if NET40
+
+        /// <inheritdoc cref="DirectoryInfo.CreateSubdirectory(string,DirectorySecurity)"/>
         public abstract DirectoryInfoBase CreateSubdirectory(string path, DirectorySecurity directorySecurity);
 #endif
+
+        /// <inheritdoc cref="DirectoryInfo.Delete(bool)"/>
         public abstract void Delete(bool recursive);
+
+        /// <inheritdoc cref="DirectoryInfo.EnumerateDirectories()"/>
         public abstract IEnumerable<DirectoryInfoBase> EnumerateDirectories();
+
+        /// <inheritdoc cref="DirectoryInfo.EnumerateDirectories(string)"/>
         public abstract IEnumerable<DirectoryInfoBase> EnumerateDirectories(string searchPattern);
+
+        /// <inheritdoc cref="DirectoryInfo.EnumerateDirectories(string,SearchOption)"/>
         public abstract IEnumerable<DirectoryInfoBase> EnumerateDirectories(string searchPattern, SearchOption searchOption);
+
+        /// <inheritdoc cref="DirectoryInfo.EnumerateFiles()"/>
         public abstract IEnumerable<FileInfoBase> EnumerateFiles();
+
+        /// <inheritdoc cref="DirectoryInfo.EnumerateFiles(string)"/>
         public abstract IEnumerable<FileInfoBase> EnumerateFiles(string searchPattern);
+
+        /// <inheritdoc cref="DirectoryInfo.EnumerateFiles(string,SearchOption)"/>
         public abstract IEnumerable<FileInfoBase> EnumerateFiles(string searchPattern, SearchOption searchOption);
+
+        /// <inheritdoc cref="DirectoryInfo.EnumerateFileSystemInfos()"/>
         public abstract IEnumerable<FileSystemInfoBase> EnumerateFileSystemInfos();
+
+        /// <inheritdoc cref="DirectoryInfo.EnumerateFileSystemInfos(string)"/>
         public abstract IEnumerable<FileSystemInfoBase> EnumerateFileSystemInfos(string searchPattern);
+
+        /// <inheritdoc cref="DirectoryInfo.EnumerateFileSystemInfos(string,SearchOption)"/>
         public abstract IEnumerable<FileSystemInfoBase> EnumerateFileSystemInfos(string searchPattern, SearchOption searchOption);
+
+        /// <inheritdoc cref="DirectoryInfo.GetAccessControl()"/>
         public abstract DirectorySecurity GetAccessControl();
+
+        /// <inheritdoc cref="DirectoryInfo.GetAccessControl(AccessControlSections)"/>
         public abstract DirectorySecurity GetAccessControl(AccessControlSections includeSections);
+
+        /// <inheritdoc cref="DirectoryInfo.GetDirectories()"/>
         public abstract DirectoryInfoBase[] GetDirectories();
+
+        /// <inheritdoc cref="DirectoryInfo.GetDirectories(string)"/>
         public abstract DirectoryInfoBase[] GetDirectories(string searchPattern);
+
+        /// <inheritdoc cref="DirectoryInfo.GetDirectories(string,SearchOption)"/>
         public abstract DirectoryInfoBase[] GetDirectories(string searchPattern, SearchOption searchOption);
+
+        /// <inheritdoc cref="DirectoryInfo.GetFiles(string)"/>
         public abstract FileInfoBase[] GetFiles();
+
+        /// <inheritdoc cref="DirectoryInfo.GetFiles(string)"/>
         public abstract FileInfoBase[] GetFiles(string searchPattern);
+
+        /// <inheritdoc cref="DirectoryInfo.GetFiles(string,SearchOption)"/>
         public abstract FileInfoBase[] GetFiles(string searchPattern, SearchOption searchOption);
+
+        /// <inheritdoc cref="DirectoryInfo.GetFileSystemInfos()"/>
         public abstract FileSystemInfoBase[] GetFileSystemInfos();
+
+        /// <inheritdoc cref="DirectoryInfo.GetFileSystemInfos(string)"/>
         public abstract FileSystemInfoBase[] GetFileSystemInfos(string searchPattern);
+
+        /// <inheritdoc cref="DirectoryInfo.GetFileSystemInfos(string,SearchOption)"/>
         public abstract FileSystemInfoBase[] GetFileSystemInfos(string searchPattern, SearchOption searchOption);
+
+        /// <inheritdoc cref="DirectoryInfo.MoveTo"/>
         public abstract void MoveTo(string destDirName);
+
+        /// <inheritdoc cref="DirectoryInfo.SetAccessControl"/>
         public abstract void SetAccessControl(DirectorySecurity directorySecurity);
+
+        /// <inheritdoc cref="DirectoryInfo.Parent"/>
         public abstract DirectoryInfoBase Parent { get; }
+
+        /// <inheritdoc cref="DirectoryInfo.Root"/>
         public abstract DirectoryInfoBase Root { get; }
 
         public static implicit operator DirectoryInfoBase(DirectoryInfo directoryInfo)

--- a/System.IO.Abstractions/DriveInfoBase.cs
+++ b/System.IO.Abstractions/DriveInfoBase.cs
@@ -3,6 +3,7 @@
     [Serializable]
     public abstract class DriveInfoBase
     {
+        /// <inheritdoc cref="DriveInfo.AvailableFreeSpace"/>
         /// <summary>
         /// Gets or sets the amount of available free space on a drive, in bytes.
         /// </summary>
@@ -15,6 +16,7 @@
         /// <exception cref="IOException">Thrown if an I/O error occurred (for example, a disk error or a drive was not ready).</exception>
         public virtual long AvailableFreeSpace { get; protected set; }
 
+        /// <inheritdoc cref="DriveInfo.DriveFormat"/>
         /// <summary>
         /// Gets or sets the name of the file system, such as NTFS or FAT32.
         /// </summary>
@@ -27,6 +29,7 @@
         /// <exception cref="IOException">Thrown if an I/O error occurred (for example, a disk error or a drive was not ready).</exception>
         public virtual string DriveFormat { get; protected set; }
 
+        /// <inheritdoc cref="DriveInfo.DriveType"/>
         /// <summary>
         /// Gets or sets the drive type, such as CD-ROM, removable, network, or fixed.
         /// </summary>
@@ -37,6 +40,7 @@
         /// </remarks>
         public virtual DriveType DriveType { get; protected set; }
 
+        /// <inheritdoc cref="DriveInfo.IsReady"/>
         /// <summary>
         /// Gets or sets a value indicating whether a drive is ready.
         /// </summary>
@@ -53,6 +57,7 @@
         /// </remarks>
         public virtual bool IsReady { get; protected set; }
 
+        /// <inheritdoc cref="DriveInfo.Name"/>
         /// <summary>
         /// Gets or sets the name of a drive, such as C:\.
         /// </summary>
@@ -62,12 +67,14 @@
         /// </remarks>
         public virtual string Name { get; protected set; }
 
+        /// <inheritdoc cref="DriveInfo.RootDirectory"/>
         /// <summary>
         /// Gets or sets the root directory of a drive.
         /// </summary>
         /// <value>An object that contains the root directory of the drive.</value>
         public virtual DirectoryInfoBase RootDirectory { get; protected set; }
 
+        /// <inheritdoc cref="DriveInfo.TotalFreeSpace"/>
         /// <summary>
         /// Gets or sets the total amount of free space available on a drive, in bytes.
         /// </summary>
@@ -78,6 +85,7 @@
         /// <exception cref="IOException">Thrown if an I/O error occurred (for example, a disk error or a drive was not ready).</exception>
         public virtual long TotalFreeSpace { get; protected set; }
 
+        /// <inheritdoc cref="DriveInfo.TotalSize"/>
         /// <summary>
         /// Gets or sets the total size of storage space on a drive, in bytes.
         /// </summary>
@@ -90,6 +98,7 @@
         /// <exception cref="IOException">Thrown if an I/O error occurred (for example, a disk error or a drive was not ready).</exception>
         public virtual long TotalSize { get; protected set; }
 
+        /// <inheritdoc cref="DriveInfo.VolumeLabel"/>
         /// <summary>
         /// Gets or sets the volume label of a drive.
         /// </summary>

--- a/System.IO.Abstractions/FileBase.cs
+++ b/System.IO.Abstractions/FileBase.cs
@@ -4,6 +4,7 @@ using System.Text;
 
 namespace System.IO.Abstractions
 {
+    /// <inheritdoc cref="File"/>
     [Serializable]
     public abstract class FileBase
     {

--- a/System.IO.Abstractions/FileBase.cs
+++ b/System.IO.Abstractions/FileBase.cs
@@ -7,28 +7,54 @@ namespace System.IO.Abstractions
     [Serializable]
     public abstract class FileBase
     {
+        /// <inheritdoc cref="File.AppendAllLines(string,IEnumerable{string})"/>
         public abstract void AppendAllLines(string path, IEnumerable<string> contents);
+
+        /// <inheritdoc cref="File.AppendAllLines(string,IEnumerable{string},Encoding)"/>
         public abstract void AppendAllLines(string path, IEnumerable<string> contents, Encoding encoding);
+
+        /// <inheritdoc cref="File.AppendAllText(string,string)"/>
         public abstract void AppendAllText(string path, string contents);
+
+        /// <inheritdoc cref="File.AppendAllText(string,string,Encoding)"/>
         public abstract void AppendAllText(string path, string contents, Encoding encoding);
+
+        /// <inheritdoc cref="File.AppendText"/>
         public abstract StreamWriter AppendText(string path);
+
+        /// <inheritdoc cref="File.Copy(string,string)"/>
         public abstract void Copy(string sourceFileName, string destFileName);
+
+        /// <inheritdoc cref="File.Copy(string,string,bool)"/>
         public abstract void Copy(string sourceFileName, string destFileName, bool overwrite);
+
+        /// <inheritdoc cref="File.Create(string)"/>
         public abstract Stream Create(string path);
+
+        /// <inheritdoc cref="File.Create(string,int)"/>
         public abstract Stream Create(string path, int bufferSize);
+
+        /// <inheritdoc cref="File.Create(string,int,FileOptions)"/>
         public abstract Stream Create(string path, int bufferSize, FileOptions options);
+
 #if NET40
+        /// <inheritdoc cref="File.Create(string,int,FileOptions,FileSecurity)"/>
         public abstract Stream Create(string path, int bufferSize, FileOptions options, FileSecurity fileSecurity);
 #endif
+        /// <inheritdoc cref="File.CreateText"/>
         public abstract StreamWriter CreateText(string path);
 #if NET40
+        /// <inheritdoc cref="File.Decrypt"/>
         public abstract void Decrypt(string path);
 #endif
+        /// <inheritdoc cref="File.Delete"/>
         public abstract void Delete(string path);
 #if NET40
+        /// <inheritdoc cref="File.Encrypt"/>
         public abstract void Encrypt(string path);
 #endif
 
+        /// <inheritdoc cref="File.Exists"/>
         /// <summary>
         /// Determines whether the specified file exists.
         /// </summary>
@@ -57,9 +83,14 @@ namespace System.IO.Abstractions
         /// </para>
         /// </remarks>
         public abstract bool Exists(string path);
+
+        /// <inheritdoc cref="File.GetAccessControl(string)"/>
         public abstract FileSecurity GetAccessControl(string path);
+
+        /// <inheritdoc cref="File.GetAccessControl(string,AccessControlSections)"/>
         public abstract FileSecurity GetAccessControl(string path, AccessControlSections includeSections);
 
+        /// <inheritdoc cref="File.GetAttributes"/>
         /// <summary>
         /// Gets the <see cref="FileAttributes"/> of the file on the path.
         /// </summary>
@@ -74,6 +105,7 @@ namespace System.IO.Abstractions
         /// <exception cref="UnauthorizedAccessException">The caller does not have the required permission.</exception>
         public abstract FileAttributes GetAttributes(string path);
 
+        /// <inheritdoc cref="File.GetCreationTime"/>
         /// <summary>
         /// Returns the creation date and time of the specified file or directory.
         /// </summary>
@@ -97,6 +129,7 @@ namespace System.IO.Abstractions
         /// </remarks>
         public abstract DateTime GetCreationTime(string path);
 
+        /// <inheritdoc cref="File.GetCreationTimeUtc"/>
         /// <summary>
         /// Returns the creation date and time, in coordinated universal time (UTC), of the specified file or directory.
         /// </summary>
@@ -120,6 +153,7 @@ namespace System.IO.Abstractions
         /// </remarks>
         public abstract DateTime GetCreationTimeUtc(string path);
 
+        /// <inheritdoc cref="File.GetLastAccessTime"/>
         /// <summary>
         /// Returns the date and time the specified file or directory was last accessed.
         /// </summary>
@@ -143,6 +177,7 @@ namespace System.IO.Abstractions
         /// </remarks>
         public abstract DateTime GetLastAccessTime(string path);
 
+        /// <inheritdoc cref="File.GetLastAccessTimeUtc"/>
         /// <summary>
         /// Returns the date and time, in coordinated universal time (UTC), that the specified file or directory was last accessed.
         /// </summary>
@@ -166,6 +201,7 @@ namespace System.IO.Abstractions
         /// </remarks>
         public abstract DateTime GetLastAccessTimeUtc(string path);
 
+        /// <inheritdoc cref="File.GetLastWriteTime"/>
         /// <summary>
         /// Returns the date and time the specified file or directory was last written to.
         /// </summary>
@@ -189,6 +225,7 @@ namespace System.IO.Abstractions
         /// </remarks>
         public abstract DateTime GetLastWriteTime(string path);
 
+        /// <inheritdoc cref="File.GetLastWriteTimeUtc"/>
         /// <summary>
         /// Returns the date and time, in coordinated universal time (UTC), that the specified file or directory was last written to.
         /// </summary>
@@ -211,33 +248,82 @@ namespace System.IO.Abstractions
         /// </para>
         /// </remarks>
         public abstract DateTime GetLastWriteTimeUtc(string path);
+
+        /// <inheritdoc cref="File.Move"/>
         public abstract void Move(string sourceFileName, string destFileName);
+
+        /// <inheritdoc cref="File.Open(string,FileMode)"/>
         public abstract Stream Open(string path, FileMode mode);
+
+        /// <inheritdoc cref="File.Open(string,FileMode,FileAccess)"/>
         public abstract Stream Open(string path, FileMode mode, FileAccess access);
+
+        /// <inheritdoc cref="File.Open(string,FileMode,FileAccess,FileShare)"/>
         public abstract Stream Open(string path, FileMode mode, FileAccess access, FileShare share);
+
+        /// <inheritdoc cref="File.OpenRead"/>
         public abstract Stream OpenRead(string path);
+
+        /// <inheritdoc cref="File.OpenText"/>
         public abstract StreamReader OpenText(string path);
+
+        /// <inheritdoc cref="File.OpenWrite"/>
         public abstract Stream OpenWrite(string path);
+
+        /// <inheritdoc cref="File.ReadAllBytes"/>
         public abstract byte[] ReadAllBytes(string path);
+
+        /// <inheritdoc cref="File.ReadAllLines(string)"/>
         public abstract string[] ReadAllLines(string path);
+
+        /// <inheritdoc cref="File.ReadAllLines(string,Encoding)"/>
         public abstract string[] ReadAllLines(string path, Encoding encoding);
+
+        /// <inheritdoc cref="File.ReadAllText(string)"/>
         public abstract string ReadAllText(string path);
+
+        /// <inheritdoc cref="File.ReadAllText(string,Encoding)"/>
         public abstract string ReadAllText(string path, Encoding encoding);
+
+        /// <inheritdoc cref="File.ReadLines(string)"/>
         public abstract IEnumerable<string> ReadLines(string path);
+
+        /// <inheritdoc cref="File.ReadLines(string,Encoding)"/>
         public abstract IEnumerable<string> ReadLines(string path, Encoding encoding);
+
 #if NET40
+        /// <inheritdoc cref="File.Replace(string,string,string)"/>
         public abstract void Replace(string sourceFileName, string destinationFileName, string destinationBackupFileName);
+
+        /// <inheritdoc cref="File.Replace(string,string,string,bool)"/>
         public abstract void Replace(string sourceFileName, string destinationFileName, string destinationBackupFileName, bool ignoreMetadataErrors);
 #endif
+
+        /// <inheritdoc cref="File.SetAccessControl(string,FileSecurity)"/>
         public abstract void SetAccessControl(string path, FileSecurity fileSecurity);
+
+        /// <inheritdoc cref="File.SetAttributes"/>
         public abstract void SetAttributes(string path, FileAttributes fileAttributes);
+
+        /// <inheritdoc cref="File.SetCreationTime"/>
         public abstract void SetCreationTime(string path, DateTime creationTime);
+
+        /// <inheritdoc cref="File.SetCreationTimeUtc"/>
         public abstract void SetCreationTimeUtc(string path, DateTime creationTimeUtc);
+
+        /// <inheritdoc cref="File.SetLastAccessTime"/>
         public abstract void SetLastAccessTime(string path, DateTime lastAccessTime);
+
+        /// <inheritdoc cref="File.SetLastAccessTimeUtc"/>
         public abstract void SetLastAccessTimeUtc(string path, DateTime lastAccessTimeUtc);
+
+        /// <inheritdoc cref="File.SetLastWriteTime"/>
         public abstract void SetLastWriteTime(string path, DateTime lastWriteTime);
+
+        /// <inheritdoc cref="File.SetLastWriteTimeUtc"/>
         public abstract void SetLastWriteTimeUtc(string path, DateTime lastWriteTimeUtc);
 
+        /// <inheritdoc cref="File.WriteAllBytes"/>
         /// <summary>
         /// Creates a new file, writes the specified byte array to the file, and then closes the file.
         /// If the target file already exists, it is overwritten.
@@ -269,6 +355,7 @@ namespace System.IO.Abstractions
         /// </remarks>
         public abstract void WriteAllBytes(string path, byte[] bytes);
 
+        /// <inheritdoc cref="File.WriteAllLines(string,IEnumerable{string})"/>
         /// <summary>
         /// Creates a new file, writes a collection of strings to the file, and then closes the file.
         /// </summary>
@@ -304,6 +391,7 @@ namespace System.IO.Abstractions
         /// </remarks>
         public abstract void WriteAllLines(string path, IEnumerable<string> contents);
 
+        /// <inheritdoc cref="File.WriteAllLines(string,IEnumerable{string},Encoding)"/>
         /// <summary>
         /// Creates a new file by using the specified encoding, writes a collection of strings to the file, and then closes the file.
         /// </summary>
@@ -348,6 +436,7 @@ namespace System.IO.Abstractions
         /// </remarks>
         public abstract void WriteAllLines(string path, IEnumerable<string> contents, Encoding encoding);
 
+        /// <inheritdoc cref="File.WriteAllLines(string,string[])"/>
         /// <summary>
         /// Creates a new file, writes the specified string array to the file by using the specified encoding, and then closes the file.
         /// </summary>
@@ -387,6 +476,7 @@ namespace System.IO.Abstractions
         /// </remarks>
         public abstract void WriteAllLines(string path, string[] contents);
 
+        /// <inheritdoc cref="File.WriteAllLines(string,string[],Encoding)"/>
         /// <summary>
         /// Creates a new file, writes the specified string array to the file by using the specified encoding, and then closes the file.
         /// </summary>
@@ -424,6 +514,7 @@ namespace System.IO.Abstractions
         /// </remarks>
         public abstract void WriteAllLines(string path, string[] contents, Encoding encoding);
 
+        /// <inheritdoc cref="File.WriteAllText(string,string)"/>
         /// <summary>
         /// Creates a new file, writes the specified string to the file using the specified encoding, and then closes the file. If the target file already exists, it is overwritten.
         /// </summary>
@@ -458,6 +549,7 @@ namespace System.IO.Abstractions
         /// </remarks>
         public abstract void WriteAllText(string path, string contents);
 
+        /// <inheritdoc cref="File.WriteAllText(string,string,Encoding)"/>
         /// <summary>
         /// Creates a new file, writes the specified string to the file using the specified encoding, and then closes the file. If the target file already exists, it is overwritten.
         /// </summary>

--- a/System.IO.Abstractions/FileInfoBase.cs
+++ b/System.IO.Abstractions/FileInfoBase.cs
@@ -31,7 +31,7 @@ namespace System.IO.Abstractions
         /// <inheritdoc cref="FileInfo.GetAccessControl()"/>
         public abstract FileSecurity GetAccessControl();
 
-        /// <inheritdoc cref="FileInfo.GetAccessControl(AccessControlActions)"/>
+        /// <inheritdoc cref="FileInfo.GetAccessControl(AccessControlSections)"/>
         public abstract FileSecurity GetAccessControl(AccessControlSections includeSections);
 
         /// <inheritdoc cref="FileInfo.MoveTo"/>

--- a/System.IO.Abstractions/FileInfoBase.cs
+++ b/System.IO.Abstractions/FileInfoBase.cs
@@ -2,6 +2,7 @@
 
 namespace System.IO.Abstractions
 {
+    /// <inheritdoc cref="FileInfo"/>
     [Serializable]
     public abstract class FileInfoBase : FileSystemInfoBase
     {

--- a/System.IO.Abstractions/FileInfoBase.cs
+++ b/System.IO.Abstractions/FileInfoBase.cs
@@ -5,32 +5,77 @@ namespace System.IO.Abstractions
     [Serializable]
     public abstract class FileInfoBase : FileSystemInfoBase
     {
+        /// <inheritdoc cref="FileInfo.AppendText"/>
         public abstract StreamWriter AppendText();
+
+        /// <inheritdoc cref="FileInfo.CopyTo(string)"/>
         public abstract FileInfoBase CopyTo(string destFileName);
+
+        /// <inheritdoc cref="FileInfo.CopyTo(string,bool)"/>
         public abstract FileInfoBase CopyTo(string destFileName, bool overwrite);
+
+        /// <inheritdoc cref="FileInfo.Create"/>
         public abstract Stream Create();
+
+        /// <inheritdoc cref="FileInfo.CreateText"/>
         public abstract StreamWriter CreateText();
+
 #if NET40
+        /// <inheritdoc cref="FileInfo.Decrypt"/>
         public abstract void Decrypt();
+
+        /// <inheritdoc cref="FileInfo.Encrypt"/>
         public abstract void Encrypt();
 #endif
+
+        /// <inheritdoc cref="FileInfo.GetAccessControl()"/>
         public abstract FileSecurity GetAccessControl();
+
+        /// <inheritdoc cref="FileInfo.GetAccessControl(AccessControlActions)"/>
         public abstract FileSecurity GetAccessControl(AccessControlSections includeSections);
+
+        /// <inheritdoc cref="FileInfo.MoveTo"/>
         public abstract void MoveTo(string destFileName);
+
+        /// <inheritdoc cref="FileInfo.Open(FileMode)"/>
         public abstract Stream Open(FileMode mode);
+
+        /// <inheritdoc cref="FileInfo.Open(FileMode,FileAccess)"/>
         public abstract Stream Open(FileMode mode, FileAccess access);
+
+        /// <inheritdoc cref="FileInfo.Open(FileMode,FileAccess,FileShare)"/>
         public abstract Stream Open(FileMode mode, FileAccess access, FileShare share);
+
+        /// <inheritdoc cref="FileInfo.OpenRead"/>
         public abstract Stream OpenRead();
+
+        /// <inheritdoc cref="FileInfo.OpenText"/>
         public abstract StreamReader OpenText();
+
+        /// <inheritdoc cref="FileInfo.OpenWrite"/>
         public abstract Stream OpenWrite();
+
 #if NET40
+        /// <inheritdoc cref="FileInfo.Replace(string,string)"/>
         public abstract FileInfoBase Replace(string destinationFileName, string destinationBackupFileName);
+
+        /// <inheritdoc cref="FileInfo.Replace(string,string,bool)"/>
         public abstract FileInfoBase Replace(string destinationFileName, string destinationBackupFileName, bool ignoreMetadataErrors);
 #endif
+
+        /// <inheritdoc cref="FileInfo.SetAccessControl(FileSecurity)"/>
         public abstract void SetAccessControl(FileSecurity fileSecurity);
+
+        /// <inheritdoc cref="FileInfo.Directory"/>
         public abstract DirectoryInfoBase Directory { get; }
+
+        /// <inheritdoc cref="FileInfo.DirectoryName"/>
         public abstract string DirectoryName { get; }
+
+        /// <inheritdoc cref="FileInfo.IsReadOnly"/>
         public abstract bool IsReadOnly { get; set; }
+
+        /// <inheritdoc cref="FileInfo.Length"/>
         public abstract long Length { get; }
 
         public static implicit operator FileInfoBase(FileInfo fileInfo)

--- a/System.IO.Abstractions/FileSystemInfoBase.cs
+++ b/System.IO.Abstractions/FileSystemInfoBase.cs
@@ -1,20 +1,46 @@
 ﻿namespace System.IO.Abstractions
 {
+    /// <inheritdoc cref="FileSystemInfo"/>
     [Serializable]
     public abstract class FileSystemInfoBase
     {
+        /// <inheritdoc cref="FileSystemInfo.Delete"/>
         public abstract void Delete();
+
+        /// <inheritdoc cref="FileSystemInfo.Refresh"/>
         public abstract void Refresh();
+
+        /// <inheritdoc cref="FileSystemInfo.Attributes"/>
         public abstract FileAttributes Attributes { get; set; }
+
+        /// <inheritdoc cref="FileSystemInfo.CreationTime"/>
         public abstract DateTime CreationTime { get; set; }
+
+        /// <inheritdoc cref="FileSystemInfo.CreationTimeUtc"/>
         public abstract DateTime CreationTimeUtc { get; set; }
+
+        /// <inheritdoc cref="FileSystemInfo.Exists"/>
         public abstract bool Exists { get; }
+
+        /// <inheritdoc cref="FileSystemInfo.Extension"/>
         public abstract string Extension { get; }
+
+        /// <inheritdoc cref="FileSystemInfo.FullName"/>
         public abstract string FullName { get; }
+
+        /// <inheritdoc cref="FileSystemInfo.LastAccessTime"/>
         public abstract DateTime LastAccessTime { get; set; }
+
+        /// <inheritdoc cref="FileSystemInfo.LastAccessTimeUtc"/>
         public abstract DateTime LastAccessTimeUtc { get; set; }
+
+        /// <inheritdoc cref="FileSystemInfo.LastWriteTime"/>
         public abstract DateTime LastWriteTime { get; set; }
+
+        /// <inheritdoc cref="FileSystemInfo.LastWriteTimeUtc"/>
         public abstract DateTime LastWriteTimeUtc { get; set; }
+
+        /// <inheritdoc cref="FileSystemInfo.Name"/>
         public abstract string Name { get; }
     }
 }

--- a/System.IO.Abstractions/FileSystemWatcherBase.cs
+++ b/System.IO.Abstractions/FileSystemWatcherBase.cs
@@ -2,6 +2,7 @@
 
 namespace System.IO.Abstractions
 {
+    /// <inheritdoc cref="FileSystemWatcher"/>
     [Serializable]
     public abstract class FileSystemWatcherBase : IDisposable
     {

--- a/System.IO.Abstractions/FileSystemWatcherBase.cs
+++ b/System.IO.Abstractions/FileSystemWatcherBase.cs
@@ -5,24 +5,52 @@ namespace System.IO.Abstractions
     [Serializable]
     public abstract class FileSystemWatcherBase : IDisposable
     {
+        /// <inheritdoc cref="FileSystemWatcher.IncludeSubdirectories"/>
         public abstract bool IncludeSubdirectories { get; set; }
+
+        /// <inheritdoc cref="FileSystemWatcher.EnableRaisingEvents"/>
         public abstract bool EnableRaisingEvents { get; set; }
+
+        /// <inheritdoc cref="FileSystemWatcher.Filter"/>
         public abstract string Filter { get; set; }
+
+        /// <inheritdoc cref="FileSystemWatcher.InternalBufferSize"/>
         public abstract int InternalBufferSize { get; set; }
+
+        /// <inheritdoc cref="FileSystemWatcher.NotifyFilter"/>
         public abstract NotifyFilters NotifyFilter { get; set; }
+
+        /// <inheritdoc cref="FileSystemWatcher.Path"/>
         public abstract string Path { get; set; }
+
 #if NET40
+        /// <inheritdoc cref="FileSystemWatcher.Site"/>
         public abstract ISite Site { get; set; }
+
+        /// <inheritdoc cref="FileSystemWatcher.SynchronizingObject"/>
         public abstract ISynchronizeInvoke SynchronizingObject { get; set; }
 #endif
+
+        /// <inheritdoc cref="FileSystemWatcher.Changed"/>
         public virtual event FileSystemEventHandler Changed;
+
+        /// <inheritdoc cref="FileSystemWatcher.Created"/>
         public virtual event FileSystemEventHandler Created;
+
+        /// <inheritdoc cref="FileSystemWatcher.Deleted"/>
         public virtual event FileSystemEventHandler Deleted;
+
+        /// <inheritdoc cref="FileSystemWatcher.Error"/>
         public virtual event ErrorEventHandler Error;
+
+        /// <inheritdoc cref="FileSystemWatcher.Renamed"/>
         public virtual event RenamedEventHandler Renamed;
+
 #if NET40
+        /// <inheritdoc cref="FileSystemWatcher.BeginInit"/>
         public abstract void BeginInit();
 #endif
+
         public void Dispose()
         {
             Dispose(true);
@@ -30,9 +58,14 @@ namespace System.IO.Abstractions
         }
 
 #if NET40
+        /// <inheritdoc cref="FileSystemWatcher.EndInit"/>
         public abstract void EndInit();
 #endif
+
+        /// <inheritdoc cref="FileSystemWatcher.WaitForChanged(WatcherChangeTypes)"/>
         public abstract WaitForChangedResult WaitForChanged(WatcherChangeTypes changeType);
+
+        /// <inheritdoc cref="FileSystemWatcher.WaitForChanged(WatcherChangeTypes,int)"/>
         public abstract WaitForChangedResult WaitForChanged(WatcherChangeTypes changeType, int timeout);
 
         public static implicit operator FileSystemWatcherBase(FileSystemWatcher watcher)

--- a/System.IO.Abstractions/PathBase.cs
+++ b/System.IO.Abstractions/PathBase.cs
@@ -1,5 +1,6 @@
 ﻿namespace System.IO.Abstractions
 {
+    /// <inheritdoc cref="Path"/>
     [Serializable]
     public abstract class PathBase
     {

--- a/System.IO.Abstractions/PathBase.cs
+++ b/System.IO.Abstractions/PathBase.cs
@@ -3,32 +3,76 @@
     [Serializable]
     public abstract class PathBase
     {
+        /// <inheritdoc cref="Path.AltDirectorySeparatorChar"/>
         public abstract char AltDirectorySeparatorChar { get; }
+
+        /// <inheritdoc cref="Path.DirectorySeparatorChar"/>
         public abstract char DirectorySeparatorChar { get; }
+
 #if NET40
+        /// <inheritdoc cref="Path.InvalidPathChars"/>
         [Obsolete("Please use GetInvalidPathChars or GetInvalidFileNameChars instead.")]
         public abstract char[] InvalidPathChars { get; }
 #endif
+
+        /// <inheritdoc cref="Path.PathSeparator"/>
         public abstract char PathSeparator { get; }
+
+        /// <inheritdoc cref="Path.VolumeSeparatorChar"/>
         public abstract char VolumeSeparatorChar { get; }
 
+        /// <inheritdoc cref="Path.ChangeExtension"/>
         public abstract string ChangeExtension(string path, string extension);
+
+        /// <inheritdoc cref="Path.Combine(string[])"/>
         public abstract string Combine(params string[] paths);
+
+        /// <inheritdoc cref="Path.Combine(string,string)"/>
         public abstract string Combine(string path1, string path2);
+
+        /// <inheritdoc cref="Path.Combine(string,string,string)"/>
         public abstract string Combine(string path1, string path2, string path3);
+
+        /// <inheritdoc cref="Path.Combine(string,string,string,string)"/>
         public abstract string Combine(string path1, string path2, string path3, string path4);
+
+        /// <inheritdoc cref="Path.GetDirectoryName"/>
         public abstract string GetDirectoryName(string path);
+
+        /// <inheritdoc cref="Path.GetExtension"/>
         public abstract string GetExtension(string path);
+
+        /// <inheritdoc cref="Path.GetFileName"/>
         public abstract string GetFileName(string path);
+
+        /// <inheritdoc cref="Path.GetFileNameWithoutExtension"/>
         public abstract string GetFileNameWithoutExtension(string path);
+
+        /// <inheritdoc cref="Path.GetFullPath"/>
         public abstract string GetFullPath(string path);
+
+        /// <inheritdoc cref="Path.GetInvalidFileNameChars"/>
         public abstract char[] GetInvalidFileNameChars();
+
+        /// <inheritdoc cref="Path.GetInvalidPathChars"/>
         public abstract char[] GetInvalidPathChars();
+
+        /// <inheritdoc cref="Path.GetPathRoot"/>
         public abstract string GetPathRoot(string path);
+
+        /// <inheritdoc cref="Path.GetRandomFileName"/>
         public abstract string GetRandomFileName();
+
+        /// <inheritdoc cref="Path.GetTempFileName"/>
         public abstract string GetTempFileName();
+
+        /// <inheritdoc cref="Path.GetTempPath"/>
         public abstract string GetTempPath();
+
+        /// <inheritdoc cref="Path.HasExtension"/>
         public abstract bool HasExtension(string path);
+
+        /// <inheritdoc cref="Path.IsPathRooted"/>
         public abstract bool IsPathRooted(string path);
     }
 }

--- a/System.IO.Abstractions/System.IO.Abstractions.csproj
+++ b/System.IO.Abstractions/System.IO.Abstractions.csproj
@@ -21,6 +21,14 @@
         <SignAssembly>True</SignAssembly>
     </PropertyGroup>
 
+    <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net40|AnyCPU'">
+      <DocumentationFile>bin\Debug\net40\System.IO.Abstractions.xml</DocumentationFile>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net40|AnyCPU'">
+      <DocumentationFile>bin\Release\net40\System.IO.Abstractions.xml</DocumentationFile>
+    </PropertyGroup>
+
     <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">
         <PackageReference Include="System.IO.FileSystem.AccessControl">
             <Version>4.5.0</Version>


### PR DESCRIPTION
This commit is part of [Issue #245](https://github.com/System-IO-Abstractions/System.IO.Abstractions/issues/245) and adds comments using the inheritdoc tag. At present visual studio does not recognise these tags, so intellisense won't display them, but other tools such as ReSharper will.

The next stage is to modify the appveyor.yml and use the InheritDoc nuget package to modify the xml documentation on deployment. This will be a separate pull request.