### PR TITLE
Pass IFileSystem into FileWrapper instead of FileSystem

### DIFF
--- a/System.IO.Abstractions/FileWrapper.cs
+++ b/System.IO.Abstractions/FileWrapper.cs
@@ -1,14 +1,13 @@
 ﻿using System.Collections.Generic;
 using System.Security.AccessControl;
 using System.Text;
-using System.IO;
 
 namespace System.IO.Abstractions
 {
     [Serializable]
     public class FileWrapper : FileBase
     {
-        public FileWrapper(FileSystem fileSystem) : base(fileSystem)
+        public FileWrapper(IFileSystem fileSystem) : base(fileSystem)
         {
         }
 


### PR DESCRIPTION
This will allow replacement file systems to be used and is the same pattern used in all the other classes.