### PR TITLE
Skip CI on tags

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,9 @@ image: Visual Studio 2017
 configuration: Release
 
 skip_branch_with_pr: true
+
+skip_tags: true
+
 branches:
   only:
     - master


### PR DESCRIPTION
This change disables the AppVeyor pipeline to be triggered when a tag is pushed. 

That in turn allows us to create proper GitHub releases (as requested e.g. in #363) without triggering a new build (and therefore a new deployment).