### PR TITLE
Call base.Close() in MockFileStream.Close()

### DIFF
--- a/System.IO.Abstractions.TestingHelpers.Tests/MockFileStreamTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockFileStreamTests.cs
@@ -106,5 +106,20 @@
             // Assert
             Assert.DoesNotThrow(() => stream.Dispose());
         }
+
+        [Test]
+        public void MockFileStream_Dispose_OperationsAfterDisposeThrow()
+        {
+            var fileSystem = new MockFileSystem();
+            var path = XFS.Path("C:\\test");
+            fileSystem.AddFile(path, new MockFileData(new byte[0]));
+            var stream = fileSystem.FileInfo.FromFileName(path).OpenWrite();
+
+            // Act
+            stream.Dispose();
+
+            // Assert
+            Assert.Throws<ObjectDisposedException>(() => stream.WriteByte(0));
+        }
     }
 }

--- a/System.IO.Abstractions.TestingHelpers/MockFileStream.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockFileStream.cs
@@ -65,13 +65,13 @@
 #if NET40
         public override void Close()
         {
-            if(closed)
+            if (closed)
             {
                 return;
             }
             InternalFlush();
-            OnClose();
             base.Close();
+            OnClose();
             closed = true;
         }
 #else

--- a/System.IO.Abstractions.TestingHelpers/MockFileStream.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockFileStream.cs
@@ -66,6 +66,7 @@
         {
             InternalFlush();
             OnClose();
+            base.Close();
         }
 #else
         protected override void Dispose(bool disposing)

--- a/System.IO.Abstractions.TestingHelpers/MockFileStream.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockFileStream.cs
@@ -8,6 +8,7 @@
         private readonly bool canWrite = true;
         private readonly FileOptions options;
         private bool disposed;
+        private bool closed;
 
         public enum StreamType
         {
@@ -64,9 +65,14 @@
 #if NET40
         public override void Close()
         {
+            if(closed)
+            {
+                return;
+            }
             InternalFlush();
             OnClose();
             base.Close();
+            closed = true;
         }
 #else
         protected override void Dispose(bool disposing)


### PR DESCRIPTION
Fixes #397.