### PR TITLE
Fix file operations that fail when used with relative paths 

### DIFF
--- a/System.IO.Abstractions.TestingHelpers.Tests/MockFileAppendAllTextTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockFileAppendAllTextTests.cs
@@ -143,5 +143,16 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 expected,
                 file.ReadAllBytes(path));
         }
+        
+        [Test]
+        public void MockFile_AppendAllText_ShouldWorkWithRelativePath()
+        {
+            var file = "file.txt";
+            var fileSystem = new MockFileSystem();
+
+            fileSystem.File.AppendAllText(file, "Foo");
+            
+            Assert.That(fileSystem.File.Exists(file));
+        }
     }
 }

--- a/System.IO.Abstractions.TestingHelpers.Tests/MockFileCopyTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockFileCopyTests.cs
@@ -368,5 +368,18 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             Assert.Throws<FileNotFoundException>(action);
         }
+        
+        [Test]
+        public void MockFile_Copy_ShouldWorkWithRelativePaths()
+        {
+            var sourceFile = "source_file.txt";
+            var destinationFile = "destination_file.txt";
+            var fileSystem = new MockFileSystem();
+
+            fileSystem.File.Create(sourceFile).Close();
+            fileSystem.File.Copy(sourceFile, destinationFile);
+
+            Assert.That(fileSystem.File.Exists(destinationFile));
+        }
     }
 }

--- a/System.IO.Abstractions.TestingHelpers.Tests/MockFileCreateTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockFileCreateTests.cs
@@ -279,5 +279,16 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             Assert.IsTrue(fileInfo.Attributes.HasFlag(FileAttributes.Encrypted));
         }
 #endif
+
+        [Test]
+        public void MockFile_Create_ShouldWorkWithRelativePath()
+        {
+            var relativeFile = "file.txt";
+            var fileSystem = new MockFileSystem();
+
+            fileSystem.File.Create(relativeFile).Close();
+
+            Assert.That(fileSystem.File.Exists(relativeFile));
+        }
     }
 }

--- a/System.IO.Abstractions.TestingHelpers.Tests/MockFileCreateTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockFileCreateTests.cs
@@ -155,12 +155,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         {
             // Arrange
             var fileSystem = new MockFileSystem();
+            var file = XFS.Path("C:\\path\\NotFound.ext");
 
             // Act
-            TestDelegate action = () => fileSystem.File.Create("C:\\Path\\NotFound.ext");
+            TestDelegate action = () => fileSystem.File.Create(file);
 
             // Assert
-            Assert.IsFalse(fileSystem.Directory.Exists("C:\\path"));
             var exception = Assert.Throws<DirectoryNotFoundException>(action);
             Assert.That(exception.Message, Does.StartWith("Could not find a part of the path"));
         }

--- a/System.IO.Abstractions.TestingHelpers.Tests/MockFileOpenTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockFileOpenTests.cs
@@ -258,5 +258,16 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var exception = Assert.Throws<DirectoryNotFoundException>(action);
             Assert.That(exception.Message, Does.StartWith("Could not find a part of the path"));
         }
+
+        [Test]
+        public void MockFile_OpenWrite_ShouldWorkWithRelativePath()
+        {
+            var file = "file.txt";
+            var fileSystem = new MockFileSystem();
+
+            fileSystem.File.OpenWrite(file).Close();
+
+            Assert.That(fileSystem.File.Exists(file));
+        }
     }
 }

--- a/System.IO.Abstractions.TestingHelpers.Tests/MockFileOpenTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockFileOpenTests.cs
@@ -249,12 +249,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         {
             // Arrange
             var fileSystem = new MockFileSystem();
+            var file = XFS.Path("C:\\path\\NotFound.ext");
 
             // Act
-            TestDelegate action = () => fileSystem.File.Open("C:\\Path\\NotFound.ext", FileMode.Create);
+            TestDelegate action = () => fileSystem.File.Open(file, FileMode.Create);
 
             // Assert
-            Assert.IsFalse(fileSystem.Directory.Exists("C:\\path"));
             var exception = Assert.Throws<DirectoryNotFoundException>(action);
             Assert.That(exception.Message, Does.StartWith("Could not find a part of the path"));
         }

--- a/System.IO.Abstractions.TestingHelpers/MockFile.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockFile.cs
@@ -57,7 +57,8 @@ namespace System.IO.Abstractions.TestingHelpers
 
             if (!mockFileDataAccessor.FileExists(path))
             {
-                var dir = mockFileDataAccessor.Path.GetDirectoryName(path);
+                var mockPath = mockFileDataAccessor.Path;
+                var dir = mockPath.GetDirectoryName(mockPath.GetFullPath(path));
                 if (!mockFileDataAccessor.Directory.Exists(dir))
                 {
                     throw new DirectoryNotFoundException(string.Format(CultureInfo.InvariantCulture, StringResources.Manager.GetString("COULD_NOT_FIND_PART_OF_PATH_EXCEPTION"), path));
@@ -112,7 +113,7 @@ namespace System.IO.Abstractions.TestingHelpers
                 throw new FileNotFoundException(string.Format(CultureInfo.InvariantCulture, StringResources.Manager.GetString("COULD_NOT_FIND_FILE_EXCEPTION"), sourceFileName));
             }
 
-            var directoryNameOfDestination = mockPath.GetDirectoryName(destFileName);
+            var directoryNameOfDestination = mockPath.GetDirectoryName(mockPath.GetFullPath(destFileName));
             if (!mockFileDataAccessor.Directory.Exists(directoryNameOfDestination))
             {
                 throw new DirectoryNotFoundException(string.Format(CultureInfo.InvariantCulture, StringResources.Manager.GetString("COULD_NOT_FIND_PART_OF_PATH_EXCEPTION"), destFileName));
@@ -155,7 +156,8 @@ namespace System.IO.Abstractions.TestingHelpers
             }
 
             mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, nameof(path));
-            var directoryPath = mockPath.GetDirectoryName(path);
+
+            var directoryPath = mockPath.GetDirectoryName(mockPath.GetFullPath(path));
 
             if (!mockFileDataAccessor.Directory.Exists(directoryPath))
             {


### PR DESCRIPTION
Root cause for the problems is https://github.com/wleader/System.IO.Abstractions/commit/95ead3a2a3fbe848e34642931f2e5fafc2368c5a#diff-e76db4b13ed41e41943b80f8f1075287 where we started using `Path.GetDirectoryName` to get the parent directory, but unfortunately this method returns an empty string when the path does not contain directory information (e.g. a plain file name).

The changes here make the paths absolute before passing them on to `Path.GetDirectoryName`.

Fixes #404 and #401