### PR TITLE
Implement MockFileSystemWatcher

### DIFF
--- a/System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemWatcherFactoryTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemWatcherFactoryTests.cs
@@ -13,7 +13,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         public void MockFileSystemWatcherFactory_CreateNew_ShouldReturnNonNullMockWatcher()
         {
             // Arrange
-            var factory = new MockFileSystemWatcherFactory();
+            var fs = new MockFileSystem();
+            var factory = new MockFileSystemWatcherFactory(fs);
 
             // Act
             var result = factory.CreateNew();
@@ -26,7 +27,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         public void MockFileSystemWatcherFactory_FromPath_ShouldReturnNonNullMockWatcher()
         {
             // Arrange
-            var factory = new MockFileSystemWatcherFactory();
+            var fs = new MockFileSystem();
+            var factory = new MockFileSystemWatcherFactory(fs);
 
             // Act
             var result = factory.FromPath(@"y:\test");
@@ -40,7 +42,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         {
             // Arrange
             const string path = @"z:\test";
-            var factory = new MockFileSystemWatcherFactory();
+            var fs = new MockFileSystem();
+            var factory = new MockFileSystemWatcherFactory(fs);
 
             // Act
             var result = factory.FromPath(path);

--- a/System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemWatcherTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemWatcherTests.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using NUnit.Framework;
+
+namespace System.IO.Abstractions.TestingHelpers.Tests
+{
+    [TestFixture]
+    public class MockFileSystemWatcherTests
+    {
+        [Test]
+        public void MockFileSystemWatcher_ListenForFileCreated()
+        {
+            var fs = new MockFileSystem();
+            fs.AddDirectory(@"C:\");
+            var created = false;
+
+            using (var watcher = fs.FileSystemWatcher.FromPath(@"C:\"))
+            {
+                watcher.Created += (sender, e) =>
+                {
+                    created = true;
+                };
+                fs.File.Create(@"C:\test.txt").Close();
+            }
+
+            Thread.Sleep(100); // TODO: make this unnecessary
+            Assert.IsTrue(created);
+        }
+    }
+}

--- a/System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemWatcherTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemWatcherTests.cs
@@ -1,8 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading;
+﻿using System.Threading;
+using System.Threading.Tasks;
 using NUnit.Framework;
 
 namespace System.IO.Abstractions.TestingHelpers.Tests
@@ -11,23 +8,61 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
     public class MockFileSystemWatcherTests
     {
         [Test]
-        public void MockFileSystemWatcher_ListenForFileCreated()
+        public void MockFileSystemWatcher_OnCreated_Listen()
         {
             var fs = new MockFileSystem();
             fs.AddDirectory(@"C:\");
-            var created = false;
+            var count = 0;
 
             using (var watcher = fs.FileSystemWatcher.FromPath(@"C:\"))
             {
-                watcher.Created += (sender, e) =>
-                {
-                    created = true;
-                };
+                watcher.Created += (sender, e) => count++;
                 fs.File.Create(@"C:\test.txt").Close();
             }
 
-            Thread.Sleep(100); // TODO: make this unnecessary
-            Assert.IsTrue(created);
+            Thread.Sleep(500); // TODO: make this unnecessary
+            Assert.AreEqual(1, count);
+        }
+
+        [Test]
+        public void MockFileSystemWatcher_OnCreated_UnderSpecificRoot()
+        {
+            var fs = new MockFileSystem();
+            fs.AddDirectory(@"C:\root");
+            var count = 0;
+
+            using (var watcher = fs.FileSystemWatcher.FromPath(@"C:\root"))
+            {
+                watcher.Created += (sender, e) => count++;
+                fs.File.Create(@"C:\test.txt").Close();
+                fs.File.Create(@"C:\root\test.txt").Close();
+            }
+
+            Thread.Sleep(500); // TODO: make this unnecessary
+            Assert.AreEqual(1, count);
+        }
+
+        [Test]
+        public void MockFileSystemWatcher_WaitForChanged_SpecificChangeType()
+        {
+            var fs = new MockFileSystem();
+            fs.AddDirectory(@"C:\root");
+            var count = 0;
+
+            using (var watcher = fs.FileSystemWatcher.FromPath(@"C:\root"))
+            {
+                var task = Task.Factory
+                    .StartNew(() => watcher.WaitForChanged(WatcherChangeTypes.Deleted, 1000))
+                    .ContinueWith(_ => count++);
+                fs.File.Create(@"C:\root\test.txt").Close();
+                fs.File.Move(@"C:\root\test.txt", @"C:\root\other.txt");
+                Thread.Sleep(500); // TODO: make this unnecessary
+                Assert.AreEqual(0, count);
+                fs.File.Delete(@"C:\root\other.txt");
+            }
+
+            Thread.Sleep(500); // TODO: make this unnecessary
+            Assert.AreEqual(1, count);
         }
     }
 }

--- a/System.IO.Abstractions.TestingHelpers/IMockFileDataAccessor.cs
+++ b/System.IO.Abstractions.TestingHelpers/IMockFileDataAccessor.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Reflection;
 
 namespace System.IO.Abstractions.TestingHelpers
@@ -21,6 +22,7 @@ namespace System.IO.Abstractions.TestingHelpers
         void AddFileFromEmbeddedResource(string path, Assembly resourceAssembly, string embeddedResourcePath);
         void AddFilesFromEmbeddedNamespace(string path, Assembly resourceAssembly, string embeddedRresourcePath);
 
+        void MoveFile(string sourcePath, string destPath);
         void MoveDirectory(string sourcePath, string destPath);
 
         /// <summary>
@@ -60,9 +62,9 @@ namespace System.IO.Abstractions.TestingHelpers
         PathBase Path { get; }
         IDirectoryInfoFactory DirectoryInfo { get; }
         IDriveInfoFactory DriveInfo { get; }
-
         PathVerifier PathVerifier { get; }
-
         IFileSystem FileSystem { get; }
+
+        ConcurrentQueue<FileSystemEventArgs> Listen();
     }
 }

--- a/System.IO.Abstractions.TestingHelpers/MockFile.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockFile.cs
@@ -362,16 +362,11 @@ namespace System.IO.Abstractions.TestingHelpers
                 }
             }
 
-
-            var sourceFile = mockFileDataAccessor.GetFile(sourceFileName);
-
-            if (sourceFile == null)
+            if (!mockFileDataAccessor.FileExists(sourceFileName))
                 throw new FileNotFoundException(string.Format(CultureInfo.InvariantCulture, "The file \"{0}\" could not be found.", sourceFileName), sourceFileName);
 
             VerifyDirectoryExists(destFileName);
-
-            mockFileDataAccessor.AddFile(destFileName, new MockFileData(sourceFile.Contents));
-            mockFileDataAccessor.RemoveFile(sourceFileName);
+            mockFileDataAccessor.MoveFile(sourceFileName, destFileName);
         }
 
         public override Stream Open(string path, FileMode mode)

--- a/System.IO.Abstractions.TestingHelpers/MockFileInfo.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockFileInfo.cs
@@ -1,5 +1,8 @@
 ﻿using System.Security.AccessControl;
 
+// TODO: make sure mock file system events are
+//       fired for operations on MockFileInfo
+
 namespace System.IO.Abstractions.TestingHelpers
 {
     [Serializable]

--- a/System.IO.Abstractions.TestingHelpers/MockFileInfo.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockFileInfo.cs
@@ -217,6 +217,11 @@ namespace System.IO.Abstractions.TestingHelpers
             }
             Delete();
             path = movedFileInfo.FullName;
+
+            // TODO: use File.Move instead
+            //var destPath = mockFileSystem.Path.GetFullPath(destFileName);
+            //mockFileSystem.MoveFile(path, destPath);
+            //path = destPath;
         }
 
         public override Stream Open(FileMode mode)

--- a/System.IO.Abstractions.TestingHelpers/MockFileSystemWatcher.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockFileSystemWatcher.cs
@@ -1,9 +1,47 @@
-﻿using System.ComponentModel;
+﻿using System.Collections.Concurrent;
+using System.ComponentModel;
+using System.Threading.Tasks;
 
 namespace System.IO.Abstractions.TestingHelpers
 {
     public class MockFileSystemWatcher : FileSystemWatcherBase
     {
+        private bool running = true;
+        private readonly Task task;
+
+        public MockFileSystemWatcher(ConcurrentQueue<FileSystemEventArgs> queue)
+        {
+            task = Task.Factory.StartNew(() =>
+            {
+                while (running)
+                {
+                    // TODO: filter on root path
+                    if (queue.TryDequeue(out var e))
+                    {
+                        if (e.ChangeType.HasFlag(WatcherChangeTypes.Created))
+                        {
+                            OnCreated(this, e);
+                        }
+
+                        if (e.ChangeType.HasFlag(WatcherChangeTypes.Deleted))
+                        {
+                            OnDeleted(this, e);
+                        }
+
+                        if (e.ChangeType.HasFlag(WatcherChangeTypes.Renamed))
+                        {
+                            OnRenamed(this, (RenamedEventArgs)e);
+                        }
+
+                        if (e.ChangeType.HasFlag(WatcherChangeTypes.Changed))
+                        {
+                            OnChanged(this, e);
+                        }
+                    }
+                }
+            });
+        }
+
         public override bool IncludeSubdirectories { get; set; }
         public override bool EnableRaisingEvents { get; set; }
         public override string Filter { get; set; }
@@ -24,6 +62,15 @@ namespace System.IO.Abstractions.TestingHelpers
         {
         }
 #endif
+
+        public override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+            running = false;
+            task.Wait();
+        }
+
+        // TODO: notify threads blocked waiting for event
 
         public override WaitForChangedResult WaitForChanged(WatcherChangeTypes changeType)
         {

--- a/System.IO.Abstractions.TestingHelpers/MockFileSystemWatcherFactory.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockFileSystemWatcherFactory.cs
@@ -9,9 +9,9 @@
             this.mockFileDataAccessor = mockFileDataAccessor;
 
         public FileSystemWatcherBase CreateNew() =>
-            new MockFileSystemWatcher(mockFileDataAccessor.Listen());
+            new MockFileSystemWatcher(mockFileDataAccessor);
 
         public FileSystemWatcherBase FromPath(string path) =>
-            new MockFileSystemWatcher(mockFileDataAccessor.Listen()) {Path = path};
+            new MockFileSystemWatcher(mockFileDataAccessor, path);
     }
 }

--- a/System.IO.Abstractions.TestingHelpers/MockFileSystemWatcherFactory.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockFileSystemWatcherFactory.cs
@@ -1,21 +1,17 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace System.IO.Abstractions.TestingHelpers
+﻿namespace System.IO.Abstractions.TestingHelpers
 {
     [Serializable]
     public class MockFileSystemWatcherFactory : IFileSystemWatcherFactory
     {
-        public FileSystemWatcherBase CreateNew()
-        {
-            return new MockFileSystemWatcher();
-        }
+        private readonly IMockFileDataAccessor mockFileDataAccessor;
 
-        public FileSystemWatcherBase FromPath(string path)
-        {
-            return new MockFileSystemWatcher {Path = path};
-        }
+        public MockFileSystemWatcherFactory(IMockFileDataAccessor mockFileDataAccessor) =>
+            this.mockFileDataAccessor = mockFileDataAccessor;
+
+        public FileSystemWatcherBase CreateNew() =>
+            new MockFileSystemWatcher(mockFileDataAccessor.Listen());
+
+        public FileSystemWatcherBase FromPath(string path) =>
+            new MockFileSystemWatcher(mockFileDataAccessor.Listen()) {Path = path};
     }
 }

--- a/System.IO.Abstractions.TestingHelpers/WaitableRef.cs
+++ b/System.IO.Abstractions.TestingHelpers/WaitableRef.cs
@@ -1,0 +1,32 @@
+﻿using System.Threading;
+
+namespace System.IO.Abstractions.TestingHelpers
+{
+    public class WaitableRef<T>
+    {
+        private readonly ManualResetEventSlim signal = new ManualResetEventSlim();
+        private T value;
+
+        public void Send(T value)
+        {
+            this.value = value;
+            signal.Set();
+        }
+
+        public T Wait()
+        {
+            signal.Wait();
+            return value;
+        }
+
+        public T Wait(int millisecondsTimeout)
+        {
+            if (signal.Wait(millisecondsTimeout))
+            {
+                return value;
+            }
+
+            throw new TimeoutException();
+        }
+    }
+}

--- a/System.IO.Abstractions/FileSystemWatcherBase.cs
+++ b/System.IO.Abstractions/FileSystemWatcherBase.cs
@@ -52,6 +52,7 @@ namespace System.IO.Abstractions
         public abstract void BeginInit();
 #endif
 
+        /// <inheritdoc cref="FileSystemWatcher.Dispose" />
         public void Dispose()
         {
             Dispose(true);
@@ -69,6 +70,10 @@ namespace System.IO.Abstractions
         /// <inheritdoc cref="FileSystemWatcher.WaitForChanged(WatcherChangeTypes,int)"/>
         public abstract WaitForChangedResult WaitForChanged(WatcherChangeTypes changeType, int timeout);
 
+        /// <summary>
+        /// Converts a standard <see cref="FileSystemWatcher"/> to a
+        /// compatible <see cref="FileSystemWatcherBase"/>.
+        /// </summary>
         public static implicit operator FileSystemWatcherBase(FileSystemWatcher watcher)
         {
             if (watcher == null)
@@ -79,31 +84,37 @@ namespace System.IO.Abstractions
             return new FileSystemWatcherWrapper(watcher);
         }
 
+        /// <inheritdoc cref="FileSystemWatcher.Dispose(bool)" />
         public virtual void Dispose(bool disposing)
         {
             // do nothing
         }
 
+        /// <inheritdoc cref="FileSystemWatcher.OnCreated(FileSystemEventArgs)" />
         protected void OnCreated(object sender, FileSystemEventArgs args)
         {
             Created?.Invoke(sender, args);
         }
 
+        /// <inheritdoc cref="FileSystemWatcher.OnChanged(FileSystemEventArgs)" />
         protected void OnChanged(object sender, FileSystemEventArgs args)
         {
             Changed?.Invoke(sender, args);
         }
 
+        /// <inheritdoc cref="FileSystemWatcher.OnDeleted(FileSystemEventArgs)" />
         protected void OnDeleted(object sender, FileSystemEventArgs args)
         {
             Deleted?.Invoke(sender, args);
         }
 
+        /// <inheritdoc cref="FileSystemWatcher.OnRenamed(RenamedEventArgs)" />
         protected void OnRenamed(object sender, RenamedEventArgs args)
         {
             Renamed?.Invoke(sender, args);
         }
 
+        /// <inheritdoc cref="FileSystemWatcher.OnError(ErrorEventArgs)" />
         protected void OnError(object sender, ErrorEventArgs args)
         {
             Error?.Invoke(sender, args);

--- a/System.IO.Abstractions/FileSystemWatcherWrapper.cs
+++ b/System.IO.Abstractions/FileSystemWatcherWrapper.cs
@@ -1,5 +1,7 @@
 ﻿using System.ComponentModel;
 
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
 namespace System.IO.Abstractions
 {
     [Serializable]


### PR DESCRIPTION
Fixes #329

Here's my attempt at a working `MockFileSystemWatcher`. The referenced issue was only for the `WaitForChanged` methods, but really the whole class didn't do anything.

In order to support this, `MockFileSystem` needed an event dispatch system built into it.

### Current Approach

Listeners can get hold of a `ConcurrentQueue` by calling `Listen` and the MFS will keep a list of those queues, pushing events into them as modification operations are performed.

For the `WaitForChanged` methods specifically, they are effectively one-time filtered (by event type) event handlers. A `WaitableRef` class was added to so the accumulation of waiters on a particular event can be modeled. Each waiter has a `ManualResetEvent` to signal when the required event type has happened and an internal field to hold the event object. The waiters get added to a dictionary in the `MockFileSystemWatcher`. When the watcher receives an event, it checks if there are waiters that need that event type, `Send` it to them (which triggers the `Wait`ing thread to wake up) and removes them from the dictionary.

There are a few tests, but they don't pass reliably on my machine. Concurrency is surely not implemented too well. I would also want to get rid of those `Thread.Sleep`s.

More notes:
  * Operations on directories are ignored as I believe the `FileSystemWatcher` only handles events on files.
  * `MockFileSystem` dispatches events synchronously. Not too big of a deal as the event handling code doesn't immediately run on the same thread, but this does make the calling thread to `File.Create`, etc spend the time to add the events to the queues.
  * If a file is "moved" to the same directory, but with a different name, it's considered a `Renamed` event, not two separate `Deleted` and `Created` events.
  * Added internal `MockFileSystem.MoveFile` event to better identify events.
  * `MockFileInfo` still needs to be updated, in particular, to prevent it from doing delete/create and using the internal `MoveFile` function instead.
  * `Changed` event currently not dispatched. I assume this means file contents changed.

---

### Reactive

The current use of concurrency is fairly fragile, and it occurred to me that `System.Reactive` would be a better way to go. The MFS would have a `Subject` that it would `OnNext` events to, and the FSWs would be able to simply `Subscribe` to the `Subject` and use `.Where` to filter for messages under the directory root that they are watching. Waiters would subscribe to their watcher's filtered subscription, but with an additional `.FirstAsync(e => e.ChangeType == changeType)` so they only get the next event of the required type. Then chain `.ToTask().Wait(int)` to synchronously wait for the event as the `WaitForChanged` method is designed that way.

I don't think adding `System.Reactive` would be too onerous as it would only be added to the `TestingHelpers`, it wouldn't make the S.IO.A.dll any bigger, or introduce transitive dependency issues in prod. On the other hand, I wasn't sure which version to use to support `net40`, `netstandard1.4` and `netstandard2.0` as this library does.

---

OK, so after all of that, how accurately do we want to reproduce the behavior of `FileSystemWatcher`? Should we just cut corner on this one? Unit tests could get a hold of the MockFSW passed into SUT and call its `OnCreate`, etc methods directly. That might be enough?