### PR TITLE
Throw ArgumentException when path contains invalid characters

### DIFF
--- a/System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
@@ -277,5 +277,20 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             Assert.IsTrue(fileSystem.FileExists(path2));
         }
+
+        [Test]
+        public void MockFileSystem_GetFiles_ThrowsCorrectExceptionForInvalidCharacters()
+        {
+            // Arrange
+            const string path = @"c:\";
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddDirectory(XFS.Path(path));
+            
+            // Act
+            TestDelegate wrapped = () => fileSystem.Directory.GetFiles($"{path}{'\0'}.txt");
+
+            // Assert
+            Assert.Throws<ArgumentException>(wrapped);
+        }
     }
 }

--- a/System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
@@ -279,7 +279,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
-        public void MockFileSystem_GetFiles_ThrowsCorrectExceptionForInvalidCharacters()
+        public void MockFileSystem_GetFiles_ThrowsArgumentExceptionForInvalidCharacters()
         {
             // Arrange
             const string path = @"c:\";
@@ -287,10 +287,10 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.AddDirectory(XFS.Path(path));
             
             // Act
-            TestDelegate wrapped = () => fileSystem.Directory.GetFiles($"{path}{'\0'}.txt");
+            TestDelegate getFilesWithInvalidCharacterInPath = () => fileSystem.Directory.GetFiles($"{path}{'\0'}.txt");
 
             // Assert
-            Assert.Throws<ArgumentException>(wrapped);
+            Assert.Throws<ArgumentException>(getFilesWithInvalidCharacterInPath);
         }
     }
 }

--- a/System.IO.Abstractions.TestingHelpers/MockDirectory.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockDirectory.cs
@@ -177,12 +177,12 @@ namespace System.IO.Abstractions.TestingHelpers
         {
             if (path == null)
             {
-                throw new ArgumentNullException();
+                throw new ArgumentNullException(nameof(path));
             }
             
             if (path.Any(c => Path.GetInvalidPathChars().Contains(c)))
             {
-                throw new ArgumentException();
+                throw new ArgumentException("Invalid character(s) in path", nameof(path));
             }
 
             if (!Exists(path))

--- a/System.IO.Abstractions.TestingHelpers/MockDirectory.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockDirectory.cs
@@ -97,7 +97,6 @@ namespace System.IO.Abstractions.TestingHelpers
 
             try
             {
-
                 path = path.TrimSlashes();
                 path = mockFileDataAccessor.Path.GetFullPath(path);
                 return mockFileDataAccessor.AllDirectories.Any(p => p.Equals(path, StringComparison.OrdinalIgnoreCase));
@@ -176,8 +175,15 @@ namespace System.IO.Abstractions.TestingHelpers
 
         public override string[] GetFiles(string path, string searchPattern, SearchOption searchOption)
         {
-            if(path == null)
+            if (path == null)
+            {
                 throw new ArgumentNullException();
+            }
+            
+            if (path.Any(c => Path.GetInvalidPathChars().Contains(c)))
+            {
+                throw new ArgumentException();
+            }
 
             if (!Exists(path))
             {


### PR DESCRIPTION
Fixes #367 