### PR TITLE
Throw DirectoryNotFoundException when try open FileStream for non-exiting path.

### DIFF
--- a/System.IO.Abstractions.TestingHelpers.Tests/MockFileCreateTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockFileCreateTests.cs
@@ -169,7 +169,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         public void MockFile_Create_TruncateShouldWriteNewContents()
         {
             // Arrange
-            const string testFileName = @"c:\someFile.txt";
+            string testFileName = XFS.Path(@"c:\someFile.txt");
             var fileSystem = new MockFileSystem();
             
             using (var stream = fileSystem.FileStream.Create(testFileName, FileMode.Create, FileAccess.Write))
@@ -197,7 +197,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         public void MockFile_Create_TruncateShouldClearFileContentsOnOpen()
         {
             // Arrange
-            const string testFileName = @"c:\someFile.txt";
+            string testFileName = XFS.Path(@"c:\someFile.txt");
             var fileSystem = new MockFileSystem();
 
             using (var stream = fileSystem.FileStream.Create(testFileName, FileMode.Create, FileAccess.Write))

--- a/System.IO.Abstractions.TestingHelpers.Tests/MockFileStreamFactoryTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockFileStreamFactoryTests.cs
@@ -3,6 +3,8 @@ using NUnit.Framework;
 
 namespace System.IO.Abstractions.TestingHelpers.Tests
 {
+    using XFS = MockUnixSupport;
+
     [TestFixture]
     public class MockFileStreamFactoryTests
     {
@@ -40,6 +42,22 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             // Assert
             Assert.IsNotNull(result);
+        }
+
+        [Test]
+        [TestCase(FileMode.Create)]
+        [TestCase(FileMode.Open)]
+        public void MockFileStreamFactory_CreateInNonExistingDirectory_ShouldThrowDirectoryNotFoundException(FileMode fileMode)
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddDirectory(XFS.Path(@"C:\Test"));
+
+            // Act
+            var fileStreamFactory = new MockFileStreamFactory(fileSystem);
+
+            // Assert
+            Assert.Throws<DirectoryNotFoundException>(() => fileStreamFactory.Create(@"C:\Test\NonExistingDirectory\some_random_file.txt", fileMode));
         }
     }
 }

--- a/System.IO.Abstractions.TestingHelpers.Tests/MockFileStreamFactoryTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockFileStreamFactoryTests.cs
@@ -38,7 +38,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var fileStreamFactory = new MockFileStreamFactory(fileSystem);
 
             // Act
-            var result = fileStreamFactory.Create(@"c:\not_existing.txt", fileMode);
+            var result = fileStreamFactory.Create(XFS.Path(@"c:\not_existing.txt"), fileMode);
 
             // Assert
             Assert.IsNotNull(result);

--- a/System.IO.Abstractions.TestingHelpers.Tests/MockFileStreamTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockFileStreamTests.cs
@@ -15,7 +15,7 @@
             // Arrange
             var filepath = XFS.Path(@"C:\something\foo.txt");
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>());
-            fileSystem.AddFile(@"C:\something\foo.txt", new MockFileData(""));
+            fileSystem.AddDirectory(@"C:\something");
 
             var cut = new MockFileStream(fileSystem, filepath, MockFileStream.StreamType.WRITE);
 

--- a/System.IO.Abstractions.TestingHelpers.Tests/MockFileStreamTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockFileStreamTests.cs
@@ -15,7 +15,7 @@
             // Arrange
             var filepath = XFS.Path(@"C:\something\foo.txt");
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>());
-            fileSystem.AddDirectory(@"C:\something");
+            fileSystem.AddDirectory(XFS.Path(@"C:\something"));
 
             var cut = new MockFileStream(fileSystem, filepath, MockFileStream.StreamType.WRITE);
 

--- a/System.IO.Abstractions.TestingHelpers.Tests/MockFileStreamTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockFileStreamTests.cs
@@ -13,16 +13,18 @@
         public void MockFileStream_Flush_WritesByteToFile()
         {
             // Arrange
-            var filepath = XFS.Path(@"c:\something\foo.txt");
-            var filesystem = new MockFileSystem(new Dictionary<string, MockFileData>());
-            var cut = new MockFileStream(filesystem, filepath, MockFileStream.StreamType.WRITE);
+            var filepath = XFS.Path(@"C:\something\foo.txt");
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>());
+            fileSystem.AddFile(@"C:\something\foo.txt", new MockFileData(""));
+
+            var cut = new MockFileStream(fileSystem, filepath, MockFileStream.StreamType.WRITE);
 
             // Act
             cut.WriteByte(255);
             cut.Flush();
 
             // Assert
-            CollectionAssert.AreEqual(new byte[]{255}, filesystem.GetFile(filepath).Contents);
+            CollectionAssert.AreEqual(new byte[]{255}, fileSystem.GetFile(filepath).Contents);
         }
 
         [Test]
@@ -52,10 +54,11 @@
         {
             // Arrange
             var nonexistentFilePath = XFS.Path(@"c:\something\foo.txt");
-            var filesystem = new MockFileSystem(new Dictionary<string, MockFileData>());
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>());
+            fileSystem.AddDirectory(XFS.Path(@"C:\something"));
 
             // Act
-            Assert.Throws<FileNotFoundException>(() => new MockFileStream(filesystem, nonexistentFilePath, MockFileStream.StreamType.READ));
+            Assert.Throws<FileNotFoundException>(() => new MockFileStream(fileSystem, nonexistentFilePath, MockFileStream.StreamType.READ));
 
             // Assert - expect an exception
         }

--- a/System.IO.Abstractions.TestingHelpers/MockFileStream.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockFileStream.cs
@@ -57,7 +57,7 @@
             }
             else
             {
-                if (!mockFileDataAccessor.Directory.Exists(Path.GetDirectoryName(path)))
+                if (!mockFileDataAccessor.Directory.Exists(mockFileDataAccessor.Path.GetDirectoryName(path)))
                 {
                     throw CommonExceptions.CouldNotFindPartOfPath(path);
                 }

--- a/System.IO.Abstractions.TestingHelpers/MockFileStream.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockFileStream.cs
@@ -57,10 +57,16 @@
             }
             else
             {
+                if (!mockFileDataAccessor.Directory.Exists(Path.GetDirectoryName(path)))
+                {
+                    throw CommonExceptions.CouldNotFindPartOfPath(path);
+                }
+
                 if (StreamType.READ.Equals(streamType))
                 {
                     throw CommonExceptions.FileNotFound(path);
                 }
+
                 mockFileDataAccessor.AddFile(path, new MockFileData(new byte[] { }));
             }
             


### PR DESCRIPTION
Refered to issue #460 

+ Throw DirectoryNotFoundException when try open FileStream for non-exiting path,
+ Added test for that case,
+ Fix existing test to pass after that change (directory init).