### PR TITLE
Make paths case-sensitive on Unix

### DIFF
--- a/System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
@@ -1285,6 +1285,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
+        [WindowsOnly(WindowsSpecifics.StrictPathRules)]
         public void MockDirectory_GetParent_ShouldThrowArgumentExceptionIfPathHasIllegalCharacters()
         {
             // Arrange

--- a/System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
@@ -599,6 +599,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
+        [WindowsOnly(WindowsSpecifics.CaseInsensitivity)]
         public void MockDirectory_Delete_ShouldDeleteDirectoryCaseInsensitively()
         {
             // Arrange
@@ -612,6 +613,40 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             // Assert
             Assert.IsFalse(fileSystem.Directory.Exists(XFS.Path(@"c:\bar")));
+        }
+
+        [Test]
+        [UnixOnly(UnixSpecifics.CaseSensitivity)]
+        public void MockDirectory_Delete_ShouldThrowDirectoryNotFoundException_WhenSpecifiedWithInDifferentCase()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { "/bar/foo.txt", new MockFileData("Demo text content") }
+            });
+
+            // Act
+            TestDelegate action = () => fileSystem.Directory.Delete("/BAR", true);
+
+            // Assert
+            Assert.Throws<DirectoryNotFoundException>(action);
+        }
+
+        [Test]
+        [UnixOnly(UnixSpecifics.CaseSensitivity)]
+        public void MockDirectory_Delete_ShouldDeleteDirectoryCaseSensitively()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { "/bar/foo.txt", new MockFileData("Demo text content") }
+            });
+
+            // Act
+            fileSystem.Directory.Delete("/bar", true);
+
+            // Assert
+            Assert.IsFalse(fileSystem.Directory.Exists("/bar"));
         }
 
         [Test]

--- a/System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
@@ -1312,6 +1312,21 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             Assert.IsNull(actualResult);
         }
 
+        [Test]
+        [UnixOnly(UnixSpecifics.SlashRoot)]
+        public void MockDirectory_GetParent_ShouldReturnRootIfDirectoryIsInRoot()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddDirectory("/bar");
+
+            // Act
+            var parent = fileSystem.Directory.GetParent("/bar");
+
+            // Assert
+            Assert.AreEqual("/", parent.FullName);
+        }
+
         public static IEnumerable<string[]> MockDirectory_GetParent_Cases
         {
             get

--- a/System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
@@ -884,8 +884,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             else
             {
                 Assert.AreEqual(2, drives.Length);
-                Assert.IsTrue(drives.Contains("c:\\"));
-                Assert.IsTrue(drives.Contains("d:\\"));
+                Assert.IsTrue(drives.Contains(@"C:\"));
+                Assert.IsTrue(drives.Contains(@"D:\"));
             }
         }
 #endif

--- a/System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
@@ -1285,7 +1285,6 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
-        [WindowsOnly(WindowsSpecifics.EmptyInvalidPathChars)]
         public void MockDirectory_GetParent_ShouldThrowArgumentExceptionIfPathHasIllegalCharacters()
         {
             // Arrange

--- a/System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
@@ -547,10 +547,10 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var fileSystem = new MockFileSystem();
 
             // Act
-            fileSystem.Directory.CreateDirectory(XFS.Path(@"\\server\share\path\to\create", () => false));
+            fileSystem.Directory.CreateDirectory(@"\\server\share\path\to\create");
 
             // Assert
-            Assert.IsTrue(fileSystem.Directory.Exists(XFS.Path(@"\\server\share\path\to\create\", () => false)));
+            Assert.IsTrue(fileSystem.Directory.Exists(@"\\server\share\path\to\create\"));
         }
 
         [Test]
@@ -561,7 +561,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var fileSystem = new MockFileSystem();
 
             // Act
-            var ex = Assert.Throws<ArgumentException>(() => fileSystem.Directory.CreateDirectory(XFS.Path(@"\\server", () => false)));
+            var ex = Assert.Throws<ArgumentException>(() => fileSystem.Directory.CreateDirectory(@"\\server"));
 
             // Assert
             StringAssert.StartsWith("The UNC path should be of the form \\\\server\\share.", ex.Message);
@@ -576,10 +576,10 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var fileSystem = new MockFileSystem();
 
             // Act
-            fileSystem.Directory.CreateDirectory(XFS.Path(@"\\server\share", () => false));
+            fileSystem.Directory.CreateDirectory(@"\\server\share");
 
             // Assert
-            Assert.IsTrue(fileSystem.Directory.Exists(XFS.Path(@"\\server\share\", () => false)));
+            Assert.IsTrue(fileSystem.Directory.Exists(@"\\server\share\"));
         }
 
         [Test]
@@ -1250,14 +1250,9 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
+        [WindowsOnly(WindowsSpecifics.EmptyInvalidPathChars)]
         public void MockDirectory_GetParent_ShouldThrowArgumentExceptionIfPathHasIllegalCharacters()
         {
-            if (XFS.IsUnixPlatform())
-            {
-                Assert.Pass("Path.GetInvalidChars() does not return anything on Mono");
-                return;
-            }
-
             // Arrange
             var fileSystem = new MockFileSystem();
 

--- a/System.IO.Abstractions.TestingHelpers.Tests/MockFileExistsTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockFileExistsTests.cs
@@ -6,21 +6,20 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
     using XFS = MockUnixSupport;
 
-    public class MockFileExistsTests {
+    public class MockFileExistsTests
+    {
         [Test]
         public void MockFile_Exists_ShouldReturnTrueForSamePath()
         {
             // Arrange
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
             {
-                { XFS.Path(@"c:\something\demo.txt"), new MockFileData("Demo text content") },
-                { XFS.Path(@"c:\something\other.gif"), new MockFileData(new byte[] { 0x21, 0x58, 0x3f, 0xa9 }) }
+                { XFS.Path(@"C:\something\demo.txt"), new MockFileData("Demo text content") },
+                { XFS.Path(@"C:\something\other.gif"), new MockFileData("gif content") }
             });
 
-            var file = new MockFile(fileSystem);
-
             // Act
-            var result = file.Exists(XFS.Path(@"c:\something\other.gif"));
+            var result = fileSystem.File.Exists(XFS.Path(@"C:\something\other.gif"));
 
             // Assert
             Assert.IsTrue(result);
@@ -33,14 +32,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             // Arrange
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
             {
-                { XFS.Path(@"c:\something\demo.txt"), new MockFileData("Demo text content") },
-                { XFS.Path(@"c:\something\other.gif"), new MockFileData(new byte[] { 0x21, 0x58, 0x3f, 0xa9 }) }
+                { @"C:\something\demo.txt", new MockFileData("Demo text content") }
             });
 
-            var file = new MockFile(fileSystem);
-
             // Act
-            var result = file.Exists(XFS.Path(@"c:\SomeThing\Other.gif"));
+            var result = fileSystem.File.Exists(@"C:\SomeThing\DEMO.txt");
 
             // Assert
             Assert.IsTrue(result);
@@ -53,14 +49,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             // Arrange
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
             {
-                { XFS.Path(@"c:\something\demo.txt"), new MockFileData("Demo text content") },
-                { XFS.Path(@"c:\something\other.gif"), new MockFileData(new byte[] { 0x21, 0x58, 0x3f, 0xa9 }) }
+                { "/something/demo.txt", new MockFileData("Demo text content") }
             });
 
-            var file = new MockFile(fileSystem);
-
             // Act
-            var result = file.Exists(XFS.Path(@"c:\SomeThing\Other.gif"));
+            var result = fileSystem.File.Exists("/SomeThing/Other.gif");
 
             // Assert
             Assert.IsFalse(result);
@@ -72,14 +65,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             // Arrange
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
             {
-                { XFS.Path(@"c:\something\demo.txt"), new MockFileData("Demo text content") },
-                { XFS.Path(@"c:\something\other.gif"), new MockFileData(new byte[] { 0x21, 0x58, 0x3f, 0xa9 }) }
+                { XFS.Path(@"C:\something\demo.txt"), new MockFileData("Demo text content") },
+                { XFS.Path(@"C:\something\other.gif"), new MockFileData("gif content") }
             });
 
-            var file = new MockFile(fileSystem);
-
             // Act
-            var result = file.Exists(XFS.Path(@"c:\SomeThing\DoesNotExist.gif"));
+            var result = fileSystem.File.Exists(XFS.Path(@"C:\SomeThing\DoesNotExist.gif"));
 
             // Assert
             Assert.IsFalse(result);
@@ -88,9 +79,14 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         [Test]
         public void MockFile_Exists_ShouldReturnFalseForNullPath()
         {
-            var file = new MockFile(new MockFileSystem());
+            // Arrange
+            var fileSystem = new MockFileSystem();
 
-            Assert.That(file.Exists(null), Is.False);
+            // Act
+            var result = fileSystem.File.Exists(null);
+
+            // Assert
+            Assert.IsFalse(result);
         }
 
         [Test]
@@ -99,14 +95,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             // Arrange
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
             {
-                { XFS.Path(@"c:\something\demo.txt"), new MockFileData("Demo text content") },
-                { XFS.Path(@"c:\something\other.gif"), new MockFileData(new byte[] { 0x21, 0x58, 0x3f, 0xa9 }) }
+                { XFS.Path(@"C:\something\demo.txt"), new MockFileData("Demo text content") },
+                { XFS.Path(@"C:\something\other.gif"), new MockFileData("gif content") }
             });
 
-            var file = new MockFile(fileSystem);
-
             // Act
-            var result = file.Exists(XFS.Path(@"c:\SomeThing\"));
+            var result = fileSystem.File.Exists(XFS.Path(@"C:\something\"));
 
             // Assert
             Assert.IsFalse(result);

--- a/System.IO.Abstractions.TestingHelpers.Tests/MockFileExistsTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockFileExistsTests.cs
@@ -14,7 +14,6 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             // Arrange
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
             {
-                { XFS.Path(@"C:\something\demo.txt"), new MockFileData("Demo text content") },
                 { XFS.Path(@"C:\something\other.gif"), new MockFileData("gif content") }
             });
 
@@ -53,7 +52,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             });
 
             // Act
-            var result = fileSystem.File.Exists("/SomeThing/Other.gif");
+            var result = fileSystem.File.Exists("/SomeThing/DEMO.txt");
 
             // Assert
             Assert.IsFalse(result);

--- a/System.IO.Abstractions.TestingHelpers.Tests/MockFileExistsTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockFileExistsTests.cs
@@ -27,6 +27,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
+        [WindowsOnly(WindowsSpecifics.CaseInsensitivity)]
         public void MockFile_Exists_ShouldReturnTrueForPathVaryingByCase()
         {
             // Arrange
@@ -43,6 +44,26 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             // Assert
             Assert.IsTrue(result);
+        }
+
+        [Test]
+        [UnixOnly(UnixSpecifics.CaseSensitivity)]
+        public void MockFile_Exists_ShouldReturnFalseForPathVaryingByCase()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\something\demo.txt"), new MockFileData("Demo text content") },
+                { XFS.Path(@"c:\something\other.gif"), new MockFileData(new byte[] { 0x21, 0x58, 0x3f, 0xa9 }) }
+            });
+
+            var file = new MockFile(fileSystem);
+
+            // Act
+            var result = file.Exists(XFS.Path(@"c:\SomeThing\Other.gif"));
+
+            // Assert
+            Assert.IsFalse(result);
         }
 
         [Test]

--- a/System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
@@ -41,6 +41,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
+        [WindowsOnly(WindowsSpecifics.CaseInsensitivity)]
         public void MockFileSystem_GetFile_ShouldReturnFileRegisteredInConstructorWhenPathsDifferByCase()
         {
             var file1 = new MockFileData("Demo\r\ntext\ncontent\rvalue");
@@ -56,14 +57,31 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
-        public void MockFileSystem_AddFile_ShouldHandleNullFileDataAsEmpty()
+        [UnixOnly(UnixSpecifics.CaseSensitivity)]
+        public void MockFileSystem_GetFile_ShouldNotReturnFileRegisteredInConstructorWhenPathsDifferByCase()
         {
+            var file1 = new MockFileData("Demo\r\ntext\ncontent\rvalue");
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
             {
-                { @"c:\something\nullish.txt", null }
+                { "/something/demo.txt", file1 },
+                { "/something/other.gif", new MockFileData(new byte[] { 0x21, 0x58, 0x3f, 0xa9 }) }
             });
 
-            var result = fileSystem.File.ReadAllText(@"c:\SomeThing\nullish.txt");
+            var result = fileSystem.GetFile("/SomeThing/DEMO.txt");
+
+            Assert.AreEqual(file1, result);
+        }
+
+        [Test]
+        public void MockFileSystem_AddFile_ShouldHandleNullFileDataAsEmpty()
+        {
+            var path = XFS.Path(@"c:\something\nullish.txt");
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { path, null }
+            });
+
+            var result = fileSystem.File.ReadAllText(path);
 
             Assert.IsEmpty(result, "Null MockFileData should be allowed for and result in an empty file.");
         }
@@ -71,7 +89,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         [Test]
         public void MockFileSystem_AddFile_ShouldRepaceExistingFile()
         {
-            const string path = @"c:\some\file.txt";
+            var path = XFS.Path(@"c:\some\file.txt");
             const string existingContent = "Existing content";
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
             {
@@ -157,6 +175,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
+        [WindowsOnly(WindowsSpecifics.CaseInsensitivity)]
         public void MockFileSystem_AddFile_ShouldMatchCapitalization_PartialMatch()
         {
             var fileSystem = new MockFileSystem();
@@ -175,6 +194,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
+        [WindowsOnly(WindowsSpecifics.CaseInsensitivity)]
         public void MockFileSystem_AddFile_ShouldMatchCapitalization_PartialMatch_FurtherLeft()
         {
             var fileSystem = new MockFileSystem();

--- a/System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
@@ -17,7 +17,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
             {
                 { @"c:\something\demo.txt", new MockFileData("Demo\r\ntext\ncontent\rvalue") },
-                { @"c:\something\other.gif", new MockFileData(new byte[] { 0x21, 0x58, 0x3f, 0xa9 }) }
+                { @"c:\something\other.gif", new MockFileData("gif content") }
             });
 
             var result = fileSystem.GetFile(@"c:\something\else.txt");
@@ -32,7 +32,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
             {
                 { @"c:\something\demo.txt", file1 },
-                { @"c:\something\other.gif", new MockFileData(new byte[] { 0x21, 0x58, 0x3f, 0xa9 }) }
+                { @"c:\something\other.gif", new MockFileData("gif content") }
             });
 
             var result = fileSystem.GetFile(@"c:\something\demo.txt");
@@ -48,7 +48,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
             {
                 { @"c:\something\demo.txt", file1 },
-                { @"c:\something\other.gif", new MockFileData(new byte[] { 0x21, 0x58, 0x3f, 0xa9 }) }
+                { @"c:\something\other.gif", new MockFileData("gif content") }
             });
 
             var result = fileSystem.GetFile(@"c:\SomeThing\DEMO.txt");
@@ -60,11 +60,10 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         [UnixOnly(UnixSpecifics.CaseSensitivity)]
         public void MockFileSystem_GetFile_ShouldNotReturnFileRegisteredInConstructorWhenPathsDifferByCase()
         {
-            var file1 = new MockFileData("Demo\r\ntext\ncontent\rvalue");
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
             {
-                { "/something/demo.txt", file1 },
-                { "/something/other.gif", new MockFileData(new byte[] { 0x21, 0x58, 0x3f, 0xa9 }) }
+                { "/something/demo.txt", new MockFileData("Demo\r\ntext\ncontent\rvalue") },
+                { "/something/other.gif", new MockFileData("gif content") }
             });
 
             var result = fileSystem.GetFile("/SomeThing/DEMO.txt");
@@ -76,13 +75,13 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         public void MockFileSystem_AddFile_ShouldHandleUnnormalizedSlashes()
         {
             var path = XFS.Path(@"c:\d1\d2\file.txt");
-            var altPath = XFS.Path("c:/d1/d2/file.txt");
-            var altParentPath = XFS.Path("c://d1//d2/");
+            var alternatePath = XFS.Path("c:/d1/d2/file.txt");
+            var alternateParentPath = XFS.Path("c://d1//d2/");
             var fs = new MockFileSystem();
             fs.AddFile(path, new MockFileData("Hello"));
 
-            var fileCount = fs.Directory.GetFiles(altParentPath).Length;
-            var fileExists = fs.File.Exists(altPath);
+            var fileCount = fs.Directory.GetFiles(alternateParentPath).Length;
+            var fileExists = fs.File.Exists(alternatePath);
 
             Assert.AreEqual(1, fileCount);
             Assert.IsTrue(fileExists);

--- a/System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
@@ -73,6 +73,22 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
+        public void MockFileSystem_AddFile_ShouldHandleUnnormalizedSlashes()
+        {
+            var path = XFS.Path(@"c:\d1\d2\file.txt");
+            var altPath = XFS.Path("c:/d1/d2/file.txt");
+            var altParentPath = XFS.Path("c://d1//d2/");
+            var fs = new MockFileSystem();
+            fs.AddFile(path, new MockFileData("Hello"));
+
+            var fileCount = fs.Directory.GetFiles(altParentPath).Length;
+            var fileExists = fs.File.Exists(altPath);
+
+            Assert.AreEqual(1, fileCount);
+            Assert.IsTrue(fileExists);
+        }
+
+        [Test]
         public void MockFileSystem_AddFile_ShouldHandleNullFileDataAsEmpty()
         {
             var path = XFS.Path(@"c:\something\nullish.txt");

--- a/System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
@@ -69,7 +69,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileSystem.GetFile("/SomeThing/DEMO.txt");
 
-            Assert.AreEqual(file1, result);
+            Assert.IsNull(result);
         }
 
         [Test]

--- a/System.IO.Abstractions.TestingHelpers.Tests/MockUnixSupportTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockUnixSupportTests.cs
@@ -2,19 +2,23 @@
 
 namespace System.IO.Abstractions.TestingHelpers.Tests
 {
+    using XFS = MockUnixSupport;
+
     [TestFixture]
     public class MockUnixSupportTests
     {
         [Test]
+        [UnixOnly(UnixSpecifics.SlashRoot)]
         public void Should_Convert_Backslashes_To_Slashes_On_Unix()
         {
-            Assert.AreEqual("/test/", MockUnixSupport.Path(@"\test\", () => true));
+            Assert.AreEqual("/test/", XFS.Path(@"\test\"));
         }
 
         [Test]
+        [UnixOnly(UnixSpecifics.SlashRoot)]
         public void Should_Remove_Drive_Letter_On_Unix()
         {
-            Assert.AreEqual("/test/", MockUnixSupport.Path(@"c:\test\", () => true));
+            Assert.AreEqual("/test/", XFS.Path(@"c:\test\"));
         }
     }
 }

--- a/System.IO.Abstractions.TestingHelpers.Tests/System.IO.Abstractions.TestingHelpers.Tests.csproj
+++ b/System.IO.Abstractions.TestingHelpers.Tests/System.IO.Abstractions.TestingHelpers.Tests.csproj
@@ -46,7 +46,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="nunit" Version="3.8.1" />
+    <PackageReference Include="nunit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.11.2" />
   </ItemGroup>
 

--- a/System.IO.Abstractions.TestingHelpers.Tests/UnixSpecifics.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/UnixSpecifics.cs
@@ -2,8 +2,8 @@
 {
     internal static class UnixSpecifics
     {
-        public const string SlashRoot = "Filesystem root is just '/' in Unix";
+        public const string SlashRoot = "Filesystem root is just '/' on Unix";
 
-        public const string CaseSensitivity = "Paths are case-sensitivity in Unix";
+        public const string CaseSensitivity = "Paths are case-sensitive on Unix";
     }
 }

--- a/System.IO.Abstractions.TestingHelpers.Tests/UnixSpecifics.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/UnixSpecifics.cs
@@ -3,5 +3,7 @@
     internal static class UnixSpecifics
     {
         public const string SlashRoot = "Filesystem root is just '/' in Unix";
+
+        public const string CaseSensitivity = "Paths are case-sensitivity in Unix";
     }
 }

--- a/System.IO.Abstractions.TestingHelpers.Tests/WindowsOnlyAttribute.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/WindowsOnlyAttribute.cs
@@ -16,7 +16,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
         public void BeforeTest(ITest test)
         {
-            if (MockUnixSupport.IsUnixPlatform())
+            if (!MockUnixSupport.IsWindowsPlatform())
             {
                 Assert.Inconclusive(reason);
             }

--- a/System.IO.Abstractions.TestingHelpers.Tests/WindowsSpecifics.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/WindowsSpecifics.cs
@@ -11,5 +11,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         public const string StrictPathRules = "Windows has stricter path rules than other platforms";
 
         public const string EmptyInvalidPathChars = "Path.GetInvalidPathChars() doesn't return anything on Mono";
+
+        public const string CaseInsensitivity = "Windows paths are case-insensitivity";
     }
 }

--- a/System.IO.Abstractions.TestingHelpers.Tests/WindowsSpecifics.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/WindowsSpecifics.cs
@@ -12,6 +12,6 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
         public const string EmptyInvalidPathChars = "Path.GetInvalidPathChars() doesn't return anything on Mono";
 
-        public const string CaseInsensitivity = "Windows paths are case-insensitivity";
+        public const string CaseInsensitivity = "Paths are case-insensitive on Windows";
     }
 }

--- a/System.IO.Abstractions.TestingHelpers.Tests/WindowsSpecifics.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/WindowsSpecifics.cs
@@ -9,5 +9,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         public const string UNCPaths = "UNC paths are a Windows-only concept";
         
         public const string StrictPathRules = "Windows has stricter path rules than other platforms";
+
+        public const string EmptyInvalidPathChars = "Path.GetInvalidPathChars() doesn't return anything on Mono";
     }
 }

--- a/System.IO.Abstractions.TestingHelpers.Tests/WindowsSpecifics.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/WindowsSpecifics.cs
@@ -10,8 +10,6 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         
         public const string StrictPathRules = "Windows has stricter path rules than other platforms";
 
-        public const string EmptyInvalidPathChars = "Path.GetInvalidPathChars() doesn't return anything on Mono";
-
         public const string CaseInsensitivity = "Paths are case-insensitive on Windows";
     }
 }

--- a/System.IO.Abstractions.TestingHelpers/IMockFileDataAccessor.cs
+++ b/System.IO.Abstractions.TestingHelpers/IMockFileDataAccessor.cs
@@ -54,6 +54,10 @@ namespace System.IO.Abstractions.TestingHelpers
         /// </summary>
         IEnumerable<string> AllDirectories { get; }
 
+        bool CaseSensitive { get; }
+        StringComparer Comparer { get; }
+        StringComparison Comparison { get; }
+
         FileBase File { get; }
         DirectoryBase Directory { get; }
         IFileInfoFactory FileInfo {get; }

--- a/System.IO.Abstractions.TestingHelpers/IMockFileDataAccessor.cs
+++ b/System.IO.Abstractions.TestingHelpers/IMockFileDataAccessor.cs
@@ -54,9 +54,7 @@ namespace System.IO.Abstractions.TestingHelpers
         /// </summary>
         IEnumerable<string> AllDirectories { get; }
 
-        bool CaseSensitive { get; }
-        StringComparer Comparer { get; }
-        StringComparison Comparison { get; }
+        StringOperations StringOperations { get; }
 
         FileBase File { get; }
         DirectoryBase Directory { get; }

--- a/System.IO.Abstractions.TestingHelpers/MockDirectory.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockDirectory.cs
@@ -296,7 +296,7 @@ namespace System.IO.Abstractions.TestingHelpers
             return mockFileDataAccessor
                 .AllDirectories
                 .Select(d => new MockDirectoryInfo(mockFileDataAccessor, d).Root.FullName)
-                .Select(r => mockFileDataAccessor.CaseSensitive ? r : r.ToLowerInvariant())
+                .Select(r => mockFileDataAccessor.CaseSensitive ? r : r.ToUpperInvariant())
                 .Distinct()
                 .ToArray();
         }

--- a/System.IO.Abstractions.TestingHelpers/MockDirectory.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockDirectory.cs
@@ -194,22 +194,23 @@ namespace System.IO.Abstractions.TestingHelpers
         {
             CheckSearchPattern(searchPattern);
             path = path.TrimSlashes();
+            path = path.NormalizeSlashes();
             path = EnsureAbsolutePath(path);
 
-            if (!path.EndsWith(Path.DirectorySeparatorChar.ToString())
-                && !path.EndsWith(Path.AltDirectorySeparatorChar.ToString()))
+            if (!path.EndsWith(Path.DirectorySeparatorChar.ToString()))
             {
                 path += Path.DirectorySeparatorChar;
             }
 
-            bool isUnix = XFS.IsUnixPlatform();
+            var isUnix = XFS.IsUnixPlatform();
 
-            string allDirectoriesPattern = isUnix
+            var allDirectoriesPattern = isUnix
                 ? @"([^<>:""/|?*]*/)*"
                 : @"([^<>:""/\\|?*]*\\)*";
 
             string fileNamePattern;
             string pathPatternSpecial = null;
+
             if (searchPattern == "*")
             {
                 fileNamePattern = isUnix ? @"[^/]*?/?" : @"[^\\]*?\\?";
@@ -241,22 +242,9 @@ namespace System.IO.Abstractions.TestingHelpers
                 searchOption == SearchOption.AllDirectories ? allDirectoriesPattern : string.Empty,
                 fileNamePattern);
 
-
             return files
-                .Where(p =>
-                    {
-                        if (Regex.IsMatch(p, pathPattern))
-                        {
-                            return true;
-                        }
-
-                        if (pathPatternSpecial != null && Regex.IsMatch(p, pathPatternSpecial))
-                        {
-                            return true;
-                        }
-
-                        return false;
-                    })
+                .Where(p => Regex.IsMatch(p, pathPattern)
+                    || (pathPatternSpecial != null && Regex.IsMatch(p, pathPatternSpecial)))
                 .ToArray();
         }
 

--- a/System.IO.Abstractions.TestingHelpers/MockDirectoryInfo.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockDirectoryInfo.cs
@@ -74,7 +74,8 @@ namespace System.IO.Abstractions.TestingHelpers
             get
             {
                 var root = mockFileDataAccessor.Path.GetPathRoot(directoryPath);
-                if (string.Equals(directoryPath, root, mockFileDataAccessor.Comparison))
+
+                if (mockFileDataAccessor.StringOperations.Equals(directoryPath, root))
                 {
                     // drives have the trailing slash
                     return directoryPath;

--- a/System.IO.Abstractions.TestingHelpers/MockDirectoryInfo.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockDirectoryInfo.cs
@@ -73,7 +73,7 @@ namespace System.IO.Abstractions.TestingHelpers
             get
             {
                 var root = mockFileDataAccessor.Path.GetPathRoot(directoryPath);
-                if (string.Equals(directoryPath, root, StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(directoryPath, root, mockFileDataAccessor.Comparison))
                 {
                     // drives have the trailing slash
                     return directoryPath;

--- a/System.IO.Abstractions.TestingHelpers/MockDriveInfo.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockDriveInfo.cs
@@ -7,10 +7,7 @@
 
         public MockDriveInfo(IMockFileDataAccessor mockFileDataAccessor, string name) : base(mockFileDataAccessor?.FileSystem)
         {
-            if (mockFileDataAccessor == null)
-            {
-                throw new ArgumentNullException(nameof(mockFileDataAccessor));
-            }
+            this.mockFileDataAccessor = mockFileDataAccessor ?? throw new ArgumentNullException(nameof(mockFileDataAccessor));
 
             if (name == null)
             {
@@ -18,34 +15,32 @@
             }
 
             const string DRIVE_SEPARATOR = @":\";
-            if (name.Length == 1)
+
+            if (name.Length == 1
+                || (name.Length == 2 && name[1] == ':')
+                || (name.Length == 3 && name.EndsWith(DRIVE_SEPARATOR, mockFileDataAccessor.Comparison)))
             {
-                name = char.ToUpperInvariant(name[0]) + DRIVE_SEPARATOR;
-            }
-            else if (name.Length == 2 && name[1] == ':')
-            {
-                name = char.ToUpperInvariant(name[0]) + DRIVE_SEPARATOR;
-            }
-            else if (name.Length == 3 && name.EndsWith(DRIVE_SEPARATOR, StringComparison.Ordinal))
-            {
-                name = char.ToUpperInvariant(name[0]) + DRIVE_SEPARATOR;
+                name = ToUpper(name[0]) + DRIVE_SEPARATOR;
             }
             else
             {
-                MockPath.CheckInvalidPathChars(name);
+                mockFileDataAccessor.PathVerifier.CheckInvalidPathChars(name);
                 name = mockFileDataAccessor.Path.GetPathRoot(name);
 
-                if (string.IsNullOrEmpty(name) || name.StartsWith(@"\\", StringComparison.Ordinal))
+                if (string.IsNullOrEmpty(name) || name.StartsWith(@"\\", mockFileDataAccessor.Comparison))
                 {
                     throw new ArgumentException(
                         @"Object must be a root directory (""C:\"") or a drive letter (""C"").");
                 }
             }
 
-            this.mockFileDataAccessor = mockFileDataAccessor;
-
             Name = name;
             IsReady = true;
+        }
+
+        private char ToUpper(char c)
+        {
+            return mockFileDataAccessor.CaseSensitive ? c : char.ToUpperInvariant(c);
         }
 
         public new long AvailableFreeSpace { get; set; }
@@ -58,8 +53,7 @@
         {
             get
             {
-                var directory = mockFileDataAccessor.DirectoryInfo.FromDirectoryName(Name);
-                return directory;
+                return mockFileDataAccessor.DirectoryInfo.FromDirectoryName(Name);
             }
         }
 

--- a/System.IO.Abstractions.TestingHelpers/MockDriveInfo.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockDriveInfo.cs
@@ -20,7 +20,7 @@
                 || (name.Length == 2 && name[1] == ':')
                 || (name.Length == 3 && name.EndsWith(DRIVE_SEPARATOR, mockFileDataAccessor.Comparison)))
             {
-                name = ToUpper(name[0]) + DRIVE_SEPARATOR;
+                name = name[0] + DRIVE_SEPARATOR;
             }
             else
             {
@@ -36,11 +36,6 @@
 
             Name = name;
             IsReady = true;
-        }
-
-        private char ToUpper(char c)
-        {
-            return mockFileDataAccessor.CaseSensitive ? c : char.ToUpperInvariant(c);
         }
 
         public new long AvailableFreeSpace { get; set; }

--- a/System.IO.Abstractions.TestingHelpers/MockDriveInfo.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockDriveInfo.cs
@@ -18,7 +18,7 @@
 
             if (name.Length == 1
                 || (name.Length == 2 && name[1] == ':')
-                || (name.Length == 3 && name.EndsWith(DRIVE_SEPARATOR, mockFileDataAccessor.Comparison)))
+                || (name.Length == 3 && mockFileDataAccessor.StringOperations.EndsWith(name, DRIVE_SEPARATOR)))
             {
                 name = name[0] + DRIVE_SEPARATOR;
             }
@@ -27,7 +27,7 @@
                 mockFileDataAccessor.PathVerifier.CheckInvalidPathChars(name);
                 name = mockFileDataAccessor.Path.GetPathRoot(name);
 
-                if (string.IsNullOrEmpty(name) || name.StartsWith(@"\\", mockFileDataAccessor.Comparison))
+                if (string.IsNullOrEmpty(name) || mockFileDataAccessor.StringOperations.StartsWith(name, @"\\"))
                 {
                     throw new ArgumentException(
                         @"Object must be a root directory (""C:\"") or a drive letter (""C"").");

--- a/System.IO.Abstractions.TestingHelpers/MockDriveInfoFactory.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockDriveInfoFactory.cs
@@ -47,12 +47,12 @@ namespace System.IO.Abstractions.TestingHelpers
 
         private string NormalizeDriveName(string driveName)
         {
-            if (driveName.Length == 3 && driveName.EndsWith(@":\", mockFileSystem.Comparison))
+            if (driveName.Length == 3 && mockFileSystem.StringOperations.EndsWith(driveName, @":\"))
             {
-                return (mockFileSystem.CaseSensitive ? driveName[0] : char.ToUpperInvariant(driveName[0])) + @":\";
+                return mockFileSystem.StringOperations.ToUpper(driveName[0]) + @":\";
             }
 
-            if (driveName.StartsWith(@"\\", mockFileSystem.Comparison))
+            if (mockFileSystem.StringOperations.StartsWith(driveName, @"\\"))
             {
                 return null;
             }
@@ -71,32 +71,18 @@ namespace System.IO.Abstractions.TestingHelpers
 
             public bool Equals(string x, string y)
             {
-                if (ReferenceEquals(x, y))
-                {
-                    return true;
-                }
+                return ReferenceEquals(x, y) ||
+                       (HasDrivePrefix(x) && HasDrivePrefix(y) && mockFileSystem.StringOperations.Equals(x[0], y[0]));
+            }
 
-                if (ReferenceEquals(x, null))
-                {
-                    return false;
-                }
-
-                if (ReferenceEquals(y, null))
-                {
-                    return false;
-                }
-
-                if (x[1] == ':' && y[1] == ':')
-                {
-                    return mockFileSystem.Comparer.Compare(x.Substring(0, 1), y.Substring(0, 1)) == 0;
-                }
-
-                return false;
+            private static bool HasDrivePrefix(string x)
+            {
+                return x != null && x.Length >= 2 && x[1] == ':';
             }
 
             public int GetHashCode(string obj)
             {
-                return (mockFileSystem.CaseSensitive ? obj : obj.ToUpperInvariant()).GetHashCode();
+                return mockFileSystem.StringOperations.ToUpper(obj).GetHashCode();
             }
         }
     }

--- a/System.IO.Abstractions.TestingHelpers/MockFile.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockFile.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Security.AccessControl;
@@ -55,14 +55,7 @@ namespace System.IO.Abstractions.TestingHelpers
 
             if (!mockFileDataAccessor.FileExists(path))
             {
-                var dir = mockFileDataAccessor.Path.GetDirectoryName(
-                    mockFileDataAccessor.Path.GetFullPath(path));
-
-                if (!mockFileDataAccessor.Directory.Exists(dir))
-                {
-                    throw new DirectoryNotFoundException(string.Format(CultureInfo.InvariantCulture, StringResources.Manager.GetString("COULD_NOT_FIND_PART_OF_PATH_EXCEPTION"), path));
-                }
-
+                CheckDirectoryExists(path);
                 mockFileDataAccessor.AddFile(path, new MockFileData(contents, encoding));
             }
             else
@@ -112,13 +105,7 @@ namespace System.IO.Abstractions.TestingHelpers
                 throw new FileNotFoundException(string.Format(CultureInfo.InvariantCulture, StringResources.Manager.GetString("COULD_NOT_FIND_FILE_EXCEPTION"), sourceFileName));
             }
 
-            var directoryNameOfDestination = mockFileDataAccessor.Path.GetDirectoryName(
-                mockFileDataAccessor.Path.GetFullPath(destFileName));
-
-            if (!mockFileDataAccessor.Directory.Exists(directoryNameOfDestination))
-            {
-                throw new DirectoryNotFoundException(string.Format(CultureInfo.InvariantCulture, StringResources.Manager.GetString("COULD_NOT_FIND_PART_OF_PATH_EXCEPTION"), destFileName));
-            }
+            CheckDirectoryExists(destFileName);
 
             var fileExists = mockFileDataAccessor.FileExists(destFileName);
             if (fileExists)
@@ -157,18 +144,7 @@ namespace System.IO.Abstractions.TestingHelpers
             }
 
             mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, nameof(path));
-
-            var directoryPath = mockFileDataAccessor.Path.GetDirectoryName(
-                mockFileDataAccessor.Path.GetFullPath(path));
-
-            if (!mockFileDataAccessor.Directory.Exists(directoryPath))
-            {
-                throw new DirectoryNotFoundException(
-                    string.Format(
-                        CultureInfo.InvariantCulture,
-                        StringResources.Manager.GetString("COULD_NOT_FIND_PART_OF_PATH_EXCEPTION"),
-                        path));
-            }
+            CheckDirectoryExists(path);
 
             var mockFileData = new MockFileData(new byte[0])
             {
@@ -976,6 +952,21 @@ namespace System.IO.Abstractions.TestingHelpers
             using (var sr = new StreamReader(ms, encoding))
             {
                 return sr.ReadToEnd();
+            }
+        }
+
+        private void CheckDirectoryExists(string path)
+        {
+            var pathOps = mockFileDataAccessor.Path;
+            var dir = pathOps.GetDirectoryName(pathOps.GetFullPath(path));
+
+            if (!mockFileDataAccessor.Directory.Exists(dir))
+            {
+                throw new DirectoryNotFoundException(
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        StringResources.Manager.GetString("COULD_NOT_FIND_PART_OF_PATH_EXCEPTION"),
+                        path));
             }
         }
 

--- a/System.IO.Abstractions.TestingHelpers/MockFile.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockFile.cs
@@ -55,7 +55,7 @@ namespace System.IO.Abstractions.TestingHelpers
 
             if (!mockFileDataAccessor.FileExists(path))
             {
-                CheckDirectoryExists(path);
+                VerifyDirectoryExists(path);
                 mockFileDataAccessor.AddFile(path, new MockFileData(contents, encoding));
             }
             else
@@ -105,7 +105,7 @@ namespace System.IO.Abstractions.TestingHelpers
                 throw new FileNotFoundException(string.Format(CultureInfo.InvariantCulture, StringResources.Manager.GetString("COULD_NOT_FIND_FILE_EXCEPTION"), sourceFileName));
             }
 
-            CheckDirectoryExists(destFileName);
+            VerifyDirectoryExists(destFileName);
 
             var fileExists = mockFileDataAccessor.FileExists(destFileName);
             if (fileExists)
@@ -144,7 +144,7 @@ namespace System.IO.Abstractions.TestingHelpers
             }
 
             mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, nameof(path));
-            CheckDirectoryExists(path);
+            VerifyDirectoryExists(path);
 
             var mockFileData = new MockFileData(new byte[0])
             {
@@ -955,21 +955,6 @@ namespace System.IO.Abstractions.TestingHelpers
             }
         }
 
-        private void CheckDirectoryExists(string path)
-        {
-            var pathOps = mockFileDataAccessor.Path;
-            var dir = pathOps.GetDirectoryName(pathOps.GetFullPath(path));
-
-            if (!mockFileDataAccessor.Directory.Exists(dir))
-            {
-                throw new DirectoryNotFoundException(
-                    string.Format(
-                        CultureInfo.InvariantCulture,
-                        StringResources.Manager.GetString("COULD_NOT_FIND_PART_OF_PATH_EXCEPTION"),
-                        path));
-            }
-        }
-
         private string ReadAllTextInternal(string path, Encoding encoding)
         {
             var mockFileData = mockFileDataAccessor.GetFile(path);
@@ -986,14 +971,16 @@ namespace System.IO.Abstractions.TestingHelpers
 
         private void VerifyDirectoryExists(string path)
         {
-            DirectoryInfoBase dir = mockFileDataAccessor.Directory.GetParent(path);
-            if (!dir.Exists)
+            var pathOps = mockFileDataAccessor.Path;
+            var dir = pathOps.GetDirectoryName(pathOps.GetFullPath(path));
+
+            if (!mockFileDataAccessor.Directory.Exists(dir))
             {
                 throw new DirectoryNotFoundException(
                     string.Format(
                         CultureInfo.InvariantCulture, 
-                        StringResources.Manager.GetString("COULD_NOT_FIND_PART_OF_PATH_EXCEPTION"), 
-                        dir));
+                        StringResources.Manager.GetString("COULD_NOT_FIND_PART_OF_PATH_EXCEPTION"),
+                        path));
             }
         }
     }

--- a/System.IO.Abstractions.TestingHelpers/MockFile.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockFile.cs
@@ -10,12 +10,10 @@ namespace System.IO.Abstractions.TestingHelpers
     public class MockFile : FileBase
     {
         private readonly IMockFileDataAccessor mockFileDataAccessor;
-        private readonly MockPath mockPath;
 
         public MockFile(IMockFileDataAccessor mockFileDataAccessor) : base(mockFileDataAccessor?.FileSystem)
         {
             this.mockFileDataAccessor = mockFileDataAccessor ?? throw new ArgumentNullException(nameof(mockFileDataAccessor));
-            mockPath = new MockPath(mockFileDataAccessor);
         }
 
         public override void AppendAllLines(string path, IEnumerable<string> contents)
@@ -57,8 +55,9 @@ namespace System.IO.Abstractions.TestingHelpers
 
             if (!mockFileDataAccessor.FileExists(path))
             {
-                var mockPath = mockFileDataAccessor.Path;
-                var dir = mockPath.GetDirectoryName(mockPath.GetFullPath(path));
+                var dir = mockFileDataAccessor.Path.GetDirectoryName(
+                    mockFileDataAccessor.Path.GetFullPath(path));
+
                 if (!mockFileDataAccessor.Directory.Exists(dir))
                 {
                     throw new DirectoryNotFoundException(string.Format(CultureInfo.InvariantCulture, StringResources.Manager.GetString("COULD_NOT_FIND_PART_OF_PATH_EXCEPTION"), path));
@@ -113,7 +112,9 @@ namespace System.IO.Abstractions.TestingHelpers
                 throw new FileNotFoundException(string.Format(CultureInfo.InvariantCulture, StringResources.Manager.GetString("COULD_NOT_FIND_FILE_EXCEPTION"), sourceFileName));
             }
 
-            var directoryNameOfDestination = mockPath.GetDirectoryName(mockPath.GetFullPath(destFileName));
+            var directoryNameOfDestination = mockFileDataAccessor.Path.GetDirectoryName(
+                mockFileDataAccessor.Path.GetFullPath(destFileName));
+
             if (!mockFileDataAccessor.Directory.Exists(directoryNameOfDestination))
             {
                 throw new DirectoryNotFoundException(string.Format(CultureInfo.InvariantCulture, StringResources.Manager.GetString("COULD_NOT_FIND_PART_OF_PATH_EXCEPTION"), destFileName));
@@ -157,7 +158,8 @@ namespace System.IO.Abstractions.TestingHelpers
 
             mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, nameof(path));
 
-            var directoryPath = mockPath.GetDirectoryName(mockPath.GetFullPath(path));
+            var directoryPath = mockFileDataAccessor.Path.GetDirectoryName(
+                mockFileDataAccessor.Path.GetFullPath(path));
 
             if (!mockFileDataAccessor.Directory.Exists(directoryPath))
             {
@@ -571,15 +573,13 @@ namespace System.IO.Abstractions.TestingHelpers
                 throw new FileNotFoundException(string.Format(CultureInfo.InvariantCulture, StringResources.Manager.GetString("COULD_NOT_FIND_FILE_EXCEPTION"), destinationFileName));
             }
 
-            var mockFile = new MockFile(mockFileDataAccessor);
-
             if (destinationBackupFileName != null)
             {
-                mockFile.Copy(destinationFileName, destinationBackupFileName, true);
+                Copy(destinationFileName, destinationBackupFileName, true);
             }
 
-            mockFile.Delete(destinationFileName);
-            mockFile.Move(sourceFileName, destinationFileName);
+            Delete(destinationFileName);
+            Move(sourceFileName, destinationFileName);
         }
 #endif
 

--- a/System.IO.Abstractions.TestingHelpers/MockFile.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockFile.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Security.AccessControl;
@@ -551,7 +551,7 @@ namespace System.IO.Abstractions.TestingHelpers
 
             if (destinationBackupFileName != null)
             {
-                Copy(destinationFileName, destinationBackupFileName, true);
+                Copy(destinationFileName, destinationBackupFileName, overwrite: true);
             }
 
             Delete(destinationFileName);

--- a/System.IO.Abstractions.TestingHelpers/MockFileInfo.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockFileInfo.cs
@@ -168,7 +168,7 @@ namespace System.IO.Abstractions.TestingHelpers
             {
                 return this;
             }
-            new MockFile(mockFileSystem).Copy(FullName, destFileName, overwrite);
+            mockFileSystem.File.Copy(FullName, destFileName, overwrite);
             return mockFileSystem.FileInfo.FromFileName(destFileName);
         }
 

--- a/System.IO.Abstractions.TestingHelpers/MockFileStream.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockFileStream.cs
@@ -7,8 +7,12 @@
         private readonly string path;
         private readonly bool canWrite = true;
         private readonly FileOptions options;
-        private bool disposed;
+
+#if NET40
         private bool closed;
+#else
+        private bool disposed;
+#endif
 
         public enum StreamType
         {

--- a/System.IO.Abstractions.TestingHelpers/MockPath.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockPath.cs
@@ -32,8 +32,8 @@ namespace System.IO.Abstractions.TestingHelpers
             path = path.Replace(AltDirectorySeparatorChar, DirectorySeparatorChar);
 
             bool isUnc =
-                path.StartsWith(@"\\", mockFileDataAccessor.Comparison) ||
-                path.StartsWith(@"//", mockFileDataAccessor.Comparison);
+                mockFileDataAccessor.StringOperations.StartsWith(path, @"\\") ||
+                mockFileDataAccessor.StringOperations.StartsWith(path, @"//");
 
             string root = GetPathRoot(path);
 
@@ -56,7 +56,8 @@ namespace System.IO.Abstractions.TestingHelpers
                     throw new ArgumentException(@"The UNC path should be of the form \\server\share.", "path");
                 }
             }
-            else if (@"\".Equals(root, mockFileDataAccessor.Comparison) || @"/".Equals(root, mockFileDataAccessor.Comparison))
+            else if (mockFileDataAccessor.StringOperations.Equals(@"\", root) ||
+                     mockFileDataAccessor.StringOperations.Equals(@"/", root))
             {
                 // absolute path on the current drive or volume
                 pathSegments = GetSegments(GetPathRoot(mockFileDataAccessor.Directory.GetCurrentDirectory()), path);
@@ -67,9 +68,9 @@ namespace System.IO.Abstractions.TestingHelpers
             }
 
             // unc paths need at least two segments, the others need one segment
-            bool isUnixRooted =
-                mockFileDataAccessor.Directory.GetCurrentDirectory()
-                    .StartsWith(string.Format(CultureInfo.InvariantCulture, "{0}", DirectorySeparatorChar), mockFileDataAccessor.Comparison);
+            var isUnixRooted = mockFileDataAccessor.StringOperations.StartsWith(
+                mockFileDataAccessor.Directory.GetCurrentDirectory(),
+                string.Format(CultureInfo.InvariantCulture, "{0}", DirectorySeparatorChar));
 
             var minPathSegments = isUnc
                 ? 2
@@ -78,7 +79,7 @@ namespace System.IO.Abstractions.TestingHelpers
             var stack = new Stack<string>();
             foreach (var segment in pathSegments)
             {
-                if ("..".Equals(segment, mockFileDataAccessor.Comparison))
+                if (mockFileDataAccessor.StringOperations.Equals("..", segment))
                 {
                     // only pop, if afterwards are at least the minimal amount of path segments
                     if (stack.Count > minPathSegments)
@@ -86,7 +87,7 @@ namespace System.IO.Abstractions.TestingHelpers
                         stack.Pop();
                     }
                 }
-                else if (".".Equals(segment, mockFileDataAccessor.Comparison))
+                else if (mockFileDataAccessor.StringOperations.Equals(".", segment))
                 {
                     // ignore .
                 }

--- a/System.IO.Abstractions.TestingHelpers/MockUnixSupport.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockUnixSupport.cs
@@ -4,28 +4,13 @@ namespace System.IO.Abstractions.TestingHelpers
 {
     public static class MockUnixSupport
     {
-        public static string Path(string path, Func<bool> isUnixF = null)
-        {
-            var isUnix = isUnixF ?? IsUnixPlatform;
+        private static readonly Regex pathTransform = new Regex(@"^[a-zA-Z]:(?<path>.*)$");
 
-            if (isUnix())
-            {
-                path = Regex.Replace(path, @"^[a-zA-Z]:(?<path>.*)$", "${path}");
-                path = path.Replace(@"\", "/");
-            }
+        public static string Path(string path) => IsUnixPlatform()
+            ? pathTransform.Replace(path, "${path}").Replace(@"\", "/")
+            : path;
 
-            return path;
-        }
-
-        public static string Separator(Func<bool> isUnixF = null)
-        {
-            var isUnix = isUnixF ?? IsUnixPlatform;
-            return isUnix() ? "/" : @"\";
-        }
-
-        public static bool IsUnixPlatform()
-        {
-            return IO.Path.DirectorySeparatorChar == '/';
-        }
+        public static bool IsUnixPlatform() => IO.Path.DirectorySeparatorChar == '/';
+        public static bool IsWindowsPlatform() => IO.Path.DirectorySeparatorChar == '\\';
     }
 }

--- a/System.IO.Abstractions.TestingHelpers/PathVerifier.cs
+++ b/System.IO.Abstractions.TestingHelpers/PathVerifier.cs
@@ -6,6 +6,7 @@ namespace System.IO.Abstractions.TestingHelpers
 
     public class PathVerifier
     {
+        private static readonly char[] AdditionalInvalidPathChars = { '*', '?' };
         private readonly IMockFileDataAccessor _mockFileDataAccessor;
 
         internal PathVerifier(IMockFileDataAccessor mockFileDataAccessor)
@@ -42,7 +43,7 @@ namespace System.IO.Abstractions.TestingHelpers
 
             var filePath = ExtractFilePath(path);
 
-            if (HasIllegalCharacters(filePath, false))
+            if (HasIllegalCharacters(filePath, checkAdditional: false))
             {
                 throw new ArgumentException(StringResources.Manager.GetString("ILLEGAL_CHARACTERS_IN_PATH_EXCEPTION"));
             }
@@ -68,8 +69,6 @@ namespace System.IO.Abstractions.TestingHelpers
                 _mockFileDataAccessor.Path.AltDirectorySeparatorChar);
             return string.Join(_mockFileDataAccessor.Path.DirectorySeparatorChar.ToString(), extractFilePath.Take(extractFilePath.Length - 1));
         }
-
-        private readonly char[] AdditionalInvalidPathChars = { '*', '?' };
 
         public bool HasIllegalCharacters(string path, bool checkAdditional)
         {

--- a/System.IO.Abstractions.TestingHelpers/StringExtensions.cs
+++ b/System.IO.Abstractions.TestingHelpers/StringExtensions.cs
@@ -85,5 +85,25 @@ namespace System.IO.Abstractions.TestingHelpers
 
             return trimmed;
         }
+
+        [Pure]
+        public static string NormalizeSlashes(this string path)
+        {
+            path = path.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
+            var sep = Path.DirectorySeparatorChar.ToString();
+            var doubleSep = sep + sep;
+
+            while (true)
+            {
+                var newPath = path.Replace(doubleSep, sep);
+
+                if (path == newPath)
+                {
+                    return path;
+                }
+
+                path = newPath;
+            }
+        }
     }
 }

--- a/System.IO.Abstractions.TestingHelpers/StringExtensions.cs
+++ b/System.IO.Abstractions.TestingHelpers/StringExtensions.cs
@@ -4,6 +4,8 @@ using System.Text;
 
 namespace System.IO.Abstractions.TestingHelpers
 {
+    using XFS = MockUnixSupport;
+
     public static class StringExtensions
     {
         [Pure]
@@ -66,14 +68,14 @@ namespace System.IO.Abstractions.TestingHelpers
 
             var trimmed = path.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
 
-            if (MockUnixSupport.IsUnixPlatform()
+            if (XFS.IsUnixPlatform()
                 && (path[0] == Path.DirectorySeparatorChar || path[0] == Path.AltDirectorySeparatorChar)
                 && trimmed == "")
             {
                 return Path.DirectorySeparatorChar.ToString();
             }
 
-            if (!MockUnixSupport.IsUnixPlatform()
+            if (XFS.IsWindowsPlatform()
                 && trimmed.Length == 2
                 && char.IsLetter(trimmed[0])
                 && trimmed[1] == ':')

--- a/System.IO.Abstractions.TestingHelpers/StringExtensions.cs
+++ b/System.IO.Abstractions.TestingHelpers/StringExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics.Contracts;
+using System.Linq;
 using System.Text;
 
 namespace System.IO.Abstractions.TestingHelpers
@@ -93,13 +94,27 @@ namespace System.IO.Abstractions.TestingHelpers
             var sep = Path.DirectorySeparatorChar.ToString();
             var doubleSep = sep + sep;
 
+            var prefixSeps = new string(path.TakeWhile(c => c == Path.DirectorySeparatorChar).ToArray());
+            path = path.Substring(prefixSeps.Length);
+
+            // UNC Paths start with double slash but no reason
+            // to have more than 2 slashes at the start of a path
+            if (XFS.IsWindowsPlatform() && prefixSeps.Length > 2)
+            {
+                prefixSeps = prefixSeps.Substring(0, 2);
+            }
+            else if (prefixSeps.Length > 1)
+            {
+                prefixSeps = prefixSeps.Substring(0, 1);
+            }
+
             while (true)
             {
                 var newPath = path.Replace(doubleSep, sep);
 
                 if (path == newPath)
                 {
-                    return path;
+                    return prefixSeps + path;
                 }
 
                 path = newPath;

--- a/System.IO.Abstractions.TestingHelpers/StringOperations.cs
+++ b/System.IO.Abstractions.TestingHelpers/StringOperations.cs
@@ -1,0 +1,29 @@
+﻿namespace System.IO.Abstractions.TestingHelpers
+{
+    [Serializable]
+    public class StringOperations
+    {
+        private readonly bool caseSensitive;
+        private readonly StringComparison comparison;
+
+        public StringOperations(bool caseSensitive)
+        {
+            this.caseSensitive = caseSensitive;
+            comparison = caseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
+        }
+
+        public StringComparer Comparer => caseSensitive ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase;
+        public bool StartsWith(string s, string prefix) => s.StartsWith(prefix, comparison);
+        public bool EndsWith(string s, string suffix) => s.EndsWith(suffix, comparison);
+        public bool Equals(string x, string y) => string.Equals(x, y, comparison);
+        public bool Equals(char x, char y) => caseSensitive ? x == y : char.ToUpper(x) == char.ToUpper(y);
+        public int IndexOf(string s, string substring) => s.IndexOf(substring, comparison);
+        public int IndexOf(string s, string substring, int startIndex) => s.IndexOf(substring, startIndex, comparison);
+        public bool Contains(string s, string substring) => s.IndexOf(substring, comparison) >= 0;
+        public string Replace(string s, string oldValue, string newValue) => s.Replace(oldValue, newValue, comparison);
+        public char ToLower(char c) => caseSensitive ? c : char.ToLower(c);
+        public char ToUpper(char c) => caseSensitive ? c : char.ToUpper(c);
+        public string ToLower(string s) => caseSensitive ? s : s.ToLower();
+        public string ToUpper(string s) => caseSensitive ? s : s.ToUpper();
+    }
+}


### PR DESCRIPTION
Fixes #321 

- Added properties `bool CaseSensitive`, `StringComparer Comparer`, `StringComparison Comparison` to `MockFileSystem`, `IMockFileDataAccessor`. The other `Mock*` classes use these properties to perform string comparisons and to opt to do `ToUpper`/`ToLower` or not.
- `MockDirectory.GetLogicalDrives()` returns drive letters in upper case instead of lower case.
- Moved `HasIllegalCharacters`, `CheckInvalidPathChars` from `MockPath` to `PathVerifier` as it's the more appropriate place.
- Added `IsWindowsPlatform()` to `MockUnixSupport`.
- Removed the optional `Func<bool>` argument to methods on `MockUnixSupport` that overrides platform detection. Tests that need to run on a specific platform are labeled with the relevant `*Only` attribute.
- Added/updated tests as needed. Tests that specifically asserted case-insensitive behavior were labeled `WindowsOnly`. Similar tests were added to assert case-sensitive behavior and are labeled `UnixOnly`.

Fixes #395 

- Added special case handling to `MockDirectory.GetParent` for Unix to make sure a slash-root parent is properly identified and returned.
- Added a test for this, labeled `UnixOnly`.

Fixes #405 

- Fixed `MockDirectory.GetFiles` to handle un-normalized slashes:
  - Use of alternate slashes.
  - Missing or present trailing slash.
  - Redundant slashes.
- Added cross platform test for this.