### PR TITLE
Deploy from master again

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,14 +10,5 @@ The base version represents the MAJOR and MINOR parts of [SemVer](https://semver
 
 ## Branches / tags
 
-* `master` contains the latest sources - this is where we develop.
-* `release/v*` contains the sources for the respective version on `nuget.org` - this is where we deploy from.
-* All versions on `nuget.org` have a matching GitHub release/tag
-
-### Release workflow
-
-1. Check out latest master branch
-1. Call `nbgv prepare-release` (you need [the NBGV CLI tool](https://github.com/AArnott/Nerdbank.GitVersioning/blob/master/doc/nbgv-cli.md))
-1. Push the newly created branch
-1. Inspect CI run (test results, version number)
-1. Inspect newly created package versions on NuGet.org and newly created GitHub release
+* `master` contains the latest sources. Each merge there triggers a deploy to `nuget.org`.
+* All versions on `nuget.org` have a matching GitHub release/tag.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,11 +10,10 @@ skip_branch_with_pr: true
 # Don't start CI when tags are pushed
 skip_tags: true
 
-# Limit CI to master/release branches (and PRs targeting them)
+# Limit CI to master branch (and PRs targeting it)
 branches:
   only:
     - master
-    - /release/v.*$/
 
 environment:
   INHERITDOC_VERSION: 1.2.2.1
@@ -48,7 +47,7 @@ for:
     skip_symbols: false
     artifact: /.*\.nupkg/
     on:
-      branch: /release/v.*$/
+      branch: master
 
   - provider: GitHub
     tag: v$(appveyor_build_version)
@@ -57,4 +56,4 @@ for:
     auth_token:
       secure: Rrk1zp93EpCyxec/GXKnRnJjX7vU+ClNZEBnxbM+1j6l+C56qSV7B/fUrVsJuZYV
     on: 
-      branch: /release/v.*$/
+      branch: master

--- a/version.json
+++ b/version.json
@@ -1,18 +1,15 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "4.2-alpha",
+  "version": "4.2",
   "assemblyVersion": {
     "precision": "major"
   },
   "publicReleaseRefSpec": [
-    "^refs/heads/release/v.*$"
+    "^refs/heads/master$"
   ],
   "cloudBuild": {
     "buildNumber": {
       "enabled": true
     }
-  },
-  "release": {
-    "branchName": "release/v{version}"
   }
 }


### PR DESCRIPTION
This PR reverts to the simplest possible release strategy, deploying directly from master.

I am currently the only one actively maintaining this project, so I want to reduce the effort on my side as much as possible.