### PR TITLE
Support File.ReadAllLinesAsync and friends on .NET Core 3 / netstandard2.1

### DIFF
--- a/System.IO.Abstractions.TestingHelpers.Tests/FileSystemTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/FileSystemTests.cs
@@ -20,7 +20,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 #endif
 
-#if NETCOREAPP2_0
+#if NETCOREAPP2_0 || NETSTANDARD2_1
         [Test]
         public void Mock_File_Succeeds()
         {

--- a/System.IO.Abstractions.TestingHelpers.Tests/MockFileAppendAllLinesTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockFileAppendAllLinesTests.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 using NUnit.Framework;
 using XFS = System.IO.Abstractions.TestingHelpers.MockUnixSupport;
 
-#if NETCOREAPP2_0
+#if NETCOREAPP2_0 || NETSTANDARD2_1
 using System.Threading.Tasks;
 #endif
 
@@ -123,7 +123,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             Assert.That(exception.ParamName, Is.EqualTo("encoding"));
         }
 
-#if NETCOREAPP2_0
+#if NETCOREAPP2_0 || NETSTANDARD2_1
         [Test]
         public async Task MockFile_AppendAllLinesAsync_ShouldPersistNewLinesToExistingFile()
         {

--- a/System.IO.Abstractions.TestingHelpers.Tests/MockFileAppendAllTextTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockFileAppendAllTextTests.cs
@@ -9,7 +9,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
     using XFS = MockUnixSupport;
 
-#if NETCOREAPP2_0
+#if NETCOREAPP2_0 || NETSTANDARD2_1
     using System.Threading.Tasks;
 #endif
 
@@ -158,7 +158,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             Assert.That(fileSystem.File.Exists(file));
         }
 
-#if NETCOREAPP2_0
+#if NETCOREAPP2_0 || NETSTANDARD2_1
         [Test]
         public async Task MockFile_AppendAllTextAsync_ShouldPersistNewText()
         {

--- a/System.IO.Abstractions.TestingHelpers.Tests/MockFileReadAllBytesTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockFileReadAllBytesTests.cs
@@ -2,7 +2,7 @@
 using NUnit.Framework;
 using XFS = System.IO.Abstractions.TestingHelpers.MockUnixSupport;
 
-#if NETCOREAPP2_0
+#if NETCOREAPP2_0 || NETSTANDARD2_1
 using System.Threading.Tasks;
 #endif
 
@@ -64,7 +64,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             Assert.AreEqual(data, fileSystem.File.ReadAllBytes(altPath));
         }
-#if NETCOREAPP2_0
+#if NETCOREAPP2_0 || NETSTANDARD2_1
         [Test]
         public async Task MockFile_ReadAllBytesAsync_ShouldReturnOriginalByteData()
         {

--- a/System.IO.Abstractions.TestingHelpers.Tests/MockFileReadAllLinesTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockFileReadAllLinesTests.cs
@@ -8,7 +8,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
     using XFS = MockUnixSupport;
 
-#if NETCOREAPP2_0
+#if NETCOREAPP2_0 || NETSTANDARD2_1
     using System.Threading.Tasks;
 #endif
 
@@ -71,7 +71,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             Assert.That(exception.Message, Is.EqualTo("Could not find file '" + absentFileNameFullPath + "'."));
         }
 
-#if NETCOREAPP2_0
+#if NETCOREAPP2_0 || NETSTANDARD2_1
         [Test]
         public async Task MockFile_ReadAllLinesAsync_ShouldReturnOriginalTextData()
         {

--- a/System.IO.Abstractions.TestingHelpers.Tests/MockFileWriteAllBytesTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockFileWriteAllBytesTests.cs
@@ -2,7 +2,7 @@
 using NUnit.Framework;
 using XFS = System.IO.Abstractions.TestingHelpers.MockUnixSupport;
 
-#if NETCOREAPP2_0
+#if NETCOREAPP2_0 || NETSTANDARD2_1
 using System.Threading.Tasks;
 #endif
 
@@ -85,7 +85,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             Assert.That(exception.ParamName, Is.EqualTo("bytes"));
         }
 
-#if NETCOREAPP2_0
+#if NETCOREAPP2_0 || NETSTANDARD2_1
         [Test]
         public void MockFile_WriteAllBytesAsync_ShouldThrowDirectoryNotFoundExceptionIfPathDoesNotExists()
         {

--- a/System.IO.Abstractions.TestingHelpers.Tests/MockFileWriteAllLinesTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockFileWriteAllLinesTests.cs
@@ -195,7 +195,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 }
             }
 
-#if NETCOREAPP2_0
+#if NETCOREAPP2_0 || NETSTANDARD2_1
             public static IEnumerable ForDifferentEncodingAsync
             {
                 get
@@ -485,7 +485,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             Assert.That(exception.ParamName, Is.EqualTo("contents"));
         }
 
-#if NETCOREAPP2_0
+#if NETCOREAPP2_0 || NETSTANDARD2_1
         [TestCaseSource(typeof(TestDataForWriteAllLines), "ForDifferentEncodingAsync")]
         public void MockFile_WriteAllLinesAsyncGeneric_ShouldWriteTheCorrectContent(IMockFileDataAccessor fileSystem, Action action, string expectedContent)
         {

--- a/System.IO.Abstractions.TestingHelpers.Tests/MockFileWriteAllTextTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockFileWriteAllTextTests.cs
@@ -8,7 +8,7 @@
 
     using XFS = MockUnixSupport;
 
-#if NETCOREAPP2_0
+#if NETCOREAPP2_0 || NETSTANDARD2_1
     using System.Threading.Tasks;
 #endif
 
@@ -227,7 +227,7 @@
                 fileSystem.GetFile(path).TextContents);
         }
 
-#if NETCOREAPP2_0
+#if NETCOREAPP2_0 || NETSTANDARD2_1
         [Test]
         public async Task MockFile_WriteAllTextAsync_ShouldWriteTextFileToMemoryFileSystem()
         {

--- a/System.IO.Abstractions.TestingHelpers/MockFile.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockFile.cs
@@ -39,7 +39,7 @@ namespace System.IO.Abstractions.TestingHelpers
             AppendAllText(path, concatContents, encoding);
         }
 
-#if NETCOREAPP2_0
+#if NETCOREAPP2_0 || NETSTANDARD2_1
         public override Task AppendAllLinesAsync(string path, IEnumerable<string> contents, CancellationToken cancellationToken = default(CancellationToken))
         {
             AppendAllLines(path, contents);
@@ -82,7 +82,7 @@ namespace System.IO.Abstractions.TestingHelpers
             }
         }
 
-#if NETCOREAPP2_0
+#if NETCOREAPP2_0 || NETSTANDARD2_1
         public override Task AppendAllTextAsync(string path, string contents, CancellationToken cancellationToken = default(CancellationToken))
         {
             AppendAllText(path, contents);
@@ -491,7 +491,7 @@ namespace System.IO.Abstractions.TestingHelpers
             return mockFileDataAccessor.GetFile(path).Contents;
         }
 
-#if NETCOREAPP2_0
+#if NETCOREAPP2_0 || NETSTANDARD2_1
         public override Task<byte[]> ReadAllBytesAsync(string path, CancellationToken cancellationToken = default(CancellationToken))
         {
             return Task.FromResult(ReadAllBytes(path));
@@ -534,7 +534,7 @@ namespace System.IO.Abstractions.TestingHelpers
                 .SplitLines();
         }
 
-#if NETCOREAPP2_0
+#if NETCOREAPP2_0 || NETSTANDARD2_1
         public override Task<string[]> ReadAllLinesAsync(string path, CancellationToken cancellationToken = default(CancellationToken))
         {
             return Task.FromResult(ReadAllLines(path));
@@ -570,7 +570,7 @@ namespace System.IO.Abstractions.TestingHelpers
             return ReadAllTextInternal(path, encoding);
         }
 
-#if NETCOREAPP2_0
+#if NETCOREAPP2_0 || NETSTANDARD2_1
         public override Task<string> ReadAllTextAsync(string path, CancellationToken cancellationToken)
         {
             return Task.FromResult(ReadAllText(path));
@@ -752,7 +752,7 @@ namespace System.IO.Abstractions.TestingHelpers
             mockFileDataAccessor.AddFile(path, new MockFileData(bytes));
         }
 
-#if NETCOREAPP2_0
+#if NETCOREAPP2_0 || NETSTANDARD2_1
         public override Task WriteAllBytesAsync(string path, byte[] bytes, CancellationToken cancellationToken)
         {
             WriteAllBytes(path, bytes);
@@ -947,7 +947,7 @@ namespace System.IO.Abstractions.TestingHelpers
             WriteAllLines(path, new List<string>(contents), encoding);
         }
 
-#if NETCOREAPP2_0
+#if NETCOREAPP2_0 || NETSTANDARD2_1
         public override Task WriteAllLinesAsync(string path, IEnumerable<string> contents, CancellationToken cancellationToken)
         {
             WriteAllLines(path, contents);
@@ -1056,7 +1056,7 @@ namespace System.IO.Abstractions.TestingHelpers
             mockFileDataAccessor.AddFile(path, data);
         }
 
-#if NETCOREAPP2_0
+#if NETCOREAPP2_0 || NETSTANDARD2_1
         public override Task WriteAllTextAsync(string path, string contents, CancellationToken cancellationToken)
         {
             WriteAllText(path, contents);

--- a/System.IO.Abstractions.TestingHelpers/System.IO.Abstractions.TestingHelpers.csproj
+++ b/System.IO.Abstractions.TestingHelpers/System.IO.Abstractions.TestingHelpers.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netstandard1.4;netstandard2.0;netcoreapp2.0</TargetFrameworks>
+        <TargetFrameworks>netstandard1.4;netstandard2.0;netstandard2.1;netcoreapp2.0</TargetFrameworks>
         <TargetFrameworks Condition="!$([MSBuild]::IsOsUnixLike())">$(TargetFrameworks);net40</TargetFrameworks>
         <PackageId>System.IO.Abstractions.TestingHelpers</PackageId>
         <Description>A set of pre-built mocks to help when testing file system interactions.</Description>
@@ -26,7 +26,7 @@
         <ProjectReference Include="..\System.IO.Abstractions\System.IO.Abstractions.csproj" />
     </ItemGroup>
 
-    <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0'">
+    <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'netstandard2.1' Or '$(TargetFramework)' == 'netcoreapp2.0'">
         <PackageReference Include="System.IO.FileSystem.AccessControl">
             <Version>4.5.0</Version>
         </PackageReference>

--- a/System.IO.Abstractions/FileBase.cs
+++ b/System.IO.Abstractions/FileBase.cs
@@ -2,7 +2,7 @@
 using System.Security.AccessControl;
 using System.Text;
 
-#if NETCOREAPP2_0
+#if NETCOREAPP2_0 || NETSTANDARD2_1
 using System.Threading.Tasks;
 using System.Threading;
 #endif
@@ -32,7 +32,7 @@ namespace System.IO.Abstractions
         /// <inheritdoc cref="File.AppendAllLines(string,IEnumerable{string},Encoding)"/>
         public abstract void AppendAllLines(string path, IEnumerable<string> contents, Encoding encoding);
 
-#if NETCOREAPP2_0
+#if NETCOREAPP2_0 || NETSTANDARD2_1
         /// <inheritdoc cref="File.AppendAllLinesAsync(string,IEnumerable{string},CancellationToken)"/>
         public abstract Task AppendAllLinesAsync(string path, IEnumerable<string> contents, CancellationToken cancellationToken);
 
@@ -46,7 +46,7 @@ namespace System.IO.Abstractions
         /// <inheritdoc cref="File.AppendAllText(string,string,Encoding)"/>
         public abstract void AppendAllText(string path, string contents, Encoding encoding);
 
-#if NETCOREAPP2_0
+#if NETCOREAPP2_0 || NETSTANDARD2_1
         /// <inheritdoc cref="File.AppendAllTextAsync(string,string,CancellationToken)"/>
         public abstract Task AppendAllTextAsync(String path, String contents, CancellationToken cancellationToken);
 
@@ -308,7 +308,7 @@ namespace System.IO.Abstractions
         /// <inheritdoc cref="File.ReadAllBytes"/>
         public abstract byte[] ReadAllBytes(string path);
 
-#if NETCOREAPP2_0
+#if NETCOREAPP2_0 || NETSTANDARD2_1
         /// <inheritdoc cref="File.ReadAllBytesAsync"/>
         public abstract Task<byte[]> ReadAllBytesAsync(string path, CancellationToken cancellationToken);
 #endif
@@ -319,7 +319,7 @@ namespace System.IO.Abstractions
         /// <inheritdoc cref="File.ReadAllLines(string,Encoding)"/>
         public abstract string[] ReadAllLines(string path, Encoding encoding);
 
-#if NETCOREAPP2_0
+#if NETCOREAPP2_0 || NETSTANDARD2_1
         /// <inheritdoc cref="File.ReadAllLinesAsync(string,CancellationToken)"/>
         public abstract Task<string[]> ReadAllLinesAsync(string path, CancellationToken cancellationToken);
 
@@ -333,7 +333,7 @@ namespace System.IO.Abstractions
         /// <inheritdoc cref="File.ReadAllText(string,Encoding)"/>
         public abstract string ReadAllText(string path, Encoding encoding);
 
-#if NETCOREAPP2_0
+#if NETCOREAPP2_0 || NETSTANDARD2_1
         ///<inheritdoc cref="File.ReadAllTextAsync(string,CancellationToken)"/>
         public abstract Task<string> ReadAllTextAsync(string path, CancellationToken cancellationToken);
 
@@ -446,7 +446,7 @@ namespace System.IO.Abstractions
         /// </para>
         /// </remarks>
 
-#if NETCOREAPP2_0
+#if NETCOREAPP2_0 || NETSTANDARD2_1
         /// <inheritdoc cref="File.WriteAllBytesAsync"/>
         public abstract Task WriteAllBytesAsync(string path, byte[] bytes, CancellationToken cancellationToken);
 #endif
@@ -610,7 +610,7 @@ namespace System.IO.Abstractions
         /// </para>
         /// </remarks>
 
-#if NETCOREAPP2_0
+#if NETCOREAPP2_0 || NETSTANDARD2_1
         /// <inheritdoc cref="File.WriteAllLinesAsync(string,IEnumerable{string},CancellationToken)"/>
         public abstract Task WriteAllLinesAsync(string path, IEnumerable<string> contents, CancellationToken cancellationToken);
 
@@ -658,7 +658,7 @@ namespace System.IO.Abstractions
         /// </remarks>
         public abstract void WriteAllText(string path, string contents, Encoding encoding);
         
-#if NETCOREAPP2_0
+#if NETCOREAPP2_0 || NETSTANDARD2_1
         /// <inheritdoc cref="File.WriteAllTextAsync(string,string,CancellationToken)"/>
         public abstract Task WriteAllTextAsync(string path, string contents, CancellationToken cancellationToken);
         

--- a/System.IO.Abstractions/FileWrapper.cs
+++ b/System.IO.Abstractions/FileWrapper.cs
@@ -2,7 +2,7 @@
 using System.Security.AccessControl;
 using System.Text;
 
-#if NETCOREAPP2_0
+#if NETCOREAPP2_0 || NETSTANDARD2_1
 using System.Threading.Tasks;
 using System.Threading;
 #endif
@@ -27,7 +27,7 @@ namespace System.IO.Abstractions
             File.AppendAllLines(path, contents, encoding);
         }
 
-#if NETCOREAPP2_0
+#if NETCOREAPP2_0 || NETSTANDARD2_1
         public override Task AppendAllLinesAsync(string path, IEnumerable<string> contents, CancellationToken cancellationToken)
         {
             return File.AppendAllLinesAsync(path, contents, cancellationToken);
@@ -49,7 +49,7 @@ namespace System.IO.Abstractions
             File.AppendAllText(path, contents, encoding);
         }
 
-#if NETCOREAPP2_0
+#if NETCOREAPP2_0 || NETSTANDARD2_1
         public override Task AppendAllTextAsync(string path, string contents, CancellationToken cancellationToken)
         {
             return File.AppendAllTextAsync(path, contents, cancellationToken);
@@ -224,7 +224,7 @@ namespace System.IO.Abstractions
             return File.ReadAllBytes(path);
         }
 
-#if NETCOREAPP2_0
+#if NETCOREAPP2_0 || NETSTANDARD2_1
         public override Task<byte[]> ReadAllBytesAsync(string path, CancellationToken cancellationToken)
         {
             return File.ReadAllBytesAsync(path, cancellationToken);
@@ -241,7 +241,7 @@ namespace System.IO.Abstractions
             return File.ReadAllLines(path, encoding);
         }
 
-#if NETCOREAPP2_0
+#if NETCOREAPP2_0 || NETSTANDARD2_1
         public override Task<string[]> ReadAllLinesAsync(string path, CancellationToken cancellationToken)
         {
             return File.ReadAllLinesAsync(path, cancellationToken);
@@ -263,7 +263,7 @@ namespace System.IO.Abstractions
             return File.ReadAllText(path, encoding);
         }
 
-#if NETCOREAPP2_0
+#if NETCOREAPP2_0 || NETSTANDARD2_1
         public override Task<string> ReadAllTextAsync(string path, CancellationToken cancellationToken)
         {
             return File.ReadAllTextAsync(path, cancellationToken);
@@ -371,7 +371,7 @@ namespace System.IO.Abstractions
             File.WriteAllBytes(path, bytes);
         }
 
-#if NETCOREAPP2_0
+#if NETCOREAPP2_0 || NETSTANDARD2_1
         public override Task WriteAllBytesAsync(string path, byte[] bytes, CancellationToken cancellationToken)
         {
             return File.WriteAllBytesAsync(path, bytes, cancellationToken);
@@ -545,7 +545,7 @@ namespace System.IO.Abstractions
             File.WriteAllLines(path, contents, encoding);
         }
 
-#if NETCOREAPP2_0
+#if NETCOREAPP2_0 || NETSTANDARD2_1
         public override Task WriteAllLinesAsync(string path, IEnumerable<string> contents, CancellationToken cancellationToken)
         {
             return File.WriteAllLinesAsync(path, contents, cancellationToken);
@@ -639,7 +639,7 @@ namespace System.IO.Abstractions
             File.WriteAllText(path, contents, encoding);
         }
 
-#if NETCOREAPP2_0
+#if NETCOREAPP2_0 || NETSTANDARD2_1
         public override Task WriteAllTextAsync(string path, string contents, CancellationToken cancellationToken)
         {
             return File.WriteAllTextAsync(path, contents, cancellationToken);

--- a/System.IO.Abstractions/IFile.cs
+++ b/System.IO.Abstractions/IFile.cs
@@ -2,7 +2,7 @@
 using System.Security.AccessControl;
 using System.Text;
 
-#if NETCOREAPP2_0
+#if NETCOREAPP2_0 || NETSTANDARD2_1
 using System.Threading.Tasks;
 using System.Threading;
 #endif
@@ -20,7 +20,7 @@ namespace System.IO.Abstractions
         void AppendAllLines(string path, IEnumerable<string> contents);
         /// <inheritdoc cref="File.AppendAllLines(string,IEnumerable{string},Encoding)"/>
         void AppendAllLines(string path, IEnumerable<string> contents, Encoding encoding);
-#if NETCOREAPP2_0
+#if NETCOREAPP2_0 || NETSTANDARD2_1
         /// <inheritdoc cref="File.AppendAllLinesAsync(string,IEnumerable{string},CancellationToken)"/>
         Task AppendAllLinesAsync(string path, IEnumerable<string> contents, CancellationToken cancellationToken = default(CancellationToken));
         /// <inheritdoc cref="File.AppendAllLinesAsync(string,IEnumerable{string},Encoding,CancellationToken)"/>
@@ -30,7 +30,7 @@ namespace System.IO.Abstractions
         void AppendAllText(string path, string contents);
         /// <inheritdoc cref="File.AppendAllText(string,string,Encoding)"/>
         void AppendAllText(string path, string contents, Encoding encoding);
-#if NETCOREAPP2_0
+#if NETCOREAPP2_0 || NETSTANDARD2_1
         /// <inheritdoc cref="File.AppendAllTextAsync(string,string,CancellationToken)"/>
         Task AppendAllTextAsync(String path, String contents, CancellationToken cancellationToken = default(CancellationToken));
         /// <inheritdoc cref="File.AppendAllTextAsync(string,string,Encoding,CancellationToken)"/>
@@ -100,7 +100,7 @@ namespace System.IO.Abstractions
         Stream OpenWrite(string path);
         /// <inheritdoc cref="File.ReadAllBytes"/>
         byte[] ReadAllBytes(string path);
-#if NETCOREAPP2_0
+#if NETCOREAPP2_0 || NETSTANDARD2_1
         /// <inheritdoc cref="File.ReadAllBytesAsync"/>
         Task<byte[]> ReadAllBytesAsync(string path, CancellationToken cancellationToken = default(CancellationToken));
 #endif
@@ -108,7 +108,7 @@ namespace System.IO.Abstractions
         string[] ReadAllLines(string path);
         /// <inheritdoc cref="File.ReadAllLines(string,Encoding)"/>
         string[] ReadAllLines(string path, Encoding encoding);
-#if NETCOREAPP2_0
+#if NETCOREAPP2_0 || NETSTANDARD2_1
         /// <inheritdoc cref="File.ReadAllLinesAsync(string,CancellationToken)"/>
         Task<string[]> ReadAllLinesAsync(string path, CancellationToken cancellationToken = default(CancellationToken));
         /// <inheritdoc cref="File.ReadAllLinesAsync(string,Encoding,CancellationToken)"/>
@@ -118,7 +118,7 @@ namespace System.IO.Abstractions
         string ReadAllText(string path);
         /// <inheritdoc cref="File.ReadAllText(string,Encoding)"/>
         string ReadAllText(string path, Encoding encoding);
-#if NETCOREAPP2_0
+#if NETCOREAPP2_0 || NETSTANDARD2_1
         ///<inheritdoc cref="File.ReadAllTextAsync(string,CancellationToken)"/>
         Task<string> ReadAllTextAsync(string path, CancellationToken cancellationToken = default(CancellationToken));
         ///<inheritdoc cref="File.ReadAllTextAsync(string,Encoding,CancellationToken)"/>
@@ -152,7 +152,7 @@ namespace System.IO.Abstractions
         void SetLastWriteTimeUtc(string path, DateTime lastWriteTimeUtc);
         /// <inheritdoc cref="File.WriteAllBytes"/>
         void WriteAllBytes(string path, byte[] bytes);
-#if NETCOREAPP2_0
+#if NETCOREAPP2_0 || NETSTANDARD2_1
         /// <inheritdoc cref="File.WriteAllBytesAsync"/>
         Task WriteAllBytesAsync(string path, byte[] bytes, CancellationToken cancellationToken = default(CancellationToken));
 #endif
@@ -164,7 +164,7 @@ namespace System.IO.Abstractions
         void WriteAllLines(string path, string[] contents);
         /// <inheritdoc cref="File.WriteAllLines(string,string[],Encoding)"/>
         void WriteAllLines(string path, string[] contents, Encoding encoding);
-#if NETCOREAPP2_0
+#if NETCOREAPP2_0 || NETSTANDARD2_1
         /// <inheritdoc cref="File.WriteAllLinesAsync(string,IEnumerable{string},CancellationToken)"/>
         Task WriteAllLinesAsync(string path, IEnumerable<string> contents, CancellationToken cancellationToken = default(CancellationToken));
         /// <inheritdoc cref="File.WriteAllLinesAsync(string,IEnumerable{string},Encoding,CancellationToken)"/>
@@ -178,7 +178,7 @@ namespace System.IO.Abstractions
         void WriteAllText(string path, string contents);
         /// <inheritdoc cref="File.WriteAllText(string,string,Encoding)"/>
         void WriteAllText(string path, string contents, Encoding encoding);
-#if NETCOREAPP2_0
+#if NETCOREAPP2_0 || NETSTANDARD2_1
         /// <inheritdoc cref="File.WriteAllTextAsync(string,string,CancellationToken)"/>
         Task WriteAllTextAsync(string path, string contents, CancellationToken cancellationToken = default(CancellationToken));
         /// <inheritdoc cref="File.WriteAllTextAsync(string,string,Encoding,CancellationToken)"/>

--- a/System.IO.Abstractions/IPath.cs
+++ b/System.IO.Abstractions/IPath.cs
@@ -25,21 +25,21 @@
         string Combine(string path1, string path2, string path3);
         /// <inheritdoc cref="Path.Combine(string,string,string,string)"/>
         string Combine(string path1, string path2, string path3, string path4);
-        /// <inheritdoc cref="Path.GetDirectoryName"/>
+        /// <inheritdoc cref="Path.GetDirectoryName(string)"/>
         string GetDirectoryName(string path);
-        /// <inheritdoc cref="Path.GetExtension"/>
+        /// <inheritdoc cref="Path.GetExtension(string)"/>
         string GetExtension(string path);
-        /// <inheritdoc cref="Path.GetFileName"/>
+        /// <inheritdoc cref="Path.GetFileName(string)"/>
         string GetFileName(string path);
-        /// <inheritdoc cref="Path.GetFileNameWithoutExtension"/>
+        /// <inheritdoc cref="Path.GetFileNameWithoutExtension(string)"/>
         string GetFileNameWithoutExtension(string path);
-        /// <inheritdoc cref="Path.GetFullPath"/>
+        /// <inheritdoc cref="Path.GetFullPath(string)"/>
         string GetFullPath(string path);
         /// <inheritdoc cref="Path.GetInvalidFileNameChars"/>
         char[] GetInvalidFileNameChars();
         /// <inheritdoc cref="Path.GetInvalidPathChars"/>
         char[] GetInvalidPathChars();
-        /// <inheritdoc cref="Path.GetPathRoot"/>
+        /// <inheritdoc cref="Path.GetPathRoot(string)"/>
         string GetPathRoot(string path);
         /// <inheritdoc cref="Path.GetRandomFileName"/>
         string GetRandomFileName();
@@ -47,9 +47,9 @@
         string GetTempFileName();
         /// <inheritdoc cref="Path.GetTempPath"/>
         string GetTempPath();
-        /// <inheritdoc cref="Path.HasExtension"/>
+        /// <inheritdoc cref="Path.HasExtension(string)"/>
         bool HasExtension(string path);
-        /// <inheritdoc cref="Path.IsPathRooted"/>
+        /// <inheritdoc cref="Path.IsPathRooted(string)"/>
         bool IsPathRooted(string path);
     }
 }

--- a/System.IO.Abstractions/PathBase.cs
+++ b/System.IO.Abstractions/PathBase.cs
@@ -50,19 +50,19 @@
         /// <inheritdoc cref="Path.Combine(string,string,string,string)"/>
         public abstract string Combine(string path1, string path2, string path3, string path4);
 
-        /// <inheritdoc cref="Path.GetDirectoryName"/>
+        /// <inheritdoc cref="Path.GetDirectoryName(string)"/>
         public abstract string GetDirectoryName(string path);
 
-        /// <inheritdoc cref="Path.GetExtension"/>
+        /// <inheritdoc cref="Path.GetExtension(string)"/>
         public abstract string GetExtension(string path);
 
-        /// <inheritdoc cref="Path.GetFileName"/>
+        /// <inheritdoc cref="Path.GetFileName(string)"/>
         public abstract string GetFileName(string path);
 
-        /// <inheritdoc cref="Path.GetFileNameWithoutExtension"/>
+        /// <inheritdoc cref="Path.GetFileNameWithoutExtension(string)"/>
         public abstract string GetFileNameWithoutExtension(string path);
 
-        /// <inheritdoc cref="Path.GetFullPath"/>
+        /// <inheritdoc cref="Path.GetFullPath(string)"/>
         public abstract string GetFullPath(string path);
 
         /// <inheritdoc cref="Path.GetInvalidFileNameChars"/>
@@ -71,7 +71,7 @@
         /// <inheritdoc cref="Path.GetInvalidPathChars"/>
         public abstract char[] GetInvalidPathChars();
 
-        /// <inheritdoc cref="Path.GetPathRoot"/>
+        /// <inheritdoc cref="Path.GetPathRoot(string)"/>
         public abstract string GetPathRoot(string path);
 
         /// <inheritdoc cref="Path.GetRandomFileName"/>
@@ -83,10 +83,10 @@
         /// <inheritdoc cref="Path.GetTempPath"/>
         public abstract string GetTempPath();
 
-        /// <inheritdoc cref="Path.HasExtension"/>
+        /// <inheritdoc cref="Path.HasExtension(string)"/>
         public abstract bool HasExtension(string path);
 
-        /// <inheritdoc cref="Path.IsPathRooted"/>
+        /// <inheritdoc cref="Path.IsPathRooted(string)"/>
         public abstract bool IsPathRooted(string path);
     }
 }

--- a/System.IO.Abstractions/System.IO.Abstractions.csproj
+++ b/System.IO.Abstractions/System.IO.Abstractions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard1.4;netstandard2.0;netcoreapp2.0</TargetFrameworks>
+        <TargetFrameworks>netstandard1.4;netstandard2.0;netcoreapp2.0;netstandard2.1</TargetFrameworks>
         <TargetFrameworks Condition="!$([MSBuild]::IsOsUnixLike())">$(TargetFrameworks);net40</TargetFrameworks>
         <Authors>Tatham Oddie</Authors>
         <Company />
@@ -23,7 +23,7 @@
         <SignAssembly>True</SignAssembly>
     </PropertyGroup>
 
-    <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'netcoreapp2.0'">
+    <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'netstandard2.1' Or '$(TargetFramework)' == 'netcoreapp2.0'">
         <PackageReference Include="System.IO.FileSystem.AccessControl">
             <Version>4.5.0</Version>
         </PackageReference>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 image: 
-- Visual Studio 2017
+- Visual Studio 2019 Preview
 - Ubuntu
 
 configuration: Release

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 image: 
-- Visual Studio 2019 Preview
+- Visual Studio 2019
 - Ubuntu
 
 configuration: Release

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "6.0",
+  "version": "7.0",
   "assemblyVersion": {
     "precision": "major"
   },


### PR DESCRIPTION
Solves #499, but to do that I added a new netstandard2.1 target. As an example, if you look here, you'll see these async methods were there since netcoreapp2.0 but only available starting with netstandard2.1: https://docs.microsoft.com/en-us/dotnet/api/system.io.file.readallbytesasync?view=netstandard-2.1

I'm not fully sure if this will magically work for the nuget releases, nor if the build server can actually build it (it needs the now-stable preview 8 of .net core 3), but if you want you can merge this after the official .net core 3 release!