### PR TITLE
Clone binary contents rather than text contents, add test to cover th…

### DIFF
--- a/System.IO.Abstractions.TestingHelpers.Tests/MockFileCopyTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockFileCopyTests.cs
@@ -49,6 +49,28 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
+        public void MockFile_Copy_ShouldCloneBinaryContents()
+        {
+            var sourceFileName = XFS.Path(@"c:\source\demo.bin");
+            var destFileName = XFS.Path(@"c:\source\demo_copy.bin");
+
+            byte[] original = new byte[] { 0xC0 };
+            var mockFileSystem = new MockFileSystem();
+            mockFileSystem.AddFile(sourceFileName, new MockFileData(original));
+            mockFileSystem.File.Copy(sourceFileName, destFileName);
+
+            using (var stream = mockFileSystem.File.Open(sourceFileName, FileMode.Open, FileAccess.ReadWrite))
+            {
+                var binaryWriter = new System.IO.BinaryWriter(stream);
+
+                binaryWriter.Seek(0, SeekOrigin.Begin);
+                binaryWriter.Write("Modified");
+            }
+
+            CollectionAssert.AreEqual(original, mockFileSystem.File.ReadAllBytes(destFileName));
+        }
+
+        [Test]
         public void MockFile_Copy_ShouldCreateFileAtNewDestination()
         {
             string sourceFileName = XFS.Path(@"c:\source\demo.txt");

--- a/System.IO.Abstractions.TestingHelpers/MockFileData.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockFileData.cs
@@ -96,7 +96,7 @@ namespace System.IO.Abstractions.TestingHelpers
 
             accessControl = template.accessControl;
             Attributes = template.Attributes;
-            TextContents = template.TextContents;
+            Contents = template.Contents.ToArray();
             CreationTime = template.CreationTime;
             LastAccessTime = template.LastAccessTime;
             LastWriteTime = template.LastWriteTime;


### PR DESCRIPTION
…is scenario as well

Fixes #375 

When copying a file, TextContents (and underlying a TextReader) was used to copy a file rather than the actual byte[] Contents. This caused an issue when the bytes could not be read using the default UTF8 encoding. 