### PR TITLE
Release

### DIFF
--- a/System.IO.Abstractions.TestingHelpers.Tests/DirectoryInfoTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/DirectoryInfoTests.cs
@@ -1,0 +1,22 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace System.IO.Abstractions.TestingHelpers.Tests
+{
+    [TestFixture]
+    public class DirectoryInfoTests
+    {
+        [Test]
+        public void Parent_ForRootDirectory_ShouldReturnNull()
+        {
+            var wrapperFilesystem = new FileSystem();
+
+            var current = wrapperFilesystem.Directory.GetCurrentDirectory();
+            var root = wrapperFilesystem.DirectoryInfo.FromDirectoryName(current).Root;
+            var rootsParent = root.Parent;
+            Assert.IsNull(rootsParent);
+        }
+    }
+}

--- a/System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryInfoTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryInfoTests.cs
@@ -56,6 +56,29 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
+        [WindowsOnly(WindowsSpecifics.UNCPaths)]
+        public void MockDirectoryInfo_GetFiles_ShouldWorkWithUNCPath()
+        {
+            var fileName = XFS.Path(@"\\unc\folder\file.txt");
+            var directoryName = XFS.Path(@"\\unc\folder");
+            // Arrange
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                {fileName, ""}
+            });
+
+            var directoryInfo = new MockDirectoryInfo(fileSystem, directoryName);
+
+            // Act
+            var files = directoryInfo.GetFiles();
+
+            // Assert
+            Assert.AreEqual(fileName, files[0].FullName);
+        }
+
+
+
+        [Test]
         public void MockDirectoryInfo_FullName_ShouldReturnFullNameWithoutIncludingTrailingPathDelimiter()
         {
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>

--- a/System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
@@ -182,7 +182,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.Directory.GetFiles(XFS.Path(@"c:\"), "*.gif", SearchOption.AllDirectories);
 
             // Assert
-            Assert.That(result, Is.EquivalentTo( expected));
+            Assert.That(result, Is.EquivalentTo(expected));
         }
 
         [Test]
@@ -599,6 +599,29 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
+        public void MockDirectory_Delete_ShouldNotDeleteAllDirectories()
+        {
+            // Arrange
+            var folder1Path = XFS.Path(@"D:\Test\Program");
+            var folder1SubFolderPath = XFS.Path(@"D:\Test\Program\Subfolder");
+            var folder2Path = XFS.Path(@"D:\Test\Program_bak");
+
+            var fileSystem = new MockFileSystem();
+
+            fileSystem.AddDirectory(folder1Path);
+            fileSystem.AddDirectory(folder2Path);
+            fileSystem.AddDirectory(folder1SubFolderPath);
+
+            // Act
+            fileSystem.Directory.Delete(folder1Path, recursive: true);
+
+            // Assert
+            Assert.IsFalse(fileSystem.Directory.Exists(folder1Path));
+            Assert.IsFalse(fileSystem.Directory.Exists(folder1SubFolderPath));
+            Assert.IsTrue(fileSystem.Directory.Exists(folder2Path));
+        }
+
+        [Test]
         [WindowsOnly(WindowsSpecifics.CaseInsensitivity)]
         public void MockDirectory_Delete_ShouldDeleteDirectoryCaseInsensitively()
         {
@@ -700,7 +723,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         public void MockDirectory_GetFileSystemEntries_Returns_Files_And_Directories()
         {
             string testPath = XFS.Path(@"c:\foo\bar.txt");
-            string testDir =  XFS.Path(@"c:\foo\bar");
+            string testDir = XFS.Path(@"c:\foo\bar");
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
             {
                 { testPath, new MockFileData("Demo text content") },
@@ -829,7 +852,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualResult = fileSystem.Directory.GetFiles(XFS.Path(@"c:\"), XFS.Path(@"foo..r\*"));
 
             // Assert
-            Assert.That(actualResult, Is.EquivalentTo(new [] { testPath }));
+            Assert.That(actualResult, Is.EquivalentTo(new[] { testPath }));
         }
 
 #if NET40
@@ -925,7 +948,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualResult = fileSystem.Directory.GetDirectories(XFS.Path(@"c:\Folder\"), "*.foo");
 
             // Assert
-            Assert.That(actualResult, Is.EquivalentTo(new []{XFS.Path(@"C:\Folder\.foo"), XFS.Path(@"C:\Folder\foo.foo")}));
+            Assert.That(actualResult, Is.EquivalentTo(new[] { XFS.Path(@"C:\Folder\.foo"), XFS.Path(@"C:\Folder\foo.foo") }));
         }
 
         [Test]
@@ -1211,7 +1234,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
-        public void MockDirectory_GetCurrentDirectory_ShouldReturnValueFromFileSystemConstructor() {
+        public void MockDirectory_GetCurrentDirectory_ShouldReturnValueFromFileSystemConstructor()
+        {
             string directory = XFS.Path(@"D:\folder1\folder2");
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>(), directory);
 
@@ -1219,9 +1243,9 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             Assert.AreEqual(directory, actual);
         }
-        
+
         [Test]
-        public void MockDirectory_GetCurrentDirectory_ShouldReturnDefaultPathWhenNotSet() 
+        public void MockDirectory_GetCurrentDirectory_ShouldReturnDefaultPathWhenNotSet()
         {
             string directory = XFS.Path(@"C:\");
 
@@ -1233,7 +1257,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
-        public void MockDirectory_SetCurrentDirectory_ShouldChangeCurrentDirectory() {
+        public void MockDirectory_SetCurrentDirectory_ShouldChangeCurrentDirectory()
+        {
             string directory = XFS.Path(@"D:\folder1\folder2");
             var fileSystem = new MockFileSystem();
 
@@ -1278,7 +1303,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var fileSystem = new MockFileSystem();
 
             // Act
-            var actualResult =  fileSystem.Directory.GetParent(XFS.Path(@"c:\directory\does\not\exist"));
+            var actualResult = fileSystem.Directory.GetParent(XFS.Path(@"c:\directory\does\not\exist"));
 
             // Assert
             Assert.IsNotNull(actualResult);
@@ -1331,9 +1356,9 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         {
             get
             {
-                yield return new [] { XFS.Path(@"c:\a"), XFS.Path(@"c:\") };
-                yield return new [] { XFS.Path(@"c:\a\b\c\d"), XFS.Path(@"c:\a\b\c") };
-                yield return new [] { XFS.Path(@"c:\a\b\c\d\"), XFS.Path(@"c:\a\b\c") };
+                yield return new[] { XFS.Path(@"c:\a"), XFS.Path(@"c:\") };
+                yield return new[] { XFS.Path(@"c:\a\b\c\d"), XFS.Path(@"c:\a\b\c") };
+                yield return new[] { XFS.Path(@"c:\a\b\c\d\"), XFS.Path(@"c:\a\b\c") };
             }
         }
 

--- a/System.IO.Abstractions.TestingHelpers.Tests/MockFileMoveTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockFileMoveTests.cs
@@ -312,7 +312,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var exception = Assert.Throws<FileNotFoundException>(() => fileSystem.File.Move(sourceFilePath, destFilePath));
 
-            Assert.That(exception.Message, Is.EqualTo("The file \"" + XFS.Path("c:\\something\\demo.txt") + "\" could not be found."));
+            Assert.That(exception.Message, Is.EqualTo("Could not find file '" + XFS.Path("c:\\something\\demo.txt") + "'."));
         }
 
         [Test]

--- a/System.IO.Abstractions.TestingHelpers.Tests/MockFileReadAllLinesTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockFileReadAllLinesTests.cs
@@ -51,5 +51,20 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 new [] { "Hello", "there", "Bob", "Bob!" },
                 result);
         }
+
+        [Test]
+        public void MockFile_ReadAllLines_NotExistingFile_ThrowsCorrectFileNotFoundException()
+        {
+            var absentFileNameFullPath = XFS.Path(@"c:\you surely don't have such file.hope-so");
+            var mockFileSystem = new MockFileSystem();
+
+            var act = new TestDelegate(() => 
+                mockFileSystem.File.ReadAllText(absentFileNameFullPath)
+            );
+
+            var exception = Assert.Catch<FileNotFoundException>(act);
+            Assert.That(exception.FileName, Is.EqualTo(absentFileNameFullPath));
+            Assert.That(exception.Message, Is.EqualTo("Could not find file '" + absentFileNameFullPath + "'."));
+        }
     }
 }

--- a/System.IO.Abstractions.TestingHelpers.Tests/MockFileReadLinesTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockFileReadLinesTests.cs
@@ -8,7 +8,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
     using XFS = MockUnixSupport;
 
-    public class MockFileReadLinesTests {
+    public class MockFileReadLinesTests
+    {
         [Test]
         public void MockFile_ReadLines_ShouldReturnOriginalTextData()
         {
@@ -48,7 +49,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             // Assert
             CollectionAssert.AreEqual(
-                new [] { "Hello", "there", "Bob", "Bob!" },
+                new[] { "Hello", "there", "Bob", "Bob!" },
                 result);
         }
     }

--- a/System.IO.Abstractions.TestingHelpers.Tests/StringExtensionsTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/StringExtensionsTests.cs
@@ -112,5 +112,13 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         {
             Assert.AreEqual("/", "/".TrimSlashes());
         }
+
+        [TestCase(@"\\unc\folder\file.txt", @"\\unc\folder\file.txt")]
+        [TestCase(@"//unc/folder/file.txt", @"\\unc\folder\file.txt")]
+        [WindowsOnly(WindowsSpecifics.UNCPaths)]
+        public void NormalizeSlashes_KeepsUNCPathPrefix(string path, string expectedValue)
+        {
+            Assert.AreEqual(expectedValue, path.NormalizeSlashes());
+        }
     }
 }

--- a/System.IO.Abstractions.TestingHelpers.Tests/System.IO.Abstractions.TestingHelpers.Tests.csproj
+++ b/System.IO.Abstractions.TestingHelpers.Tests/System.IO.Abstractions.TestingHelpers.Tests.csproj
@@ -47,7 +47,7 @@
 
   <ItemGroup>
     <PackageReference Include="nunit" Version="3.11.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.11.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.12.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/System.IO.Abstractions.TestingHelpers/CommonExceptions.cs
+++ b/System.IO.Abstractions.TestingHelpers/CommonExceptions.cs
@@ -1,0 +1,58 @@
+using System.Globalization;
+
+namespace System.IO.Abstractions.TestingHelpers
+{
+    internal static class CommonExceptions
+    {
+        public static FileNotFoundException FileNotFound(string path) =>
+            new FileNotFoundException(
+                string.Format(
+                    CultureInfo.InvariantCulture,
+                    StringResources.Manager.GetString("COULD_NOT_FIND_FILE_EXCEPTION"),
+                    path
+                ),
+                path
+            );
+
+        public static DirectoryNotFoundException CouldNotFindPartOfPath(string path) =>
+            new DirectoryNotFoundException(
+                string.Format(
+                    CultureInfo.InvariantCulture,
+                    StringResources.Manager.GetString("COULD_NOT_FIND_PART_OF_PATH_EXCEPTION"),
+                    path
+                )
+            );
+
+        public static UnauthorizedAccessException AccessDenied(string path) =>
+            new UnauthorizedAccessException(
+                string.Format(
+                    CultureInfo.InvariantCulture,
+                    StringResources.Manager.GetString("ACCESS_TO_THE_PATH_IS_DENIED"),
+                    path
+                )
+            );
+
+        public static Exception InvalidUseOfVolumeSeparator() =>
+            new NotSupportedException(StringResources.Manager.GetString("THE_PATH_IS_NOT_OF_A_LEGAL_FORM"));
+
+        public static Exception PathIsNotOfALegalForm(string paramName) => 
+            new ArgumentException(
+                StringResources.Manager.GetString("THE_PATH_IS_NOT_OF_A_LEGAL_FORM"), 
+                paramName
+            );
+
+        public static ArgumentNullException FilenameCannotBeNull(string paramName) =>
+            new ArgumentNullException(
+                paramName,
+                StringResources.Manager.GetString("FILENAME_CANNOT_BE_NULL")
+            );
+
+        public static ArgumentException IllegalCharactersInPath(string paramName = null) =>
+            paramName != null 
+                ? new ArgumentException(StringResources.Manager.GetString("ILLEGAL_CHARACTERS_IN_PATH_EXCEPTION"), paramName)
+                : new ArgumentException(StringResources.Manager.GetString("ILLEGAL_CHARACTERS_IN_PATH_EXCEPTION"));
+
+        public static Exception InvalidUncPath(string paramName) => 
+            new ArgumentException(@"The UNC path should be of the form \\server\share.", paramName);
+    }
+}

--- a/System.IO.Abstractions.TestingHelpers/MockDirectory.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockDirectory.cs
@@ -117,7 +117,7 @@ namespace System.IO.Abstractions.TestingHelpers
             
             if (!mockFileDataAccessor.Directory.Exists(path))
             {
-                throw new DirectoryNotFoundException(string.Format(CultureInfo.InvariantCulture, StringResources.Manager.GetString("COULD_NOT_FIND_PART_OF_PATH_EXCEPTION"), path));
+                throw CommonExceptions.CouldNotFindPartOfPath(path);
             }
 
             var directoryData = (MockDirectoryData) mockFileDataAccessor.GetFile(path);
@@ -203,11 +203,7 @@ namespace System.IO.Abstractions.TestingHelpers
 
             if (!Exists(path))
             {
-                throw new DirectoryNotFoundException(
-                    string.Format(
-                        CultureInfo.InvariantCulture,
-                        StringResources.Manager.GetString("COULD_NOT_FIND_PART_OF_PATH_EXCEPTION"),
-                        path));
+                throw CommonExceptions.CouldNotFindPartOfPath(path);
             }
 
             path = EnsureAbsolutePath(path);
@@ -402,7 +398,7 @@ namespace System.IO.Abstractions.TestingHelpers
 
             if (!mockFileDataAccessor.Directory.Exists(path))
             {
-                throw new DirectoryNotFoundException(string.Format(CultureInfo.InvariantCulture, StringResources.Manager.GetString("COULD_NOT_FIND_PART_OF_PATH_EXCEPTION"), path));
+                throw CommonExceptions.CouldNotFindPartOfPath(path);
             }
 
             var directoryData = (MockDirectoryData)mockFileDataAccessor.GetFile(path);
@@ -540,7 +536,7 @@ namespace System.IO.Abstractions.TestingHelpers
             var invalidPathChars = Path.GetInvalidPathChars();
             if (searchPattern.IndexOfAny(invalidPathChars) > -1)
             {
-                throw new ArgumentException(StringResources.Manager.GetString("ILLEGAL_CHARACTERS_IN_PATH_EXCEPTION"), "searchPattern");
+                throw CommonExceptions.IllegalCharactersInPath(nameof(searchPattern));
             }
         }
     }

--- a/System.IO.Abstractions.TestingHelpers/MockDirectoryInfo.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockDirectoryInfo.cs
@@ -293,7 +293,7 @@ namespace System.IO.Abstractions.TestingHelpers
         private MockFileData GetMockFileDataForWrite()
         {
             return mockFileDataAccessor.GetFile(directoryPath)
-                ?? throw new FileNotFoundException(StringResources.Manager.GetString("COULD_NOT_FIND_FILE_EXCEPTION"), directoryPath);
+                ?? throw CommonExceptions.FileNotFound(directoryPath);
         }
 
         public override string ToString()

--- a/System.IO.Abstractions.TestingHelpers/MockFile.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockFile.cs
@@ -89,20 +89,20 @@ namespace System.IO.Abstractions.TestingHelpers
         {
             if (sourceFileName == null)
             {
-                throw new ArgumentNullException(nameof(sourceFileName), StringResources.Manager.GetString("FILENAME_CANNOT_BE_NULL"));
+                throw CommonExceptions.FilenameCannotBeNull(nameof(sourceFileName));
             }
 
             if (destFileName == null)
             {
-                throw new ArgumentNullException(nameof(destFileName), StringResources.Manager.GetString("FILENAME_CANNOT_BE_NULL"));
+                throw CommonExceptions.FilenameCannotBeNull(nameof(destFileName));
             }
 
-            mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(sourceFileName, "sourceFileName");
-            mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(destFileName, "destFileName");
+            mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(sourceFileName, nameof(sourceFileName));
+            mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(destFileName, nameof(destFileName));
 
             if (!Exists(sourceFileName))
             {
-                throw new FileNotFoundException(string.Format(CultureInfo.InvariantCulture, StringResources.Manager.GetString("COULD_NOT_FIND_FILE_EXCEPTION"), sourceFileName));
+                throw CommonExceptions.FileNotFound(sourceFileName);
             }
 
             VerifyDirectoryExists(destFileName);
@@ -205,7 +205,7 @@ namespace System.IO.Abstractions.TestingHelpers
 
             if (!mockFileDataAccessor.FileExists(path))
             {
-                throw new FileNotFoundException(string.Format(CultureInfo.InvariantCulture, StringResources.Manager.GetString("COULD_NOT_FIND_FILE_EXCEPTION"), path));
+                throw CommonExceptions.FileNotFound(path);
             }
 
             var fileData = mockFileDataAccessor.GetFile(path);
@@ -233,7 +233,7 @@ namespace System.IO.Abstractions.TestingHelpers
         {
             if (path != null && path.Length == 0)
             {
-                throw new ArgumentException(StringResources.Manager.GetString("THE_PATH_IS_NOT_OF_A_LEGAL_FORM"), "path");
+                throw CommonExceptions.PathIsNotOfALegalForm(nameof(path));
             }
 
             mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, "path");
@@ -255,7 +255,7 @@ namespace System.IO.Abstractions.TestingHelpers
                 {
                     VerifyDirectoryExists(path);
 
-                    throw new FileNotFoundException(string.Format(CultureInfo.InvariantCulture, "Could not find file '{0}'.", path));
+                    throw CommonExceptions.FileNotFound(path);
                 }
             }
 
@@ -324,16 +324,16 @@ namespace System.IO.Abstractions.TestingHelpers
         {
             if (sourceFileName == null)
             {
-                throw new ArgumentNullException(nameof(sourceFileName), StringResources.Manager.GetString("FILENAME_CANNOT_BE_NULL"));
+                throw CommonExceptions.FilenameCannotBeNull(nameof(sourceFileName));
             }
 
             if (destFileName == null)
             {
-                throw new ArgumentNullException(nameof(destFileName), StringResources.Manager.GetString("FILENAME_CANNOT_BE_NULL"));
+                throw CommonExceptions.FilenameCannotBeNull(nameof(destFileName));
             }
 
-            mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(sourceFileName, "sourceFileName");
-            mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(destFileName, "destFileName");
+            mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(sourceFileName, nameof(sourceFileName));
+            mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(destFileName, nameof(destFileName));
 
             if (mockFileDataAccessor.GetFile(destFileName) != null)
             {
@@ -351,7 +351,9 @@ namespace System.IO.Abstractions.TestingHelpers
             var sourceFile = mockFileDataAccessor.GetFile(sourceFileName);
 
             if (sourceFile == null)
-                throw new FileNotFoundException(string.Format(CultureInfo.InvariantCulture, "The file \"{0}\" could not be found.", sourceFileName), sourceFileName);
+            {
+                throw CommonExceptions.FileNotFound(sourceFileName);
+            }
 
             VerifyDirectoryExists(destFileName);
 
@@ -391,7 +393,7 @@ namespace System.IO.Abstractions.TestingHelpers
                 throw new IOException(string.Format(CultureInfo.InvariantCulture, "The file '{0}' already exists.", path));
 
             if ((mode == FileMode.Open || mode == FileMode.Truncate) && !exists)
-                throw new FileNotFoundException(path);
+                throw CommonExceptions.FileNotFound(path);
 
             if (!exists || mode == FileMode.CreateNew)
                 return Create(path);
@@ -442,7 +444,7 @@ namespace System.IO.Abstractions.TestingHelpers
 
             if (!mockFileDataAccessor.FileExists(path))
             {
-                throw new FileNotFoundException(string.Format(CultureInfo.InvariantCulture, StringResources.Manager.GetString("COULD_NOT_FIND_FILE_EXCEPTION"), path));
+                throw CommonExceptions.FileNotFound(path);
             }
 
             return mockFileDataAccessor.GetFile(path).Contents;
@@ -454,7 +456,7 @@ namespace System.IO.Abstractions.TestingHelpers
 
             if (!mockFileDataAccessor.FileExists(path))
             {
-                throw new FileNotFoundException(string.Format(CultureInfo.InvariantCulture, StringResources.Manager.GetString("COULD_NOT_FIND_FILE_EXCEPTION"), path));
+                throw CommonExceptions.FileNotFound(path);
             }
 
             return mockFileDataAccessor
@@ -474,7 +476,7 @@ namespace System.IO.Abstractions.TestingHelpers
 
             if (!mockFileDataAccessor.FileExists(path))
             {
-                throw new FileNotFoundException(string.Format(CultureInfo.InvariantCulture, "Can't find {0}", path));
+                throw CommonExceptions.FileNotFound(path);
             }
 
             return encoding
@@ -488,7 +490,7 @@ namespace System.IO.Abstractions.TestingHelpers
 
             if (!mockFileDataAccessor.FileExists(path))
             {
-                throw new FileNotFoundException(string.Format(CultureInfo.InvariantCulture, "Can't find {0}", path));
+                throw CommonExceptions.FileNotFound(path);
             }
 
             return ReadAllText(path, MockFileData.DefaultEncoding);
@@ -541,12 +543,12 @@ namespace System.IO.Abstractions.TestingHelpers
 
             if (!mockFileDataAccessor.FileExists(sourceFileName))
             {
-                throw new FileNotFoundException(string.Format(CultureInfo.InvariantCulture, StringResources.Manager.GetString("COULD_NOT_FIND_FILE_EXCEPTION"), sourceFileName));
+                throw CommonExceptions.FileNotFound(sourceFileName);
             }
 
             if (!mockFileDataAccessor.FileExists(destinationFileName))
             {
-                throw new FileNotFoundException(string.Format(CultureInfo.InvariantCulture, StringResources.Manager.GetString("COULD_NOT_FIND_FILE_EXCEPTION"), destinationFileName));
+                throw CommonExceptions.FileNotFound(destinationFileName);
             }
 
             if (destinationBackupFileName != null)
@@ -565,7 +567,7 @@ namespace System.IO.Abstractions.TestingHelpers
 
             if (!mockFileDataAccessor.FileExists(path))
             {
-                throw new FileNotFoundException(string.Format(CultureInfo.InvariantCulture, "Can't find {0}", path), path);
+                throw CommonExceptions.FileNotFound(path);
             }
 
             var fileData = mockFileDataAccessor.GetFile(path);
@@ -586,7 +588,7 @@ namespace System.IO.Abstractions.TestingHelpers
                 }
                 else
                 {
-                    throw new FileNotFoundException(string.Format(CultureInfo.InvariantCulture, StringResources.Manager.GetString("COULD_NOT_FIND_FILE_EXCEPTION"), path), path);
+                    throw CommonExceptions.FileNotFound(path);
                 }
             }
             else
@@ -676,7 +678,7 @@ namespace System.IO.Abstractions.TestingHelpers
             mockFileDataAccessor.AddFile(path, new MockFileData(bytes));
         }
 
-       /// <summary>
+        /// <summary>
         /// Creates a new file, writes a collection of strings to the file, and then closes the file.
         /// </summary>
         /// <param name="path">The file to write to.</param>
@@ -937,7 +939,7 @@ namespace System.IO.Abstractions.TestingHelpers
 
             if (mockFileDataAccessor.Directory.Exists(path))
             {
-                throw new UnauthorizedAccessException(string.Format(CultureInfo.InvariantCulture, StringResources.Manager.GetString("ACCESS_TO_THE_PATH_IS_DENIED"), path));
+                throw CommonExceptions.AccessDenied(path);
             }
 
             VerifyDirectoryExists(path);
@@ -976,11 +978,7 @@ namespace System.IO.Abstractions.TestingHelpers
 
             if (!mockFileDataAccessor.Directory.Exists(dir))
             {
-                throw new DirectoryNotFoundException(
-                    string.Format(
-                        CultureInfo.InvariantCulture, 
-                        StringResources.Manager.GetString("COULD_NOT_FIND_PART_OF_PATH_EXCEPTION"),
-                        path));
+                throw CommonExceptions.CouldNotFindPartOfPath(path);
             }
         }
     }

--- a/System.IO.Abstractions.TestingHelpers/MockFileInfo.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockFileInfo.cs
@@ -32,7 +32,7 @@ namespace System.IO.Abstractions.TestingHelpers
         {
             get
             {
-                if (MockFileData == null) throw new FileNotFoundException("File not found", path);
+                if (MockFileData == null) throw CommonExceptions.FileNotFound(path);
                 return MockFileData.Attributes;
             }
             set { MockFileData.Attributes = value; }
@@ -42,12 +42,12 @@ namespace System.IO.Abstractions.TestingHelpers
         {
             get
             {
-                if (MockFileData == null) throw new FileNotFoundException("File not found", path);
+                if (MockFileData == null) throw CommonExceptions.FileNotFound(path);
                 return MockFileData.CreationTime.DateTime;
             }
             set
             {
-                if (MockFileData == null) throw new FileNotFoundException("File not found", path);
+                if (MockFileData == null) throw CommonExceptions.FileNotFound(path);
                 MockFileData.CreationTime = value;
             }
         }
@@ -56,12 +56,12 @@ namespace System.IO.Abstractions.TestingHelpers
         {
             get
             {
-                if (MockFileData == null) throw new FileNotFoundException("File not found", path);
+                if (MockFileData == null) throw CommonExceptions.FileNotFound(path);
                 return MockFileData.CreationTime.UtcDateTime;
             }
             set
             {
-                if (MockFileData == null) throw new FileNotFoundException("File not found", path);
+                if (MockFileData == null) throw CommonExceptions.FileNotFound(path);
                 MockFileData.CreationTime = value.ToLocalTime();
             }
         }
@@ -90,12 +90,12 @@ namespace System.IO.Abstractions.TestingHelpers
         {
             get
             {
-                if (MockFileData == null) throw new FileNotFoundException("File not found", path);
+                if (MockFileData == null) throw CommonExceptions.FileNotFound(path);
                 return MockFileData.LastAccessTime.DateTime;
             }
             set
             {
-                if (MockFileData == null) throw new FileNotFoundException("File not found", path);
+                if (MockFileData == null) throw CommonExceptions.FileNotFound(path);
                 MockFileData.LastAccessTime = value;
             }
         }
@@ -104,12 +104,12 @@ namespace System.IO.Abstractions.TestingHelpers
         {
             get
             {
-                if (MockFileData == null) throw new FileNotFoundException("File not found", path);
+                if (MockFileData == null) throw CommonExceptions.FileNotFound(path);
                 return MockFileData.LastAccessTime.UtcDateTime;
             }
             set
             {
-                if (MockFileData == null) throw new FileNotFoundException("File not found", path);
+                if (MockFileData == null) throw CommonExceptions.FileNotFound(path);
                 MockFileData.LastAccessTime = value;
             }
         }
@@ -118,12 +118,12 @@ namespace System.IO.Abstractions.TestingHelpers
         {
             get
             {
-                if (MockFileData == null) throw new FileNotFoundException("File not found", path);
+                if (MockFileData == null) throw CommonExceptions.FileNotFound(path);
                 return MockFileData.LastWriteTime.DateTime;
             }
             set
             {
-                if (MockFileData == null) throw new FileNotFoundException("File not found", path);
+                if (MockFileData == null) throw CommonExceptions.FileNotFound(path);
                 MockFileData.LastWriteTime = value;
             }
         }
@@ -132,12 +132,12 @@ namespace System.IO.Abstractions.TestingHelpers
         {
             get
             {
-                if (MockFileData == null) throw new FileNotFoundException("File not found", path);
+                if (MockFileData == null) throw CommonExceptions.FileNotFound(path);
                 return MockFileData.LastWriteTime.UtcDateTime;
             }
             set
             {
-                if (MockFileData == null) throw new FileNotFoundException("File not found", path);
+                if (MockFileData == null) throw CommonExceptions.FileNotFound(path);
                 MockFileData.LastWriteTime = value.ToLocalTime();
             }
         }
@@ -149,7 +149,7 @@ namespace System.IO.Abstractions.TestingHelpers
 
         public override StreamWriter AppendText()
         {
-            if (MockFileData == null) throw new FileNotFoundException("File not found", path);
+            if (MockFileData == null) throw CommonExceptions.FileNotFound(path);
             return new StreamWriter(new MockFileStream(mockFileSystem, FullName, MockFileStream.StreamType.APPEND));
         }
 
@@ -162,7 +162,7 @@ namespace System.IO.Abstractions.TestingHelpers
         {
             if (!Exists)
             {
-                throw new FileNotFoundException("The file does not exist and can't be moved or copied.", FullName);
+                if (MockFileData == null) throw CommonExceptions.FileNotFound(FullName);
             }
             if (destFileName == FullName)
             {
@@ -185,14 +185,14 @@ namespace System.IO.Abstractions.TestingHelpers
 #if NET40
         public override void Decrypt()
         {
-            if (MockFileData == null) throw new FileNotFoundException("File not found", path);
+                if (MockFileData == null) throw CommonExceptions.FileNotFound(path);
 
             MockFileData.Attributes &= ~FileAttributes.Encrypted;
         }
 
         public override void Encrypt()
         {
-            if (MockFileData == null) throw new FileNotFoundException("File not found", path);
+                if (MockFileData == null) throw CommonExceptions.FileNotFound(path);
 
             MockFileData.Attributes |= FileAttributes.Encrypted;
         }
@@ -236,7 +236,7 @@ namespace System.IO.Abstractions.TestingHelpers
 
         public override Stream OpenRead()
         {
-            if (MockFileData == null) throw new FileNotFoundException("File not found", path);
+            if (MockFileData == null) throw CommonExceptions.FileNotFound(path);
             return new MockFileStream(mockFileSystem, path, MockFileStream.StreamType.READ);
         }
 
@@ -290,12 +290,12 @@ namespace System.IO.Abstractions.TestingHelpers
         {
             get
             {
-                if (MockFileData == null) throw new FileNotFoundException("File not found", path);
+                if (MockFileData == null) throw CommonExceptions.FileNotFound(path);
                 return (MockFileData.Attributes & FileAttributes.ReadOnly) == FileAttributes.ReadOnly;
             }
             set
             {
-                if (MockFileData == null) throw new FileNotFoundException("File not found", path);
+                if (MockFileData == null) throw CommonExceptions.FileNotFound(path);
                 if (value)
                     MockFileData.Attributes |= FileAttributes.ReadOnly;
                 else
@@ -307,7 +307,7 @@ namespace System.IO.Abstractions.TestingHelpers
         {
             get
             {
-                if (MockFileData == null) throw new FileNotFoundException("File not found", path);
+                if (MockFileData == null) throw CommonExceptions.FileNotFound(path);
                 return MockFileData.Contents.Length;
             }
         }

--- a/System.IO.Abstractions.TestingHelpers/MockFileStream.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockFileStream.cs
@@ -56,7 +56,7 @@
             {
                 if (StreamType.READ.Equals(streamType))
                 {
-                    throw new FileNotFoundException("File not found.", path);
+                    throw CommonExceptions.FileNotFound(path);
                 }
                 mockFileDataAccessor.AddFile(path, new MockFileData(new byte[] { }));
             }

--- a/System.IO.Abstractions.TestingHelpers/MockFileSystem.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockFileSystem.cs
@@ -127,7 +127,7 @@ namespace System.IO.Abstractions.TestingHelpers
 
                     if (isReadOnly || isHidden)
                     {
-                        throw new UnauthorizedAccessException(string.Format(CultureInfo.InvariantCulture, StringResources.Manager.GetString("ACCESS_TO_THE_PATH_IS_DENIED"), path));
+                        throw CommonExceptions.AccessDenied(path);
                     }
                 }
 
@@ -151,7 +151,7 @@ namespace System.IO.Abstractions.TestingHelpers
             {
                 if (FileExists(fixedPath) &&
                     (GetFile(fixedPath).Attributes & FileAttributes.ReadOnly) == FileAttributes.ReadOnly)
-                    throw new UnauthorizedAccessException(string.Format(CultureInfo.InvariantCulture, StringResources.Manager.GetString("ACCESS_TO_THE_PATH_IS_DENIED"), fixedPath));
+                        throw CommonExceptions.AccessDenied(fixedPath);
 
                 var lastIndex = 0;
                 var isUnc =
@@ -164,7 +164,7 @@ namespace System.IO.Abstractions.TestingHelpers
                     lastIndex = StringOperations.IndexOf(fixedPath, separator, 2);
 
                     if (lastIndex < 0)
-                        throw new ArgumentException(@"The UNC path should be of the form \\server\share.", "path");
+                        throw CommonExceptions.InvalidUncPath(nameof(path));
 
                     /*
                      * Although CreateDirectory(@"\\server\share\") is not going to work in real code, we allow it here for the purposes of setting up test doubles.
@@ -247,7 +247,7 @@ namespace System.IO.Abstractions.TestingHelpers
             {
                 if (FileExists(path) && (GetFile(path).Attributes & FileAttributes.ReadOnly) == FileAttributes.ReadOnly)
                 {
-                    throw new UnauthorizedAccessException(string.Format(CultureInfo.InvariantCulture, StringResources.Manager.GetString("ACCESS_TO_THE_PATH_IS_DENIED"), path));
+                    throw CommonExceptions.AccessDenied(path);
                 }
 
                 files.Remove(path);

--- a/System.IO.Abstractions.TestingHelpers/MockPath.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockPath.cs
@@ -26,7 +26,7 @@ namespace System.IO.Abstractions.TestingHelpers
 
             if (path.Length == 0)
             {
-                throw new ArgumentException(StringResources.Manager.GetString("THE_PATH_IS_NOT_OF_A_LEGAL_FORM"), "path");
+                throw CommonExceptions.PathIsNotOfALegalForm(nameof(path));
             }
 
             path = path.Replace(AltDirectorySeparatorChar, DirectorySeparatorChar);
@@ -53,7 +53,7 @@ namespace System.IO.Abstractions.TestingHelpers
                 pathSegments = GetSegments(path);
                 if (pathSegments.Length < 2)
                 {
-                    throw new ArgumentException(@"The UNC path should be of the form \\server\share.", "path");
+                    throw CommonExceptions.InvalidUncPath(nameof(path));
                 }
             }
             else if (mockFileDataAccessor.StringOperations.Equals(@"\", root) ||

--- a/System.IO.Abstractions.TestingHelpers/PathVerifier.cs
+++ b/System.IO.Abstractions.TestingHelpers/PathVerifier.cs
@@ -25,27 +25,28 @@ namespace System.IO.Abstractions.TestingHelpers
             {
                 throw new ArgumentException("Empty file name is not legal.", paramName);
             }
-
+            
             if (path.Trim() == string.Empty)
             {
-                throw new ArgumentException(StringResources.Manager.GetString("THE_PATH_IS_NOT_OF_A_LEGAL_FORM"), paramName);
+                throw CommonExceptions.PathIsNotOfALegalForm(paramName);
             }
 
             if (XFS.IsWindowsPlatform() && !IsValidUseOfVolumeSeparatorChar(path))
             {
-                throw new NotSupportedException(StringResources.Manager.GetString("THE_PATH_IS_NOT_OF_A_LEGAL_FORM"));
+                
+                throw CommonExceptions.InvalidUseOfVolumeSeparator();
             }
 
             if (ExtractFileName(path).IndexOfAny(_mockFileDataAccessor.Path.GetInvalidFileNameChars()) > -1)
             {
-                throw new ArgumentException(StringResources.Manager.GetString("ILLEGAL_CHARACTERS_IN_PATH_EXCEPTION"));
+                throw CommonExceptions.IllegalCharactersInPath();
             }
 
             var filePath = ExtractFilePath(path);
 
             if (HasIllegalCharacters(filePath, checkAdditional: false))
             {
-                throw new ArgumentException(StringResources.Manager.GetString("ILLEGAL_CHARACTERS_IN_PATH_EXCEPTION"));
+                throw CommonExceptions.IllegalCharactersInPath();
             }
         }
 
@@ -96,7 +97,7 @@ namespace System.IO.Abstractions.TestingHelpers
 
             if (HasIllegalCharacters(path, checkAdditional))
             {
-                throw new ArgumentException(StringResources.Manager.GetString("ILLEGAL_CHARACTERS_IN_PATH_EXCEPTION"));
+                throw CommonExceptions.IllegalCharactersInPath();
             }
         }
     }

--- a/System.IO.Abstractions.TestingHelpers/StringExtensions.cs
+++ b/System.IO.Abstractions.TestingHelpers/StringExtensions.cs
@@ -99,7 +99,7 @@ namespace System.IO.Abstractions.TestingHelpers
 
             // UNC Paths start with double slash but no reason
             // to have more than 2 slashes at the start of a path
-            if (XFS.IsWindowsPlatform() && prefixSeps.Length > 2)
+            if (XFS.IsWindowsPlatform() && prefixSeps.Length >= 2)
             {
                 prefixSeps = prefixSeps.Substring(0, 2);
             }

--- a/System.IO.Abstractions/DirectoryInfoWrapper.cs
+++ b/System.IO.Abstractions/DirectoryInfoWrapper.cs
@@ -227,7 +227,17 @@ namespace System.IO.Abstractions
 
         public override DirectoryInfoBase Parent
         {
-            get { return new DirectoryInfoWrapper(FileSystem, instance.Parent); }
+            get
+            {
+                if (instance.Parent == null)
+                {
+                    return null;
+                }
+                else
+                {
+                    return new DirectoryInfoWrapper(FileSystem, instance.Parent);
+                }
+            }
         }
 
         public override DirectoryInfoBase Root

--- a/System.IO.Abstractions/FileWrapper.cs
+++ b/System.IO.Abstractions/FileWrapper.cs
@@ -1,14 +1,13 @@
 ﻿using System.Collections.Generic;
 using System.Security.AccessControl;
 using System.Text;
-using System.IO;
 
 namespace System.IO.Abstractions
 {
     [Serializable]
     public class FileWrapper : FileBase
     {
-        public FileWrapper(FileSystem fileSystem) : base(fileSystem)
+        public FileWrapper(IFileSystem fileSystem) : base(fileSystem)
         {
         }
 

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "2.2-beta",
+    "version": "3.0",
     "assemblyVersion": {
       "precision": "major"
     },


### PR DESCRIPTION
- Do not throw exception when calling DirectoryInfoWrapper.Parent for the root directory (#430) by @wexman 
- Fix MockDirectoryInfo GetFiles for UNC paths caused by bug in StringExtensions.NormalizeSlashes (#422) by @DeveloperGuo 
- Pass IFileSystem into FileWrapper instead of FileSystem to allow replacement file systems to be used (#432) by @kirbatious
- Make sure FileNotFound exceptions contain path and proper message (#427) by @fgreinacher 
- Do not delete directories that start with the same path (#433) by @updateaman 