### PR TITLE
Rewrite internal path keys when using MockDirectory.Move

### DIFF
--- a/System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
@@ -1171,6 +1171,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.DirectoryInfo.FromDirectoryName(sourceDirName).MoveTo(destDirName);
 
             // Assert
+            Assert.IsFalse(fileSystem.Directory.Exists(sourceSubDirName));
             Assert.IsTrue(fileSystem.FileExists(destSubDirName));
         }
 

--- a/System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
@@ -1336,6 +1336,21 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
+        public void MockDirectory_Move_ShouldThrowADirectoryNotFoundExceptionIfDesinationDirectoryDoesNotExist()
+        {
+            // Arrange
+            string sourcePath = XFS.Path(@"c:\a");
+            string destPath = XFS.Path(@"c:\b");
+            var fileSystem = new MockFileSystem();
+
+            // Act
+            TestDelegate action = () => fileSystem.Directory.Move(sourcePath, destPath);
+
+            // Assert
+            Assert.Throws<DirectoryNotFoundException>(action, "Could not find a part of the path 'c:\a'.");
+        }
+
+        [Test]
         public void MockDirectory_Move_ShouldThrowAnIOExceptionIfDesinationDirectoryExists()
         {
             // Arrange

--- a/System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
@@ -1150,6 +1150,31 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
+        public void MockDirectory_Move_ShouldMoveDirectoryWithReadOnlySubDirectory()
+        {
+            // Arrange
+            var sourceDirName = XFS.Path(@"a:\folder1\");
+            var sourceSubDirName = XFS.Path(@"a:\folder1\sub\");
+
+            var destDirName = XFS.Path(@"a:\folder2\");
+            var destSubDirName = XFS.Path(@"a:\folder2\sub\");
+
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddDirectory(sourceSubDirName);
+
+            var subDirectoryInfo = fileSystem.DirectoryInfo.FromDirectoryName(sourceSubDirName);
+            subDirectoryInfo.Attributes |= FileAttributes.ReadOnly;
+
+            var sourceDirectoryInfo = fileSystem.DirectoryInfo.FromDirectoryName(sourceDirName);
+
+            // Act
+            fileSystem.DirectoryInfo.FromDirectoryName(sourceDirName).MoveTo(destDirName);
+
+            // Assert
+            Assert.IsTrue(fileSystem.FileExists(destSubDirName));
+        }
+
+        [Test]
         public void MockDirectory_GetCurrentDirectory_ShouldReturnValueFromFileSystemConstructor() {
             string directory = XFS.Path(@"D:\folder1\folder2");
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>(), directory);

--- a/System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
@@ -1336,6 +1336,23 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
+        public void MockDirectory_Move_ShouldThrowAnIOExceptionIfDesinationDirectoryExists()
+        {
+            // Arrange
+            string sourcePath = XFS.Path(@"c:\a");
+            string destPath = XFS.Path(@"c:\b");
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddDirectory(sourcePath);
+            fileSystem.AddDirectory(destPath);
+
+            // Act
+            TestDelegate action = () => fileSystem.Directory.Move(sourcePath, destPath);
+
+            // Assert
+            Assert.Throws<IOException>(action, "Cannot create 'c:\b\' because a file or directory with the same name already exists.'");
+        }
+
+        [Test]
         public void MockDirectory_EnumerateFiles_ShouldReturnAllFilesBelowPathWhenPatternIsWildcardAndSearchOptionIsAllDirectories()
         {
             // Arrange

--- a/System.IO.Abstractions.TestingHelpers/IMockFileDataAccessor.cs
+++ b/System.IO.Abstractions.TestingHelpers/IMockFileDataAccessor.cs
@@ -21,6 +21,8 @@ namespace System.IO.Abstractions.TestingHelpers
         void AddFileFromEmbeddedResource(string path, Assembly resourceAssembly, string embeddedResourcePath);
         void AddFilesFromEmbeddedNamespace(string path, Assembly resourceAssembly, string embeddedRresourcePath);
 
+        void MoveDirectory(string sourcePath, string destPath);
+
         /// <summary>
         /// Removes the file.
         /// </summary>

--- a/System.IO.Abstractions.TestingHelpers/MockDirectory.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockDirectory.cs
@@ -365,32 +365,7 @@ namespace System.IO.Abstractions.TestingHelpers
                 throw new IOException($"Cannot create '{fullDestPath}' because a file or directory with the same name already exists.");
             }
 
-            //Make sure that the destination exists
-            mockFileDataAccessor.Directory.CreateDirectory(fullDestPath);
-
-            //Copy over the attributes
-            var sourceDirectoryInfo = mockFileDataAccessor.DirectoryInfo.FromDirectoryName(sourceDirName);
-            var destDirectoryInfo = mockFileDataAccessor.DirectoryInfo.FromDirectoryName(destDirName);
-            destDirectoryInfo.Attributes = sourceDirectoryInfo.Attributes;
-
-            //Recursively move all the subdirectories from the source into the destination directory
-            var subdirectories = GetDirectories(fullSourcePath);
-            foreach (var subdirectory in subdirectories)
-            {
-                var newSubdirPath = subdirectory.Replace(fullSourcePath, fullDestPath, StringComparison.OrdinalIgnoreCase);
-                Move(subdirectory, newSubdirPath);
-            }
-
-            //Move the files in destination directory
-            var files = GetFiles(fullSourcePath);
-            foreach (var file in files)
-            {
-                var newFilePath = file.Replace(fullSourcePath, fullDestPath, StringComparison.OrdinalIgnoreCase);
-                mockFileDataAccessor.FileInfo.FromFileName(file).MoveTo(newFilePath);
-            }
-
-            //Delete the source directory
-            Delete(fullSourcePath);
+            mockFileDataAccessor.MoveDirectory(fullSourcePath, fullDestPath);
         }
 
         public override void SetAccessControl(string path, DirectorySecurity directorySecurity)

--- a/System.IO.Abstractions.TestingHelpers/MockDirectory.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockDirectory.cs
@@ -355,6 +355,11 @@ namespace System.IO.Abstractions.TestingHelpers
                 throw new IOException("Source and destination path must have identical roots. Move will not work across volumes.");
             }
 
+            if (!mockFileDataAccessor.Directory.Exists(fullSourcePath))
+            {
+                throw new DirectoryNotFoundException($"Could not find a part of the path '{sourceDirName}'.");
+            }
+
             if (mockFileDataAccessor.Directory.Exists(fullDestPath) || mockFileDataAccessor.File.Exists(fullDestPath))
             {
                 throw new IOException($"Cannot create '{fullDestPath}' because a file or directory with the same name already exists.");

--- a/System.IO.Abstractions.TestingHelpers/MockDirectory.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockDirectory.cs
@@ -355,6 +355,11 @@ namespace System.IO.Abstractions.TestingHelpers
                 throw new IOException("Source and destination path must have identical roots. Move will not work across volumes.");
             }
 
+            if (mockFileDataAccessor.Directory.Exists(fullDestPath) || mockFileDataAccessor.File.Exists(fullDestPath))
+            {
+                throw new IOException($"Cannot create '{fullDestPath}' because a file or directory with the same name already exists.");
+            }
+
             //Make sure that the destination exists
             mockFileDataAccessor.Directory.CreateDirectory(fullDestPath);
 

--- a/System.IO.Abstractions.TestingHelpers/MockFileSystem.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockFileSystem.cs
@@ -211,6 +211,26 @@ namespace System.IO.Abstractions.TestingHelpers
             }
         }
 
+        public void MoveDirectory(string sourcePath, string destPath)
+        {
+            sourcePath = FixPath(sourcePath);
+            destPath = FixPath(destPath);
+
+            lock (files)
+            {
+                var affectedPaths = files.Keys
+                    .Where(p => p.StartsWith(sourcePath, StringComparison.OrdinalIgnoreCase))
+                    .ToList();
+
+                foreach(var path in affectedPaths)
+                {
+                    var newPath = path.Replace(sourcePath, destPath, StringComparison.OrdinalIgnoreCase);
+                    files[newPath] = files[path];
+                    files.Remove(path);
+                }
+            }
+        }
+
         public void RemoveFile(string path)
         {
             path = FixPath(path);


### PR DESCRIPTION
Issue #339, Replaces PR #340.

I had to add a new method to `MockFileSystem` which isn't ideal, but there was nothing which exposed the internal `files` dictionary.

I've also added some additional checks to the mock directory move which I've observed on a real NTFS system, specifically a `DirectoryNotFound` exception if the source directory doesn't exist, and an `IOException` if the destination directory does exist.