### PR TITLE
Stop calling real IO.Path.GetTempPath() when creating a MockFileSystem

### DIFF
--- a/System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
@@ -1187,8 +1187,10 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
 
         [Test]
-        public void MockDirectory_GetCurrentDirectory_ShouldReturnDefaultPathWhenNotSet() {
-            string directory = Path.GetTempPath();
+        public void MockDirectory_GetCurrentDirectory_ShouldReturnDefaultPathWhenNotSet() 
+        {
+            string directory = XFS.Path(@"C:\");
+
             var fileSystem = new MockFileSystem();
 
             var actual = fileSystem.Directory.GetCurrentDirectory();

--- a/System.IO.Abstractions.TestingHelpers/MockFileSystem.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockFileSystem.cs
@@ -9,6 +9,8 @@ namespace System.IO.Abstractions.TestingHelpers
     [Serializable]
     public class MockFileSystem : IFileSystem, IMockFileDataAccessor
     {
+        private const string DEFAULT_CURRENT_DIRECTORY = @"C:\";
+
         private readonly IDictionary<string, MockFileData> files;
         [NonSerialized]
         private readonly PathVerifier pathVerifier;
@@ -19,7 +21,7 @@ namespace System.IO.Abstractions.TestingHelpers
         {
             if (string.IsNullOrEmpty(currentDirectory))
             {
-                currentDirectory = IO.Path.GetTempPath();
+                currentDirectory = XFS.Path(DEFAULT_CURRENT_DIRECTORY);
             }
 
             pathVerifier = new PathVerifier(this);


### PR DESCRIPTION
Fixes: #350 
Tried to do this with the smallest change possible. 
Hard-coding to `"C:\"` (which will get translated to `"/"` on unix) as per discussion on the issue.

Let me know if this is okay.