### PR TITLE
Implement AccessControl on FileInfo

### DIFF
--- a/TestHelpers.Tests/MockDirectoryInfoAccessControlTests.cs
+++ b/TestHelpers.Tests/MockDirectoryInfoAccessControlTests.cs
@@ -1,0 +1,64 @@
+﻿using NUnit.Framework;
+using System.Collections.Generic;
+
+namespace System.IO.Abstractions.TestingHelpers.Tests
+{
+    using Security.AccessControl;
+    using XFS = MockUnixSupport;
+
+    [TestFixture]
+    [WindowsOnly(WindowsSpecifics.AccessControlLists)]
+    public class MockDirectoryInfoAccessControlTests
+    {
+        [Test]
+        public void MockDirectoryInfo_GetAccessControl_ShouldReturnAccessControlOfDirectoryData()
+        {
+            // Arrange
+            var expectedDirectorySecurity = new DirectorySecurity();
+            expectedDirectorySecurity.SetAccessRuleProtection(false, false);
+
+            var filePath = XFS.Path(@"c:\a\");
+            var fileData = new MockDirectoryData()
+            {
+                AccessControl = expectedDirectorySecurity,
+            };
+
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>()
+            {
+                { filePath, fileData }
+            });
+
+            var directorInfo = fileSystem.DirectoryInfo.FromDirectoryName(filePath);
+
+            // Act
+            var directorySecurity = directorInfo.GetAccessControl();
+
+            // Assert
+            Assert.That(directorySecurity, Is.EqualTo(expectedDirectorySecurity));
+        }
+
+        [Test]
+        public void MockDirectoryInfo_SetAccessControl_ShouldReturnAccessControlOfDirectoryData()
+        {
+            // Arrange
+            var filePath = XFS.Path(@"c:\a\");
+            var fileData = new MockDirectoryData();
+
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>()
+            {
+                { filePath, fileData }
+            });
+
+            var directorInfo = fileSystem.DirectoryInfo.FromDirectoryName(filePath);
+
+            // Act
+            var expectedAccessControl = new DirectorySecurity();
+            expectedAccessControl.SetAccessRuleProtection(false, false);
+            directorInfo.SetAccessControl(expectedAccessControl);
+
+            // Assert
+            var accessControl = directorInfo.GetAccessControl();
+            Assert.That(accessControl, Is.EqualTo(expectedAccessControl));
+        }
+    }
+}

--- a/TestHelpers.Tests/MockDirectoryInfoAccessControlTests.cs
+++ b/TestHelpers.Tests/MockDirectoryInfoAccessControlTests.cs
@@ -1,11 +1,10 @@
 ﻿using NUnit.Framework;
 using System.Collections.Generic;
+using System.Security.AccessControl;
+using XFS = System.IO.Abstractions.TestingHelpers.MockUnixSupport;
 
 namespace System.IO.Abstractions.TestingHelpers.Tests
 {
-    using Security.AccessControl;
-    using XFS = MockUnixSupport;
-
     [TestFixture]
     [WindowsOnly(WindowsSpecifics.AccessControlLists)]
     public class MockDirectoryInfoAccessControlTests
@@ -38,7 +37,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
-        public void MockDirectoryInfo_SetAccessControl_ShouldReturnAccessControlOfDirectoryData()
+        public void MockDirectoryInfo_SetAccessControl_ShouldSetAccessControlOfDirectoryData()
         {
             // Arrange
             var filePath = XFS.Path(@"c:\a\");

--- a/TestHelpers.Tests/MockDirectorySetAccessControlTests.cs
+++ b/TestHelpers.Tests/MockDirectorySetAccessControlTests.cs
@@ -45,7 +45,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
-        public void MockDirectory_SetAccessControl_ShouldReturnAccessControlOfDirectoryData()
+        public void MockDirectory_SetAccessControl_ShouldSetAccessControlOfDirectoryData()
         {
             // Arrange
             var filePath = XFS.Path(@"c:\a\");

--- a/TestHelpers.Tests/MockFileInfoAccessControlTests.cs
+++ b/TestHelpers.Tests/MockFileInfoAccessControlTests.cs
@@ -1,11 +1,10 @@
 ﻿using NUnit.Framework;
 using System.Collections.Generic;
 using System.Security.AccessControl;
+using XFS = System.IO.Abstractions.TestingHelpers.MockUnixSupport;
 
 namespace System.IO.Abstractions.TestingHelpers.Tests
 {
-    using XFS = MockUnixSupport;
-
     [TestFixture]
     [WindowsOnly(WindowsSpecifics.AccessControlLists)]
     public class MockFileInfoAccessControlTests
@@ -38,7 +37,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
-        public void MockFile_SetAccessControl_ShouldReturnAccessControlOfFileData()
+        public void MockFile_SetAccessControl_ShouldSetAccessControlOfFileData()
         {
             // Arrange
             var filePath = XFS.Path(@"c:\a.txt");

--- a/TestHelpers.Tests/MockFileInfoAccessControlTests.cs
+++ b/TestHelpers.Tests/MockFileInfoAccessControlTests.cs
@@ -1,0 +1,64 @@
+﻿using NUnit.Framework;
+using System.Collections.Generic;
+using System.Security.AccessControl;
+
+namespace System.IO.Abstractions.TestingHelpers.Tests
+{
+    using XFS = MockUnixSupport;
+
+    [TestFixture]
+    [WindowsOnly(WindowsSpecifics.AccessControlLists)]
+    public class MockFileInfoAccessControlTests
+    {
+        [Test]
+        public void MockFileInfo_GetAccessControl_ShouldReturnAccessControlOfFileData()
+        {
+            // Arrange
+            var expectedFileSecurity = new FileSecurity();
+            expectedFileSecurity.SetAccessRuleProtection(false, false);
+
+            var filePath = XFS.Path(@"c:\a.txt");
+            var fileData = new MockFileData("Test content")
+            {
+                AccessControl = expectedFileSecurity,
+            };
+
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>()
+            {
+                { filePath, fileData }
+            });
+
+            var fileInfo = fileSystem.FileInfo.FromFileName(filePath);
+
+            // Act
+            var fileSecurity = fileInfo.GetAccessControl();
+
+            // Assert
+            Assert.That(fileSecurity, Is.EqualTo(expectedFileSecurity));
+        }
+
+        [Test]
+        public void MockFile_SetAccessControl_ShouldReturnAccessControlOfFileData()
+        {
+            // Arrange
+            var filePath = XFS.Path(@"c:\a.txt");
+            var fileData = new MockFileData("Test content");
+
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>()
+            {
+                { filePath, fileData }
+            });
+
+            var fileInfo = fileSystem.FileInfo.FromFileName(filePath);
+
+            // Act
+            var expectedAccessControl = new FileSecurity();
+            expectedAccessControl.SetAccessRuleProtection(false, false);
+            fileInfo.SetAccessControl(expectedAccessControl);
+
+            // Assert
+            var accessControl = fileInfo.GetAccessControl();
+            Assert.That(accessControl, Is.EqualTo(expectedAccessControl));
+        }
+    }
+}

--- a/TestHelpers.Tests/MockFileSetAccessControlTests.cs
+++ b/TestHelpers.Tests/MockFileSetAccessControlTests.cs
@@ -1,14 +1,10 @@
 ﻿using NUnit.Framework;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+using System.Security.AccessControl;
+using XFS = System.IO.Abstractions.TestingHelpers.MockUnixSupport;
 
 namespace System.IO.Abstractions.TestingHelpers.Tests
 {
-    using Security.AccessControl;
-    using XFS = MockUnixSupport;
-
     [TestFixture]
     [WindowsOnly(WindowsSpecifics.AccessControlLists)]
     public class MockFileSetAccessControlTests
@@ -46,7 +42,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
-        public void MockFile_SetAccessControl_ShouldReturnAccessControlOfFileData()
+        public void MockFile_SetAccessControl_ShouldSetAccessControlOfFileData()
         {
             // Arrange
             var filePath = XFS.Path(@"c:\a.txt");

--- a/TestingHelpers/MockFileInfo.cs
+++ b/TestingHelpers/MockFileInfo.cs
@@ -200,12 +200,12 @@ namespace System.IO.Abstractions.TestingHelpers
 
         public override FileSecurity GetAccessControl()
         {
-            throw new NotImplementedException(StringResources.Manager.GetString("NOT_IMPLEMENTED_EXCEPTION"));
+            return mockFileSystem.File.GetAccessControl(this.path);
         }
 
         public override FileSecurity GetAccessControl(AccessControlSections includeSections)
         {
-            throw new NotImplementedException(StringResources.Manager.GetString("NOT_IMPLEMENTED_EXCEPTION"));
+            return mockFileSystem.File.GetAccessControl(this.path, includeSections);
         }
 
         public override void MoveTo(string destFileName)
@@ -265,7 +265,7 @@ namespace System.IO.Abstractions.TestingHelpers
 
         public override void SetAccessControl(FileSecurity fileSecurity)
         {
-            throw new NotImplementedException(StringResources.Manager.GetString("NOT_IMPLEMENTED_EXCEPTION"));
+            mockFileSystem.File.SetAccessControl(this.path, fileSecurity);
         }
 
         public override DirectoryInfoBase Directory


### PR DESCRIPTION
Turns out that MockFileInfo.GetAccessControl/SetAccessControl just need to be proxied through to MockFile.GetAccessControl/SetAccessControl, as already done with MockDirectoryInfo and MockDirectory. So this resolves #330

I also took the liberty of adding a unit test for the proxied access control methods of DirectoryInfo, because  those were missing code coverage.