### PR TITLE
#351: Add IFileSystem property to base classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,6 +149,9 @@ $RECYCLE.BIN/
 # Mac crap
 .DS_Store
 
+# JetBrains Rider IDE files
+.idea/
+
 #System.IO.Abstractions specific ignores
 Releases
 System.IO.Abstractions.*.nupkg

--- a/System.IO.Abstractions.TestingHelpers.Tests/ConvertersTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/ConvertersTests.cs
@@ -32,7 +32,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         {
             var crashingFileSystemInfos = new CrashingEnumerable<FileSystemInfo>();
         
-            Assert.DoesNotThrow(() => Converters.WrapFileSystemInfos(crashingFileSystemInfos));
+            Assert.DoesNotThrow(() => crashingFileSystemInfos.WrapFileSystemInfos(new MockFileSystem()));
         }
 
         [Test]
@@ -40,14 +40,14 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         {
             var crashingFileInfos = new CrashingEnumerable<FileInfo>();
         
-            Assert.DoesNotThrow(() => Converters.WrapFiles(crashingFileInfos));
+            Assert.DoesNotThrow(() => crashingFileInfos.WrapFiles(new MockFileSystem()));
         }
         [Test]
         public void WrapDirectories_with_IEnumerable_is_lazy()
         {
             var crashingDirectoryInfos = new CrashingEnumerable<DirectoryInfo>();
         
-            Assert.DoesNotThrow(() => Converters.WrapDirectories(crashingDirectoryInfos));
+            Assert.DoesNotThrow(() => crashingDirectoryInfos.WrapDirectories(new MockFileSystem()));
         }
 
     }

--- a/System.IO.Abstractions.TestingHelpers/IMockFileDataAccessor.cs
+++ b/System.IO.Abstractions.TestingHelpers/IMockFileDataAccessor.cs
@@ -62,5 +62,7 @@ namespace System.IO.Abstractions.TestingHelpers
         IDriveInfoFactory DriveInfo { get; }
 
         PathVerifier PathVerifier { get; }
+
+        IFileSystem FileSystem { get; }
     }
 }

--- a/System.IO.Abstractions.TestingHelpers/MockDirectory.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockDirectory.cs
@@ -18,7 +18,7 @@ namespace System.IO.Abstractions.TestingHelpers
 
         private string currentDirectory;
 
-        public MockDirectory(IMockFileDataAccessor mockFileDataAccessor, FileBase fileBase, string currentDirectory)
+        public MockDirectory(IMockFileDataAccessor mockFileDataAccessor, FileBase fileBase, string currentDirectory) : base(mockFileDataAccessor?.FileSystem)
         {
             this.currentDirectory = currentDirectory;
             this.mockFileDataAccessor = mockFileDataAccessor ?? throw new ArgumentNullException(nameof(mockFileDataAccessor));

--- a/System.IO.Abstractions.TestingHelpers/MockDirectoryInfo.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockDirectoryInfo.cs
@@ -17,7 +17,7 @@ namespace System.IO.Abstractions.TestingHelpers
         /// <param name="mockFileDataAccessor">The mock file data accessor.</param>
         /// <param name="directoryPath">The directory path.</param>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="mockFileDataAccessor"/> or <paramref name="directoryPath"/> is <see langref="null"/>.</exception>
-        public MockDirectoryInfo(IMockFileDataAccessor mockFileDataAccessor, string directoryPath)
+        public MockDirectoryInfo(IMockFileDataAccessor mockFileDataAccessor, string directoryPath) : base(mockFileDataAccessor?.FileSystem)
         {
             this.mockFileDataAccessor = mockFileDataAccessor ?? throw new ArgumentNullException(nameof(mockFileDataAccessor));
 

--- a/System.IO.Abstractions.TestingHelpers/MockDriveInfo.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockDriveInfo.cs
@@ -5,7 +5,7 @@
     {
         private readonly IMockFileDataAccessor mockFileDataAccessor;
 
-        public MockDriveInfo(IMockFileDataAccessor mockFileDataAccessor, string name)
+        public MockDriveInfo(IMockFileDataAccessor mockFileDataAccessor, string name) : base(mockFileDataAccessor?.FileSystem)
         {
             if (mockFileDataAccessor == null)
             {

--- a/System.IO.Abstractions.TestingHelpers/MockFile.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockFile.cs
@@ -12,7 +12,7 @@ namespace System.IO.Abstractions.TestingHelpers
         private readonly IMockFileDataAccessor mockFileDataAccessor;
         private readonly MockPath mockPath;
 
-        public MockFile(IMockFileDataAccessor mockFileDataAccessor)
+        public MockFile(IMockFileDataAccessor mockFileDataAccessor) : base(mockFileDataAccessor?.FileSystem)
         {
             this.mockFileDataAccessor = mockFileDataAccessor ?? throw new ArgumentNullException(nameof(mockFileDataAccessor));
             mockPath = new MockPath(mockFileDataAccessor);
@@ -350,7 +350,7 @@ namespace System.IO.Abstractions.TestingHelpers
                     throw new IOException("A file can not be created if it already exists.");
                 }
             }
-                
+
 
             var sourceFile = mockFileDataAccessor.GetFile(sourceFileName);
 
@@ -399,7 +399,7 @@ namespace System.IO.Abstractions.TestingHelpers
             }
 
             var length = mockFileDataAccessor.GetFile(path).Contents.Length;
-            
+
             MockFileStream.StreamType streamType = MockFileStream.StreamType.WRITE;
             if (access == FileAccess.Read)
                 streamType = MockFileStream.StreamType.READ;
@@ -938,7 +938,7 @@ namespace System.IO.Abstractions.TestingHelpers
             }
 
             VerifyDirectoryExists(path);
-     
+
             MockFileData data = contents == null ? new MockFileData(new byte[0]) : new MockFileData(contents, encoding);
             mockFileDataAccessor.AddFile(path, data);
         }

--- a/System.IO.Abstractions.TestingHelpers/MockFileInfo.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockFileInfo.cs
@@ -8,7 +8,7 @@ namespace System.IO.Abstractions.TestingHelpers
         private readonly IMockFileDataAccessor mockFileSystem;
         private string path;
 
-        public MockFileInfo(IMockFileDataAccessor mockFileSystem, string path)
+        public MockFileInfo(IMockFileDataAccessor mockFileSystem, string path) : base(mockFileSystem?.FileSystem)
         {
             this.mockFileSystem = mockFileSystem ?? throw new ArgumentNullException(nameof(mockFileSystem));
             this.path = path ?? throw new ArgumentNullException(nameof(path));
@@ -259,7 +259,7 @@ namespace System.IO.Abstractions.TestingHelpers
         public override FileInfoBase Replace(string destinationFileName, string destinationBackupFileName, bool ignoreMetadataErrors)
         {
             mockFileSystem.File.Replace(path, destinationFileName, destinationBackupFileName, ignoreMetadataErrors);
-            return new FileInfo(destinationFileName);
+            return mockFileSystem.FileInfo.FromFileName(destinationFileName);
         }
 #endif
 

--- a/System.IO.Abstractions.TestingHelpers/MockFileSystem.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockFileSystem.cs
@@ -60,6 +60,8 @@ namespace System.IO.Abstractions.TestingHelpers
 
         public IFileSystemWatcherFactory FileSystemWatcher { get; }
 
+        public IFileSystem FileSystem => this;
+
         public PathVerifier PathVerifier => pathVerifier;
 
         private string FixPath(string path, bool checkCaps = false)

--- a/System.IO.Abstractions.TestingHelpers/MockPath.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockPath.cs
@@ -14,14 +14,9 @@ namespace System.IO.Abstractions.TestingHelpers
 
         private static readonly char[] InvalidAdditionalPathChars = { '*', '?' };
 
-        public MockPath(IMockFileDataAccessor mockFileDataAccessor)
+        public MockPath(IMockFileDataAccessor mockFileDataAccessor) : base(mockFileDataAccessor?.FileSystem)
         {
-            if (mockFileDataAccessor == null)
-            {
-                throw new ArgumentNullException(nameof(mockFileDataAccessor));
-            }
-
-            this.mockFileDataAccessor = mockFileDataAccessor;
+            this.mockFileDataAccessor = mockFileDataAccessor ?? throw new ArgumentNullException(nameof(mockFileDataAccessor));
         }
 
         public override string GetFullPath(string path)

--- a/System.IO.Abstractions/Converters.cs
+++ b/System.IO.Abstractions/Converters.cs
@@ -6,33 +6,33 @@ namespace System.IO.Abstractions
 {
     internal static class Converters
     {
-        internal static IEnumerable<FileSystemInfoBase> WrapFileSystemInfos(this IEnumerable<FileSystemInfo> input)
-            => input.Select(WrapFileSystemInfo);
+        internal static IEnumerable<FileSystemInfoBase> WrapFileSystemInfos(this IEnumerable<FileSystemInfo> input, IFileSystem fileSystem)
+            => input.Select(info => WrapFileSystemInfo(fileSystem, info));
 
-        internal static FileSystemInfoBase[] WrapFileSystemInfos(this FileSystemInfo[] input)
-            => input.Select(WrapFileSystemInfo).ToArray();
+        internal static FileSystemInfoBase[] WrapFileSystemInfos(this FileSystemInfo[] input, IFileSystem fileSystem)
+            => input.Select(info => WrapFileSystemInfo(fileSystem, info)).ToArray();
 
-        internal static IEnumerable<DirectoryInfoBase> WrapDirectories(this IEnumerable<DirectoryInfo> input) 
-            => input.Select(WrapDirectoryInfo);
+        internal static IEnumerable<DirectoryInfoBase> WrapDirectories(this IEnumerable<DirectoryInfo> input, IFileSystem fileSystem)
+            => input.Select(info => WrapDirectoryInfo(fileSystem, info));
 
-        internal static DirectoryInfoBase[] WrapDirectories(this DirectoryInfo[] input)
-            => input.Select(WrapDirectoryInfo).ToArray();
+        internal static DirectoryInfoBase[] WrapDirectories(this DirectoryInfo[] input, IFileSystem fileSystem)
+            => input.Select(info => WrapDirectoryInfo(fileSystem, info)).ToArray();
 
-        internal static IEnumerable<FileInfoBase> WrapFiles(this IEnumerable<FileInfo> input) 
-            => input.Select(WrapFileInfo);
+        internal static IEnumerable<FileInfoBase> WrapFiles(this IEnumerable<FileInfo> input, IFileSystem fileSystem)
+            => input.Select(info => WrapFileInfo(fileSystem, info));
 
-        internal static FileInfoBase[] WrapFiles(this FileInfo[] input) 
-            => input.Select(WrapFileInfo).ToArray();
+        internal static FileInfoBase[] WrapFiles(this FileInfo[] input, IFileSystem fileSystem)
+            => input.Select(info => WrapFileInfo(fileSystem, info)).ToArray();
         
-        private static FileSystemInfoBase WrapFileSystemInfo(FileSystemInfo item)
+        private static FileSystemInfoBase WrapFileSystemInfo(IFileSystem fileSystem, FileSystemInfo item)
         {
             if (item is FileInfo)
             {
-                return WrapFileInfo((FileInfo)item);
+                return WrapFileInfo(fileSystem, (FileInfo)item);
             }
             else if (item is DirectoryInfo)
             {
-                return WrapDirectoryInfo((DirectoryInfo)item);
+                return WrapDirectoryInfo(fileSystem, (DirectoryInfo)item);
             }
             else
             {
@@ -44,8 +44,8 @@ namespace System.IO.Abstractions
             }
         }
 
-        private static FileInfoBase WrapFileInfo(FileInfo f) => (FileInfoBase)f;
-    
-        private static DirectoryInfoBase WrapDirectoryInfo(DirectoryInfo d) => (DirectoryInfoBase)d;
+        private static FileInfoBase WrapFileInfo(IFileSystem fileSystem, FileInfo f) => new FileInfoWrapper(fileSystem, f);
+
+        private static DirectoryInfoBase WrapDirectoryInfo(IFileSystem fileSystem, DirectoryInfo d) => new DirectoryInfoWrapper(fileSystem, d);
     }
 }

--- a/System.IO.Abstractions/DirectoryBase.cs
+++ b/System.IO.Abstractions/DirectoryBase.cs
@@ -9,7 +9,7 @@ namespace System.IO.Abstractions
     {
         protected DirectoryBase(IFileSystem fileSystem)
         {
-            this.FileSystem = fileSystem;
+            FileSystem = fileSystem;
         }
 
         /// <summary>

--- a/System.IO.Abstractions/DirectoryBase.cs
+++ b/System.IO.Abstractions/DirectoryBase.cs
@@ -7,6 +7,16 @@ namespace System.IO.Abstractions
     [Serializable]
     public abstract class DirectoryBase
     {
+        protected DirectoryBase(IFileSystem fileSystem)
+        {
+            this.FileSystem = fileSystem;
+        }
+
+        /// <summary>
+        /// Exposes the underlying filesystem implementation. This is useful for implementing extension methods.
+        /// </summary>
+        public IFileSystem FileSystem { get; }
+
         /// <inheritdoc cref="Directory.CreateDirectory(string)"/>
         public abstract DirectoryInfoBase CreateDirectory(string path);
 

--- a/System.IO.Abstractions/DirectoryInfoBase.cs
+++ b/System.IO.Abstractions/DirectoryInfoBase.cs
@@ -7,6 +7,10 @@ namespace System.IO.Abstractions
     [Serializable]
     public abstract class DirectoryInfoBase : FileSystemInfoBase
     {
+        protected DirectoryInfoBase(IFileSystem fileSystem) : base(fileSystem)
+        {
+        }
+
         /// <inheritdoc cref="DirectoryInfo.Create()"/>
         public abstract void Create();
 #if NET40
@@ -102,7 +106,7 @@ namespace System.IO.Abstractions
         {
             if (directoryInfo == null)
                 return null;
-            return new DirectoryInfoWrapper(directoryInfo);
+            return new DirectoryInfoWrapper(new FileSystem(), directoryInfo);
         }
     }
 }

--- a/System.IO.Abstractions/DirectoryInfoFactory.cs
+++ b/System.IO.Abstractions/DirectoryInfoFactory.cs
@@ -3,10 +3,17 @@ namespace System.IO.Abstractions
     [Serializable]
     internal class DirectoryInfoFactory : IDirectoryInfoFactory
     {
+        private readonly IFileSystem fileSystem;
+
+        public DirectoryInfoFactory(IFileSystem fileSystem)
+        {
+            this.fileSystem = fileSystem;
+        }
+
         public DirectoryInfoBase FromDirectoryName(string directoryName)
         {
             var realDirectoryInfo = new DirectoryInfo(directoryName);
-            return new DirectoryInfoWrapper(realDirectoryInfo);
+            return new DirectoryInfoWrapper(fileSystem, realDirectoryInfo);
         }
     }
 }

--- a/System.IO.Abstractions/DirectoryInfoWrapper.cs
+++ b/System.IO.Abstractions/DirectoryInfoWrapper.cs
@@ -9,7 +9,7 @@ namespace System.IO.Abstractions
     {
         private readonly DirectoryInfo instance;
 
-        public DirectoryInfoWrapper(DirectoryInfo instance)
+        public DirectoryInfoWrapper(IFileSystem fileSystem, DirectoryInfo instance) : base(fileSystem)
         {
             this.instance = instance ?? throw new ArgumentNullException(nameof(instance));
         }
@@ -100,13 +100,13 @@ namespace System.IO.Abstractions
 
         public override DirectoryInfoBase CreateSubdirectory(string path)
         {
-            return new DirectoryInfoWrapper(instance.CreateSubdirectory(path));
+            return new DirectoryInfoWrapper(FileSystem, instance.CreateSubdirectory(path));
         }
 
 #if NET40
         public override DirectoryInfoBase CreateSubdirectory(string path, DirectorySecurity directorySecurity)
         {
-            return new DirectoryInfoWrapper(instance.CreateSubdirectory(path, directorySecurity));
+            return new DirectoryInfoWrapper(FileSystem, instance.CreateSubdirectory(path, directorySecurity));
         }
 #endif
 
@@ -117,47 +117,47 @@ namespace System.IO.Abstractions
 
         public override IEnumerable<DirectoryInfoBase> EnumerateDirectories()
         {
-            return instance.EnumerateDirectories().Select(directoryInfo => new DirectoryInfoWrapper(directoryInfo));
+            return instance.EnumerateDirectories().Select(directoryInfo => new DirectoryInfoWrapper(FileSystem, directoryInfo));
         }
 
         public override IEnumerable<DirectoryInfoBase> EnumerateDirectories(string searchPattern)
         {
-            return instance.EnumerateDirectories(searchPattern).Select(directoryInfo => new DirectoryInfoWrapper(directoryInfo));
+            return instance.EnumerateDirectories(searchPattern).Select(directoryInfo => new DirectoryInfoWrapper(FileSystem, directoryInfo));
         }
 
         public override IEnumerable<DirectoryInfoBase> EnumerateDirectories(string searchPattern, SearchOption searchOption)
         {
-            return instance.EnumerateDirectories(searchPattern, searchOption).Select(directoryInfo => new DirectoryInfoWrapper(directoryInfo));
+            return instance.EnumerateDirectories(searchPattern, searchOption).Select(directoryInfo => new DirectoryInfoWrapper(FileSystem, directoryInfo));
         }
 
         public override IEnumerable<FileInfoBase> EnumerateFiles()
         {
-            return instance.EnumerateFiles().Select(fileInfo => new FileInfoWrapper(fileInfo));
+            return instance.EnumerateFiles().Select(fileInfo => new FileInfoWrapper(FileSystem, fileInfo));
         }
 
         public override IEnumerable<FileInfoBase> EnumerateFiles(string searchPattern)
         {
-            return instance.EnumerateFiles(searchPattern).Select(fileInfo => new FileInfoWrapper(fileInfo));
+            return instance.EnumerateFiles(searchPattern).Select(fileInfo => new FileInfoWrapper(FileSystem, fileInfo));
         }
 
         public override IEnumerable<FileInfoBase> EnumerateFiles(string searchPattern, SearchOption searchOption)
         {
-            return instance.EnumerateFiles(searchPattern, searchOption).Select(fileInfo => new FileInfoWrapper(fileInfo));
+            return instance.EnumerateFiles(searchPattern, searchOption).Select(fileInfo => new FileInfoWrapper(FileSystem, fileInfo));
         }
 
         public override IEnumerable<FileSystemInfoBase> EnumerateFileSystemInfos()
         {
-            return instance.EnumerateFileSystemInfos().WrapFileSystemInfos();
+            return instance.EnumerateFileSystemInfos().WrapFileSystemInfos(FileSystem);
         }
 
         public override IEnumerable<FileSystemInfoBase> EnumerateFileSystemInfos(string searchPattern)
         {
-            return instance.EnumerateFileSystemInfos(searchPattern).WrapFileSystemInfos();
+            return instance.EnumerateFileSystemInfos(searchPattern).WrapFileSystemInfos(FileSystem);
         }
 
         public override IEnumerable<FileSystemInfoBase> EnumerateFileSystemInfos(string searchPattern, SearchOption searchOption)
         {
-            return instance.EnumerateFileSystemInfos(searchPattern, searchOption).WrapFileSystemInfos();
+            return instance.EnumerateFileSystemInfos(searchPattern, searchOption).WrapFileSystemInfos(FileSystem);
         }
 
         public override DirectorySecurity GetAccessControl()
@@ -172,47 +172,47 @@ namespace System.IO.Abstractions
 
         public override DirectoryInfoBase[] GetDirectories()
         {
-            return instance.GetDirectories().WrapDirectories();
+            return instance.GetDirectories().WrapDirectories(FileSystem);
         }
 
         public override DirectoryInfoBase[] GetDirectories(string searchPattern)
         {
-            return instance.GetDirectories(searchPattern).WrapDirectories();
+            return instance.GetDirectories(searchPattern).WrapDirectories(FileSystem);
         }
 
         public override DirectoryInfoBase[] GetDirectories(string searchPattern, SearchOption searchOption)
         {
-            return instance.GetDirectories(searchPattern, searchOption).WrapDirectories();
+            return instance.GetDirectories(searchPattern, searchOption).WrapDirectories(FileSystem);
         }
 
         public override FileInfoBase[] GetFiles()
         {
-            return instance.GetFiles().WrapFiles();
+            return instance.GetFiles().WrapFiles(FileSystem);
         }
 
         public override FileInfoBase[] GetFiles(string searchPattern)
         {
-            return instance.GetFiles(searchPattern).WrapFiles();
+            return instance.GetFiles(searchPattern).WrapFiles(FileSystem);
         }
 
         public override FileInfoBase[] GetFiles(string searchPattern, SearchOption searchOption)
         {
-            return instance.GetFiles(searchPattern, searchOption).WrapFiles();
+            return instance.GetFiles(searchPattern, searchOption).WrapFiles(FileSystem);
         }
 
         public override FileSystemInfoBase[] GetFileSystemInfos()
         {
-            return instance.GetFileSystemInfos().WrapFileSystemInfos();
+            return instance.GetFileSystemInfos().WrapFileSystemInfos(FileSystem);
         }
 
         public override FileSystemInfoBase[] GetFileSystemInfos(string searchPattern)
         {
-            return instance.GetFileSystemInfos(searchPattern).WrapFileSystemInfos();
+            return instance.GetFileSystemInfos(searchPattern).WrapFileSystemInfos(FileSystem);
         }
 
         public override FileSystemInfoBase[] GetFileSystemInfos(string searchPattern, SearchOption searchOption)
         {
-            return instance.GetFileSystemInfos(searchPattern, searchOption).WrapFileSystemInfos();
+            return instance.GetFileSystemInfos(searchPattern, searchOption).WrapFileSystemInfos(FileSystem);
         }
 
         public override void MoveTo(string destDirName)
@@ -227,12 +227,12 @@ namespace System.IO.Abstractions
 
         public override DirectoryInfoBase Parent
         {
-            get { return instance.Parent; }
+            get { return new DirectoryInfoWrapper(FileSystem, instance.Parent); }
         }
 
         public override DirectoryInfoBase Root
         {
-            get { return instance.Root; }
+            get { return new DirectoryInfoWrapper(FileSystem, instance.Root); }
         }
 
         public override string ToString()

--- a/System.IO.Abstractions/DirectoryWrapper.cs
+++ b/System.IO.Abstractions/DirectoryWrapper.cs
@@ -6,16 +6,20 @@ namespace System.IO.Abstractions
     [Serializable]
     public class DirectoryWrapper : DirectoryBase
     {
+        public DirectoryWrapper(IFileSystem fileSystem) : base(fileSystem)
+        {
+        }
+
         public override DirectoryInfoBase CreateDirectory(string path)
         {
-            return Directory.CreateDirectory(path);
+            return new DirectoryInfoWrapper(FileSystem, Directory.CreateDirectory(path));
         }
 
 #if NET40
         public override DirectoryInfoBase CreateDirectory(string path, DirectorySecurity directorySecurity)
         {
-            return Directory.CreateDirectory(path, directorySecurity);
-        }        
+            return new DirectoryInfoWrapper(FileSystem, Directory.CreateDirectory(path, directorySecurity));
+        }
 #endif
         public override void Delete(string path)
         {
@@ -131,7 +135,7 @@ namespace System.IO.Abstractions
 
         public override DirectoryInfoBase GetParent(string path)
         {
-            return Directory.GetParent(path);
+            return new DirectoryInfoWrapper(FileSystem, Directory.GetParent(path));
         }
 
         public override void Move(string sourceDirName, string destDirName)

--- a/System.IO.Abstractions/DriveInfoBase.cs
+++ b/System.IO.Abstractions/DriveInfoBase.cs
@@ -3,6 +3,13 @@
     [Serializable]
     public abstract class DriveInfoBase
     {
+        protected DriveInfoBase(IFileSystem fileSystem)
+        {
+            FileSystem = fileSystem ?? throw new ArgumentNullException(nameof(fileSystem));
+        }
+
+        public IFileSystem FileSystem { get; }
+
         /// <inheritdoc cref="DriveInfo.AvailableFreeSpace"/>
         /// <summary>
         /// Gets or sets the amount of available free space on a drive, in bytes.
@@ -127,7 +134,7 @@
                 return null;
             }
 
-            return new DriveInfoWrapper(driveInfo);
+            return new DriveInfoWrapper(new FileSystem(), driveInfo);
         }
     }
 }

--- a/System.IO.Abstractions/DriveInfoBase.cs
+++ b/System.IO.Abstractions/DriveInfoBase.cs
@@ -8,6 +8,9 @@
             FileSystem = fileSystem ?? throw new ArgumentNullException(nameof(fileSystem));
         }
 
+        /// <summary>
+        /// Exposes the underlying filesystem implementation. This is useful for implementing extension methods.
+        /// </summary>
         public IFileSystem FileSystem { get; }
 
         /// <inheritdoc cref="DriveInfo.AvailableFreeSpace"/>

--- a/System.IO.Abstractions/DriveInfoFactory.cs
+++ b/System.IO.Abstractions/DriveInfoFactory.cs
@@ -3,6 +3,13 @@
     [Serializable]
     internal class DriveInfoFactory : IDriveInfoFactory
     {
+        private readonly IFileSystem fileSystem;
+
+        public DriveInfoFactory(IFileSystem fileSystem)
+        {
+            this.fileSystem = fileSystem;
+        }
+
         /// <summary>
         /// Retrieves the drive names of all logical drives on a computer.
         /// </summary>
@@ -14,7 +21,7 @@
             for (int index = 0; index < driveInfos.Length; index++)
             {
                 var driveInfo = driveInfos[index];
-                driveInfoWrappers[index] = new DriveInfoWrapper(driveInfo);
+                driveInfoWrappers[index] = new DriveInfoWrapper(fileSystem, driveInfo);
             }
 
             return driveInfoWrappers;
@@ -27,7 +34,7 @@
         public DriveInfoBase FromDriveName(string driveName)
         {
             var realDriveInfo = new DriveInfo(driveName);
-            return new DriveInfoWrapper(realDriveInfo);
+            return new DriveInfoWrapper(fileSystem, realDriveInfo);
         }
     }
 }

--- a/System.IO.Abstractions/DriveInfoWrapper.cs
+++ b/System.IO.Abstractions/DriveInfoWrapper.cs
@@ -14,8 +14,9 @@
         /// <summary>
         /// Initializes a new instance of the <see cref="DriveInfoWrapper"/> class, which acts as a wrapper for a drive info.
         /// </summary>
+        /// <param name="fileSystem">The underlying IFileSystem.</param>
         /// <param name="instance">The drive info.</param>
-        public DriveInfoWrapper(DriveInfo instance)
+        public DriveInfoWrapper(IFileSystem fileSystem, DriveInfo instance) : base(fileSystem)
         {
             this.instance = instance ?? throw new ArgumentNullException(nameof(instance));
         }
@@ -128,7 +129,7 @@
         /// <value>An object that contains the root directory of the drive.</value>
         public override DirectoryInfoBase RootDirectory
         {
-            get { return instance.RootDirectory; }
+            get { return new DirectoryInfoWrapper(FileSystem, instance.RootDirectory); }
         }
 
         /// <summary>

--- a/System.IO.Abstractions/FileBase.cs
+++ b/System.IO.Abstractions/FileBase.cs
@@ -10,7 +10,7 @@ namespace System.IO.Abstractions
     {
         protected FileBase(IFileSystem fileSystem)
         {
-            this.FileSystem = fileSystem;
+            FileSystem = fileSystem;
         }
 
         /// <summary>

--- a/System.IO.Abstractions/FileBase.cs
+++ b/System.IO.Abstractions/FileBase.cs
@@ -8,6 +8,16 @@ namespace System.IO.Abstractions
     [Serializable]
     public abstract class FileBase
     {
+        protected FileBase(IFileSystem fileSystem)
+        {
+            this.FileSystem = fileSystem;
+        }
+
+        /// <summary>
+        /// Exposes the underlying filesystem implementation. This is useful for implementing extension methods.
+        /// </summary>
+        public IFileSystem FileSystem { get; }
+
         /// <inheritdoc cref="File.AppendAllLines(string,IEnumerable{string})"/>
         public abstract void AppendAllLines(string path, IEnumerable<string> contents);
 

--- a/System.IO.Abstractions/FileInfoBase.cs
+++ b/System.IO.Abstractions/FileInfoBase.cs
@@ -6,6 +6,10 @@ namespace System.IO.Abstractions
     [Serializable]
     public abstract class FileInfoBase : FileSystemInfoBase
     {
+        protected FileInfoBase(IFileSystem fileSystem) : base(fileSystem)
+        {
+        }
+
         /// <inheritdoc cref="FileInfo.AppendText"/>
         public abstract StreamWriter AppendText();
 
@@ -85,8 +89,8 @@ namespace System.IO.Abstractions
             {
                 return null;
             }
-            
-            return new FileInfoWrapper(fileInfo);
+
+            return new FileInfoWrapper(new FileSystem(), fileInfo);
         }
     }
 }

--- a/System.IO.Abstractions/FileInfoFactory.cs
+++ b/System.IO.Abstractions/FileInfoFactory.cs
@@ -3,10 +3,17 @@
     [Serializable]
     internal class FileInfoFactory : IFileInfoFactory
     {
+        private readonly IFileSystem fileSystem;
+
+        public FileInfoFactory(IFileSystem fileSystem)
+        {
+            this.fileSystem = fileSystem;
+        }
+
         public FileInfoBase FromFileName(string fileName)
         {
             var realFileInfo = new FileInfo(fileName);
-            return new FileInfoWrapper(realFileInfo);
+            return new FileInfoWrapper(fileSystem, realFileInfo);
         }
     }
 }

--- a/System.IO.Abstractions/FileInfoWrapper.cs
+++ b/System.IO.Abstractions/FileInfoWrapper.cs
@@ -7,7 +7,7 @@ namespace System.IO.Abstractions
     {
         private readonly FileInfo instance;
 
-        public FileInfoWrapper(FileInfo instance)
+        public FileInfoWrapper(IFileSystem fileSystem, FileInfo instance) : base(fileSystem)
         {
             this.instance = instance ?? throw new ArgumentNullException(nameof(instance));
         }
@@ -91,12 +91,12 @@ namespace System.IO.Abstractions
 
         public override FileInfoBase CopyTo(string destFileName)
         {
-            return instance.CopyTo(destFileName);
+            return new FileInfoWrapper(FileSystem, instance.CopyTo(destFileName));
         }
 
         public override FileInfoBase CopyTo(string destFileName, bool overwrite)
         {
-            return instance.CopyTo(destFileName, overwrite);
+            return new FileInfoWrapper(FileSystem, instance.CopyTo(destFileName, overwrite));
         }
 
         public override Stream Create()
@@ -169,12 +169,12 @@ namespace System.IO.Abstractions
 #if NET40
         public override FileInfoBase Replace(string destinationFileName, string destinationBackupFileName)
         {
-            return instance.Replace(destinationFileName, destinationBackupFileName);
+            return new FileInfoWrapper(FileSystem, instance.Replace(destinationFileName, destinationBackupFileName));
         }
 
         public override FileInfoBase Replace(string destinationFileName, string destinationBackupFileName, bool ignoreMetadataErrors)
         {
-            return instance.Replace(destinationFileName, destinationBackupFileName, ignoreMetadataErrors);
+            return new FileInfoWrapper(FileSystem, instance.Replace(destinationFileName, destinationBackupFileName, ignoreMetadataErrors));
         }
 #endif
 
@@ -185,7 +185,7 @@ namespace System.IO.Abstractions
 
         public override DirectoryInfoBase Directory
         {
-            get { return instance.Directory; }
+            get { return new DirectoryInfoWrapper(FileSystem, instance.Directory); }
         }
 
         public override string DirectoryName

--- a/System.IO.Abstractions/FileSystem.cs
+++ b/System.IO.Abstractions/FileSystem.cs
@@ -5,56 +5,30 @@
     {
         public FileSystem()
         {
-            driveInfoFactory = new Lazy<DriveInfoFactory>(() => new DriveInfoFactory(this));;
+            DriveInfo = new DriveInfoFactory(this);
+            DirectoryInfo = new DirectoryInfoFactory(this);
+            FileInfo = new FileInfoFactory(this);
+            Path = new PathWrapper(this);
+            File = new FileWrapper(this);
+            Directory = new DirectoryWrapper(this);
+            FileStream = new FileStreamFactory();
+            FileSystemWatcher = new FileSystemWatcherFactory();
         }
 
-        private DirectoryBase directory;
+        public DirectoryBase Directory { get; }
 
-        public DirectoryBase Directory
-        {
-            get { return directory ?? (directory = new DirectoryWrapper(this)); }
-        }
+        public FileBase File { get; }
 
-        FileBase file;
-        public FileBase File
-        {
-            get { return file ?? (file = new FileWrapper(this)); }
-        }
+        public IFileInfoFactory FileInfo { get; }
 
-        FileInfoFactory fileInfoFactory;
-        public IFileInfoFactory FileInfo
-        {
-            get { return fileInfoFactory ?? (fileInfoFactory = new FileInfoFactory(this)); }
-        }
+        public IFileStreamFactory FileStream { get; }
 
-        FileStreamFactory fileStreamFactory;
-        public IFileStreamFactory FileStream
-        {
-            get { return fileStreamFactory ?? (fileStreamFactory = new FileStreamFactory()); }
-        }
+        public PathBase Path { get; }
 
-        PathBase path;
-        public PathBase Path
-        {
-            get { return path ?? (path = new PathWrapper(this)); }
-        }
+        public IDirectoryInfoFactory DirectoryInfo { get; }
 
-        DirectoryInfoFactory directoryInfoFactory;
-        public IDirectoryInfoFactory DirectoryInfo
-        {
-            get { return directoryInfoFactory ?? (directoryInfoFactory = new DirectoryInfoFactory(this)); }
-        }
+        public IDriveInfoFactory DriveInfo { get; }
 
-        private readonly Lazy<DriveInfoFactory> driveInfoFactory;
-        public IDriveInfoFactory DriveInfo
-        {
-            get { return driveInfoFactory.Value; }
-        }
-
-        private IFileSystemWatcherFactory fileSystemWatcherFactory;
-        public IFileSystemWatcherFactory FileSystemWatcher
-        {
-            get { return fileSystemWatcherFactory ?? (fileSystemWatcherFactory = new FileSystemWatcherFactory()); }
-        }
+        public IFileSystemWatcherFactory FileSystemWatcher { get; }
     }
 }

--- a/System.IO.Abstractions/FileSystem.cs
+++ b/System.IO.Abstractions/FileSystem.cs
@@ -3,22 +3,28 @@
     [Serializable]
     public class FileSystem : IFileSystem
     {
-        DirectoryBase directory;
+        public FileSystem()
+        {
+            driveInfoFactory = new Lazy<DriveInfoFactory>(() => new DriveInfoFactory(this));;
+        }
+
+        private DirectoryBase directory;
+
         public DirectoryBase Directory
         {
-            get { return directory ?? (directory = new DirectoryWrapper()); }
+            get { return directory ?? (directory = new DirectoryWrapper(this)); }
         }
 
         FileBase file;
         public FileBase File
         {
-            get { return file ?? (file = new FileWrapper()); }
+            get { return file ?? (file = new FileWrapper(this)); }
         }
 
         FileInfoFactory fileInfoFactory;
         public IFileInfoFactory FileInfo
         {
-            get { return fileInfoFactory ?? (fileInfoFactory = new FileInfoFactory()); }
+            get { return fileInfoFactory ?? (fileInfoFactory = new FileInfoFactory(this)); }
         }
 
         FileStreamFactory fileStreamFactory;
@@ -30,22 +36,21 @@
         PathBase path;
         public PathBase Path
         {
-            get { return path ?? (path = new PathWrapper()); }
+            get { return path ?? (path = new PathWrapper(this)); }
         }
 
         DirectoryInfoFactory directoryInfoFactory;
         public IDirectoryInfoFactory DirectoryInfo
         {
-            get { return directoryInfoFactory ?? (directoryInfoFactory = new DirectoryInfoFactory()); }
+            get { return directoryInfoFactory ?? (directoryInfoFactory = new DirectoryInfoFactory(this)); }
         }
 
-        private readonly Lazy<DriveInfoFactory> driveInfoFactory = new Lazy<DriveInfoFactory>(() => new DriveInfoFactory());
-
+        private readonly Lazy<DriveInfoFactory> driveInfoFactory;
         public IDriveInfoFactory DriveInfo
         {
             get { return driveInfoFactory.Value; }
         }
-		
+
         private IFileSystemWatcherFactory fileSystemWatcherFactory;
         public IFileSystemWatcherFactory FileSystemWatcher
         {

--- a/System.IO.Abstractions/FileSystemInfoBase.cs
+++ b/System.IO.Abstractions/FileSystemInfoBase.cs
@@ -9,6 +9,9 @@
             FileSystem = fileSystem ?? throw new ArgumentNullException(nameof(fileSystem));
         }
 
+        /// <summary>
+        /// Exposes the underlying filesystem implementation. This is useful for implementing extension methods.
+        /// </summary>
         public IFileSystem FileSystem { get; }
 
         /// <inheritdoc cref="FileSystemInfo.Delete"/>

--- a/System.IO.Abstractions/FileSystemInfoBase.cs
+++ b/System.IO.Abstractions/FileSystemInfoBase.cs
@@ -4,6 +4,13 @@
     [Serializable]
     public abstract class FileSystemInfoBase
     {
+        protected FileSystemInfoBase(IFileSystem fileSystem)
+        {
+            FileSystem = fileSystem ?? throw new ArgumentNullException(nameof(fileSystem));
+        }
+
+        public IFileSystem FileSystem { get; }
+
         /// <inheritdoc cref="FileSystemInfo.Delete"/>
         public abstract void Delete();
 

--- a/System.IO.Abstractions/FileSystemWatcherFactory.cs
+++ b/System.IO.Abstractions/FileSystemWatcherFactory.cs
@@ -5,6 +5,7 @@ using System.Text;
 
 namespace System.IO.Abstractions
 {
+    [Serializable]
     public class FileSystemWatcherFactory : IFileSystemWatcherFactory
     {
         public FileSystemWatcherBase CreateNew()

--- a/System.IO.Abstractions/FileWrapper.cs
+++ b/System.IO.Abstractions/FileWrapper.cs
@@ -8,6 +8,10 @@ namespace System.IO.Abstractions
     [Serializable]
     public class FileWrapper : FileBase
     {
+        public FileWrapper(FileSystem fileSystem) : base(fileSystem)
+        {
+        }
+
         public override void AppendAllLines(string path, IEnumerable<string> contents)
         {
             File.AppendAllLines(path, contents);

--- a/System.IO.Abstractions/PathBase.cs
+++ b/System.IO.Abstractions/PathBase.cs
@@ -4,6 +4,16 @@
     [Serializable]
     public abstract class PathBase
     {
+        protected PathBase(IFileSystem fileSystem)
+        {
+            this.FileSystem = fileSystem;
+        }
+
+        /// <summary>
+        /// Exposes the underlying filesystem implementation. This is useful for implementing extension methods.
+        /// </summary>
+        public IFileSystem FileSystem { get; }
+
         /// <inheritdoc cref="Path.AltDirectorySeparatorChar"/>
         public abstract char AltDirectorySeparatorChar { get; }
 

--- a/System.IO.Abstractions/PathWrapper.cs
+++ b/System.IO.Abstractions/PathWrapper.cs
@@ -3,6 +3,10 @@
     [Serializable]
     public class PathWrapper : PathBase
     {
+        public PathWrapper(IFileSystem fileSystem) : base(fileSystem)
+        {
+        }
+
         public override char AltDirectorySeparatorChar
         {
             get { return Path.AltDirectorySeparatorChar; }


### PR DESCRIPTION
This allows people to get at the underlying IFileSystem implementation when developing extension methods.

For example, it may make sense to put your extension method on DirectoryBase, but you may require FileBase to actually implement it. This makes that possible.

In addition it fixes a bug in MockFileInfo.Replace where the returned FileInfo was for the concrete FileSystem not the mock one (bug caused by implicit casting).

I think this commit actually removes the need for supporting implicit casting at all.