### PR TITLE
Prevent duplicate dispose exception

### DIFF
--- a/System.IO.Abstractions.TestingHelpers.Tests/MockFileStreamTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockFileStreamTests.cs
@@ -89,5 +89,20 @@
             // Assert
             Assert.DoesNotThrow(() => stream.Close());
         }
+
+        [Test]
+        public void MockFileStream_Dispose_MultipleCallsDontThrow()
+        {
+            var fileSystem = new MockFileSystem();
+            var path = XFS.Path("C:\\test");
+            fileSystem.AddFile(path, new MockFileData("Bla"));
+            var stream = fileSystem.File.OpenRead(path);
+
+            // Act
+            stream.Dispose();
+
+            // Assert
+            Assert.DoesNotThrow(() => stream.Dispose());
+        }
     }
 }

--- a/System.IO.Abstractions.TestingHelpers.Tests/MockFileStreamTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockFileStreamTests.cs
@@ -74,5 +74,20 @@
             Assert.IsFalse(stream.CanWrite);
             Assert.Throws<NotSupportedException>(() => stream.WriteByte(1));
         }
+
+        [Test]
+        public void MockFileStream_Close_MultipleCallsDontThrow()
+        {
+            var fileSystem = new MockFileSystem();
+            var path = XFS.Path("C:\\test");
+            fileSystem.AddFile(path, new MockFileData("Bla"));
+            var stream = fileSystem.File.OpenRead(path);
+
+            // Act
+            stream.Close();
+
+            // Assert
+            Assert.DoesNotThrow(() => stream.Close());
+        }
     }
 }

--- a/System.IO.Abstractions.TestingHelpers/MockFileStream.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockFileStream.cs
@@ -50,11 +50,14 @@
         public override void Close()
         {
             InternalFlush();
-            disposed = true;
         }
 #else
         protected override void Dispose(bool disposing)
         {
+            if (disposed)
+            {
+                return;
+            }
             InternalFlush();
             base.Dispose(disposing);
             disposed = true;
@@ -68,11 +71,6 @@
 
         private void InternalFlush()
         {
-            if (disposed)
-            {
-                return;
-            }
-
             if (mockFileDataAccessor.FileExists(path))
             {
                 var mockFileData = mockFileDataAccessor.GetFile(path);

--- a/System.IO.Abstractions.TestingHelpers/MockFileStream.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockFileStream.cs
@@ -6,6 +6,7 @@
         private readonly IMockFileDataAccessor mockFileDataAccessor;
         private readonly string path;
         private readonly bool canWrite = true;
+        private bool disposed;
 
         public enum StreamType
         {
@@ -49,12 +50,14 @@
         public override void Close()
         {
             InternalFlush();
+            disposed = true;
         }
 #else
         protected override void Dispose(bool disposing)
         {
             InternalFlush();
             base.Dispose(disposing);
+            disposed = true;
         }
 #endif
 
@@ -65,6 +68,11 @@
 
         private void InternalFlush()
         {
+            if (disposed)
+            {
+                return;
+            }
+
             if (mockFileDataAccessor.FileExists(path))
             {
                 var mockFileData = mockFileDataAccessor.GetFile(path);


### PR DESCRIPTION
In situations where multiple `using`'s are stacked against a stream and a reader/writer a "Cannot access a closed Stream" exception is thrown which is not present in a default `FileSystem`. In particular it's
observed in netcore 2.0, so a new test run with `dotnet test` against original source will expose it.

The fix just keeps track of disposal attempts.