### PR TITLE
Fixes an issue with trailing spaces on directory path for Windows.

### DIFF
--- a/System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryInfoTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryInfoTests.cs
@@ -239,7 +239,6 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         [TestCase(@"c:\temp\\folder", @"c:\temp\folder")]
         [TestCase(@"c:\temp//folder", @"c:\temp\folder")]
         [TestCase(@"c:\temp//\\///folder", @"c:\temp\folder")]
-        [TestCase(@"c:\temp\folder  ", @"c:\temp\folder")]
         public void MockDirectoryInfo_FullName_ShouldReturnNormalizedPath(string directoryPath, string expectedFullName)
         {
             // Arrange
@@ -255,9 +254,25 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             Assert.AreEqual(expectedFullName, actualFullName);
         }
 
+        [TestCase(@"c:\temp\folder  ", @"c:\temp\folder")]
+        [WindowsOnly(WindowsSpecifics.Drives)]
+        public void MockDirectoryInfo_FullName_ShouldReturnPathWithTrimmedTrailingSpaces(string directoryPath, string expectedFullName)
+        {
+            // Arrange
+            directoryPath = XFS.Path(directoryPath);
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>());
+            var directoryInfo = new MockDirectoryInfo(fileSystem, directoryPath);
+
+            // Act
+            var actualFullName = directoryInfo.FullName;
+
+            // Assert
+            Assert.AreEqual(expectedFullName, actualFullName);
+        }
+
         [TestCase(@"c:\temp\\folder ", @"folder")]
         [WindowsOnly(WindowsSpecifics.Drives)]
-        public void MockDirectoryInfo_Name_ShouldReturnNormalizedName(string directoryPath, string expectedName)
+        public void MockDirectoryInfo_Name_ShouldReturnNameWithTrimmedTrailingSpaces(string directoryPath, string expectedName)
         {
             // Arrange
             directoryPath = XFS.Path(directoryPath);

--- a/System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryInfoTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryInfoTests.cs
@@ -259,7 +259,6 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         public void MockDirectoryInfo_FullName_ShouldReturnPathWithTrimmedTrailingSpaces(string directoryPath, string expectedFullName)
         {
             // Arrange
-            directoryPath = XFS.Path(directoryPath);
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>());
             var directoryInfo = new MockDirectoryInfo(fileSystem, directoryPath);
 
@@ -275,7 +274,6 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         public void MockDirectoryInfo_Name_ShouldReturnNameWithTrimmedTrailingSpaces(string directoryPath, string expectedName)
         {
             // Arrange
-            directoryPath = XFS.Path(directoryPath);
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>());
             var directoryInfo = new MockDirectoryInfo(fileSystem, directoryPath);
 

--- a/System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryInfoTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryInfoTests.cs
@@ -259,7 +259,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         public void MockDirectoryInfo_FullName_ShouldReturnPathWithTrimmedTrailingSpaces(string directoryPath, string expectedFullName)
         {
             // Arrange
-            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>());
+            var fileSystem = new MockFileSystem();
             var directoryInfo = new MockDirectoryInfo(fileSystem, directoryPath);
 
             // Act
@@ -274,7 +274,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         public void MockDirectoryInfo_Name_ShouldReturnNameWithTrimmedTrailingSpaces(string directoryPath, string expectedName)
         {
             // Arrange
-            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>());
+            var fileSystem = new MockFileSystem();
             var directoryInfo = new MockDirectoryInfo(fileSystem, directoryPath);
 
             // Act

--- a/System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryInfoTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryInfoTests.cs
@@ -239,6 +239,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         [TestCase(@"c:\temp\\folder", @"c:\temp\folder")]
         [TestCase(@"c:\temp//folder", @"c:\temp\folder")]
         [TestCase(@"c:\temp//\\///folder", @"c:\temp\folder")]
+        [TestCase(@"c:\temp\folder  ", @"c:\temp\folder")]
         public void MockDirectoryInfo_FullName_ShouldReturnNormalizedPath(string directoryPath, string expectedFullName)
         {
             // Arrange
@@ -252,6 +253,22 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             // Assert
             Assert.AreEqual(expectedFullName, actualFullName);
+        }
+
+        [TestCase(@"c:\temp\\folder ", @"folder")]
+        [WindowsOnly(WindowsSpecifics.Drives)]
+        public void MockDirectoryInfo_Name_ShouldReturnNormalizedName(string directoryPath, string expectedName)
+        {
+            // Arrange
+            directoryPath = XFS.Path(directoryPath);
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>());
+            var directoryInfo = new MockDirectoryInfo(fileSystem, directoryPath);
+
+            // Act
+            var actualName = directoryInfo.Name;
+
+            // Assert
+            Assert.AreEqual(expectedName, actualName);
         }
 
         [Test]

--- a/System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
@@ -524,6 +524,20 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
+        [WindowsOnly(WindowsSpecifics.Drives)]
+        public void MockDirectory_CreateDirectory_ShouldTrimTrailingSpaces()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+
+            // Act
+            fileSystem.Directory.CreateDirectory(XFS.Path(@"c:\temp\folder "));
+
+            // Assert
+            Assert.IsTrue(fileSystem.Directory.Exists(XFS.Path(@"c:\temp\folder")));
+        }
+
+        [Test]
         public void MockDirectory_CreMockDirectory_CreateDirectory_ShouldReturnDirectoryInfoBaseWhenDirectoryExists()
         {
             // Arrange

--- a/System.IO.Abstractions.TestingHelpers/MockDirectory.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockDirectory.cs
@@ -49,7 +49,11 @@ namespace System.IO.Abstractions.TestingHelpers
                 throw new ArgumentException(StringResources.Manager.GetString("PATH_CANNOT_BE_THE_EMPTY_STRING_OR_ALL_WHITESPACE"), "path");
             }
 
-            path = XFS.IsWindowsPlatform() ? mockFileDataAccessor.Path.GetFullPath(path).TrimSlashes().TrimEnd(' ') : mockFileDataAccessor.Path.GetFullPath(path).TrimSlashes();
+            path = mockFileDataAccessor.Path.GetFullPath(path).TrimSlashes();
+            if (XFS.IsWindowsPlatform())
+            {
+                path = path.TrimEnd(' ');
+            }
 
             if (!Exists(path))
             {

--- a/System.IO.Abstractions.TestingHelpers/MockDirectory.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockDirectory.cs
@@ -49,7 +49,7 @@ namespace System.IO.Abstractions.TestingHelpers
                 throw new ArgumentException(StringResources.Manager.GetString("PATH_CANNOT_BE_THE_EMPTY_STRING_OR_ALL_WHITESPACE"), "path");
             }
 
-            path = mockFileDataAccessor.Path.GetFullPath(path).TrimSlashes();
+            path = XFS.IsWindowsPlatform() ? mockFileDataAccessor.Path.GetFullPath(path).TrimSlashes().TrimEnd(' ') : mockFileDataAccessor.Path.GetFullPath(path).TrimSlashes();
 
             if (!Exists(path))
             {

--- a/System.IO.Abstractions.TestingHelpers/MockDirectoryInfo.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockDirectoryInfo.cs
@@ -26,7 +26,12 @@ namespace System.IO.Abstractions.TestingHelpers
             originalPath = directoryPath;
             directoryPath = mockFileDataAccessor.Path.GetFullPath(directoryPath);
 
-            this.directoryPath = XFS.IsWindowsPlatform() ? directoryPath.TrimSlashes().TrimEnd(' ') : directoryPath.TrimSlashes();
+            directoryPath = directoryPath.TrimSlashes();
+            if (XFS.IsWindowsPlatform())
+            {
+                directoryPath = directoryPath.TrimEnd(' ');
+            }
+            this.directoryPath = directoryPath;
         }
 
         public override void Delete()

--- a/System.IO.Abstractions.TestingHelpers/MockDirectoryInfo.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockDirectoryInfo.cs
@@ -4,6 +4,8 @@ using System.Security.AccessControl;
 
 namespace System.IO.Abstractions.TestingHelpers
 {
+    using XFS = MockUnixSupport;
+
     [Serializable]
     public class MockDirectoryInfo : DirectoryInfoBase
     {
@@ -24,7 +26,7 @@ namespace System.IO.Abstractions.TestingHelpers
             originalPath = directoryPath;
             directoryPath = mockFileDataAccessor.Path.GetFullPath(directoryPath);
 
-            this.directoryPath = directoryPath.TrimSlashes();
+            this.directoryPath = XFS.IsWindowsPlatform() ? directoryPath.TrimSlashes().TrimEnd(' ') : directoryPath.TrimSlashes();
         }
 
         public override void Delete()


### PR DESCRIPTION
Hey guys,

On Windows, trailing spaces are automatically removed from directory name.
If I create a directory like that
`var dirInfo = System.IO.Directory.CreateDirectory(@"C:\User\Folder ");`
Then
`dirInfo.Name == "Folder"`
should be true.