### PR TITLE
Fix for #284: MockFile.Delete does not throw exception when file does not exist.

### DIFF
--- a/System.IO.Abstractions.TestingHelpers.Tests/MockFileDeleteTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockFileDeleteTests.cs
@@ -57,7 +57,7 @@
             string filePath = XFS.Path("C:\\temp\\somefile.txt");
 
             // Delete() returns void, so there is nothing to check here beside absense of an exception
-            fileSystem.File.Delete(filePath);
+            Assert.DoesNotThrow(() => fileSystem.File.Delete(filePath));
         }
     }
 }

--- a/System.IO.Abstractions.TestingHelpers.Tests/MockFileDeleteTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockFileDeleteTests.cs
@@ -1,6 +1,7 @@
 ﻿namespace System.IO.Abstractions.TestingHelpers.Tests
 {
-    using NUnit.Framework;
+  using System.Collections.Generic;
+  using NUnit.Framework;
 
     using XFS = MockUnixSupport;
 
@@ -48,11 +49,15 @@
         [Test]
         public void MockFile_Delete_ShouldSilentlyReturnIfNonExistingFileInExistingFolder()
         {
-            var fileSystem = new MockFileSystem();
-            fileSystem.Directory.CreateDirectory("c:\\temp");
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>()
+            {
+                { XFS.Path("C:\\temp\\exist.txt"), new MockFileData("foobar") },
+            });
 
-            //Delete() returns void, so there is nothing to check here beside absense of an exception
-            fileSystem.File.Delete("C:\\temp\\somefile.txt");
+            string filePath = XFS.Path("C:\\temp\\somefile.txt");
+
+            // Delete() returns void, so there is nothing to check here beside absense of an exception
+            fileSystem.File.Delete(filePath);
         }
     }
 }

--- a/System.IO.Abstractions.TestingHelpers.Tests/MockFileDeleteTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockFileDeleteTests.cs
@@ -10,7 +10,7 @@
         public void MockFile_Delete_ShouldDeleteFile()
         {
             var fileSystem = new MockFileSystem();
-            var path = XFS.Path("C:\\test");
+            var path = XFS.Path("C:\\some_folder\\test");
             var directory = fileSystem.Path.GetDirectoryName(path);
             fileSystem.AddFile(path, new MockFileData("Bla"));
 
@@ -34,6 +34,25 @@
 
             // Assert
             Assert.Throws<ArgumentException>(action);
+        }
+
+        [Test]
+        public void MockFile_Delete_ShouldThrowDirectoryNotFoundExceptionIfParentFolderAbsent()
+        {
+            var fileSystem = new MockFileSystem();
+            var path = XFS.Path("C:\\test\\somefile.txt");
+
+            Assert.Throws<DirectoryNotFoundException>(() => fileSystem.File.Delete(path));
+        }
+
+        [Test]
+        public void MockFile_Delete_ShouldSilentlyReturnIfNonExistingFileInExistingFolder()
+        {
+            var fileSystem = new MockFileSystem();
+            fileSystem.Directory.CreateDirectory("c:\\temp");
+
+            //Delete() returns void, so there is nothing to check here beside absense of an exception
+            fileSystem.File.Delete("C:\\temp\\somefile.txt");
         }
     }
 }

--- a/System.IO.Abstractions.TestingHelpers.Tests/MockFileStreamTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockFileStreamTests.cs
@@ -29,7 +29,7 @@
         public void MockFileStream_Dispose_ShouldNotResurrectFile()
         {
             var fileSystem = new MockFileSystem();
-            var path = XFS.Path("C:\\test");
+            var path = XFS.Path("C:\\some_folder\\test");
             var directory = fileSystem.Path.GetDirectoryName(path);
             fileSystem.AddFile(path, new MockFileData("Bla"));
             var stream = fileSystem.File.Open(path, FileMode.Open, FileAccess.ReadWrite, FileShare.Delete);

--- a/System.IO.Abstractions.TestingHelpers.Tests/MockFileStreamTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockFileStreamTests.cs
@@ -28,6 +28,8 @@
         [Test]
         public void MockFileStream_Dispose_ShouldNotResurrectFile()
         {
+            // path in this test case is a subject to Directory.GetParent(path) Linux issue
+            // https://github.com/System-IO-Abstractions/System.IO.Abstractions/issues/395
             var fileSystem = new MockFileSystem();
             var path = XFS.Path("C:\\some_folder\\test");
             var directory = fileSystem.Path.GetDirectoryName(path);

--- a/System.IO.Abstractions.TestingHelpers.Tests/MockFileTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockFileTests.cs
@@ -482,9 +482,14 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
         [Test]
         public void MockFile_Delete_No_File_Does_Nothing()
-        {
-            string filePath = XFS.Path(@"c:\something\demo.txt");
-            var fileSystem = new MockFileSystem();
+        {            
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>()
+            {
+                { XFS.Path(@"c:\something\exist.txt"), new MockFileData("Demo text content") },
+            });
+
+            string filePath = XFS.Path(@"c:\something\not_exist.txt");
+
             fileSystem.File.Delete(filePath);
         }
 

--- a/System.IO.Abstractions.TestingHelpers/MockFile.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockFile.cs
@@ -191,6 +191,11 @@ namespace System.IO.Abstractions.TestingHelpers
         {
             mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, "path");
 
+            // We mimic exact behavior of the standard File.Delete() method
+            // which throws exception only if the folder does not exist,
+            // but silently returns if deleting a non-existing file in an existing folder.
+            VerifyDirectoryExists(path);
+
             mockFileDataAccessor.RemoveFile(path);
         }
 
@@ -991,7 +996,11 @@ namespace System.IO.Abstractions.TestingHelpers
             DirectoryInfoBase dir = mockFileDataAccessor.Directory.GetParent(path);
             if (!dir.Exists)
             {
-                throw new DirectoryNotFoundException(string.Format(CultureInfo.InvariantCulture, StringResources.Manager.GetString("COULD_NOT_FIND_PART_OF_PATH_EXCEPTION"), dir));
+                throw new DirectoryNotFoundException(
+                    string.Format(
+                        CultureInfo.InvariantCulture, 
+                        StringResources.Manager.GetString("COULD_NOT_FIND_PART_OF_PATH_EXCEPTION"), 
+                        dir));
             }
         }
     }


### PR DESCRIPTION
Attempt to fix the subject bug.