### PR TITLE
fix(439): Pattern "*." returns only files with no extension

### DIFF
--- a/System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
@@ -228,33 +228,139 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
-        public void MockDirectory_GetFiles_ShouldFilterForFilesWithNoExtensionsAndSearchOptionTopDirectoryOnly()
+        public void MockDirectory_GetFiles_ShouldFilterForAllFilesWithNoExtensionsAndSearchOptionTopDirectoryOnly()
         {
             // Arrange
             var fileSystem = SetupFileSystem();
-            var expected = new[] { XFS.Path(@"c:\d") };
+            fileSystem.AddFile(XFS.Path(@"C:\mytestfilename"), new MockFileData("some content"));
+            fileSystem.AddFile(XFS.Path(@"C:\mytestfilename."), new MockFileData("some content"));
+            fileSystem.AddFile(XFS.Path(@"C:\mytestfile.name"), new MockFileData("some content"));
+            fileSystem.AddFile(XFS.Path(@"C:\mytestfile.name."), new MockFileData("some content"));
+            fileSystem.AddFile(XFS.Path(@"C:\mytestfile.name.again"), new MockFileData("some content"));
+            fileSystem.AddFile(XFS.Path(@"C:\mytestfile.name.again."), new MockFileData("some content"));
+
+            var expected = new[]
+            {
+                XFS.Path(@"C:\d"),
+                XFS.Path(@"C:\mytestfilename"),
+                XFS.Path(@"C:\mytestfilename."),
+                XFS.Path(@"C:\mytestfile.name."),
+                XFS.Path(@"C:\mytestfile.name.again.")
+            };
 
             // Act
-            var result = fileSystem.Directory.GetFiles(XFS.Path(@"c:\"), "*.", SearchOption.TopDirectoryOnly);
+            var result = fileSystem.Directory.GetFiles(XFS.Path(@"C:\"), "*.", SearchOption.TopDirectoryOnly);
 
             // Assert
             Assert.That(result, Is.EquivalentTo(expected));
         }
 
         [Test]
-        public void MockDirectory_GetFiles_ShouldFilterForFilesWithNoExtensionsAndSearchOptionAllDirectories()
+        public void MockDirectory_GetFiles_ShouldFilterForAllFilesWithNoExtensionsAndSearchOptionAllDirectories()
         {
             // Arrange
             var fileSystem = SetupFileSystem();
+            fileSystem.AddFile(XFS.Path(@"C:\specialNameFormats\mytestfilename"), new MockFileData("some content"));
+            fileSystem.AddFile(XFS.Path(@"C:\specialNameFormats\mytestfilename."), new MockFileData("some content"));
+            fileSystem.AddFile(XFS.Path(@"C:\specialNameFormats\mytestfile.name"), new MockFileData("some content"));
+            fileSystem.AddFile(XFS.Path(@"C:\specialNameFormats\mytestfile.name."), new MockFileData("some content"));
+            fileSystem.AddFile(XFS.Path(@"C:\specialNameFormats\mytestfile.name.again"), new MockFileData("some content"));
+            fileSystem.AddFile(XFS.Path(@"C:\specialNameFormats\mytestfile.name.again."), new MockFileData("some content"));
+
             var expected = new[]
             {
-                XFS.Path(@"c:\d"),
-                XFS.Path(@"c:\a\d"),
-                XFS.Path(@"c:\a\a\d")
+                XFS.Path(@"C:\d"),
+                XFS.Path(@"C:\a\d"),
+                XFS.Path(@"C:\a\a\d"),
+                XFS.Path(@"C:\specialNameFormats\mytestfilename"),
+                XFS.Path(@"C:\specialNameFormats\mytestfilename."),
+                XFS.Path(@"C:\specialNameFormats\mytestfile.name."),
+                XFS.Path(@"C:\specialNameFormats\mytestfile.name.again.")
             };
 
             // Act
             var result = fileSystem.Directory.GetFiles(XFS.Path(@"c:\"), "*.", SearchOption.AllDirectories);
+
+            // Assert
+            Assert.That(result, Is.EquivalentTo(expected));
+        }
+
+        [Test]
+        public void MockDirectory_GetFiles_ShouldFilterForFilesWithNoExtensionsAndNonTrivialFilterAndSearchOptionTopDirectoryOnly()
+        {
+            // Arrange
+            var fileSystem = SetupFileSystem();
+            fileSystem.AddFile(XFS.Path(@"C:\mytestfilename"), new MockFileData("some content"));
+            fileSystem.AddFile(XFS.Path(@"C:\mytestfilename."), new MockFileData("some content"));
+            fileSystem.AddFile(XFS.Path(@"C:\mytestfile.name"), new MockFileData("some content"));
+            fileSystem.AddFile(XFS.Path(@"C:\mytestfile.name."), new MockFileData("some content"));
+            fileSystem.AddFile(XFS.Path(@"C:\mytestfile.name.again"), new MockFileData("some content"));
+            fileSystem.AddFile(XFS.Path(@"C:\mytestfile.name.again."), new MockFileData("some content"));
+
+            var expected = new[]
+            {
+                XFS.Path(@"C:\mytestfilename"),
+                XFS.Path(@"C:\mytestfilename."),
+                XFS.Path(@"C:\mytestfile.name."),
+                XFS.Path(@"C:\mytestfile.name.again.")
+
+            };
+
+            // Act
+            var result = fileSystem.Directory.GetFiles(XFS.Path(@"C:\"), "my??s*.", SearchOption.TopDirectoryOnly);
+
+            // Assert
+            Assert.That(result, Is.EquivalentTo(expected));
+        }
+
+        [Test]
+        public void MockDirectory_GetFiles_ShouldFilterForFilesWithNoExtensionsAndNonTrivialFilter2AndSearchOptionTopDirectoryOnly()
+        {
+            // Arrange
+            var fileSystem = SetupFileSystem();
+            fileSystem.AddFile(XFS.Path(@"C:\mytestfilename"), new MockFileData("some content"));
+            fileSystem.AddFile(XFS.Path(@"C:\mytestfilename."), new MockFileData("some content"));
+            fileSystem.AddFile(XFS.Path(@"C:\mytestfile.name"), new MockFileData("some content"));
+            fileSystem.AddFile(XFS.Path(@"C:\mytestfile.name."), new MockFileData("some content"));
+            fileSystem.AddFile(XFS.Path(@"C:\mytestfile.name.again"), new MockFileData("some content"));
+            fileSystem.AddFile(XFS.Path(@"C:\mytestfile.name.again."), new MockFileData("some content"));
+
+            var expected = new[]
+            {
+                XFS.Path(@"C:\mytestfile.name"),
+                XFS.Path(@"C:\mytestfile.name."),
+                XFS.Path(@"C:\mytestfile.name.again.")
+
+            };
+
+            // Act
+            var result = fileSystem.Directory.GetFiles(XFS.Path(@"C:\"), "my*.n*.", SearchOption.TopDirectoryOnly);
+
+            // Assert
+            Assert.That(result, Is.EquivalentTo(expected));
+        }
+
+        [Test]
+        public void MockDirectory_GetFiles_ShouldFilterForFilesWithNoExtensionsAndFilterThatIncludesDotAndSearchOptionTopDirectoryOnly()
+        {
+            // Arrange
+            var fileSystem = SetupFileSystem();
+            fileSystem.AddFile(XFS.Path(@"C:\mytestfilename"), new MockFileData("some content"));
+            fileSystem.AddFile(XFS.Path(@"C:\mytestfilename."), new MockFileData("some content"));
+            fileSystem.AddFile(XFS.Path(@"C:\mytestfile.name"), new MockFileData("some content"));
+            fileSystem.AddFile(XFS.Path(@"C:\mytestfile.name."), new MockFileData("some content"));
+            fileSystem.AddFile(XFS.Path(@"C:\mytestfile.name.again"), new MockFileData("some content"));
+            fileSystem.AddFile(XFS.Path(@"C:\mytestfile.name.again."), new MockFileData("some content"));
+
+            var expected = new[]
+            {
+                XFS.Path(@"C:\mytestfile.name"),
+                XFS.Path(@"C:\mytestfile.name."),
+                XFS.Path(@"C:\mytestfile.name.again.")
+            };
+
+            // Act
+            var result = fileSystem.Directory.GetFiles(XFS.Path(@"C:\"), "my*.n*.", SearchOption.TopDirectoryOnly);
 
             // Assert
             Assert.That(result, Is.EquivalentTo(expected));

--- a/System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
@@ -20,9 +20,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 XFS.Path(@"c:\a\a.txt"),
                 XFS.Path(@"c:\a\b.gif"),
                 XFS.Path(@"c:\a\c.txt"),
+                XFS.Path(@"c:\a\d"),
                 XFS.Path(@"c:\a\a\a.txt"),
                 XFS.Path(@"c:\a\a\b.txt"),
-                XFS.Path(@"c:\a\a\c.gif")
+                XFS.Path(@"c:\a\a\c.gif"),
+                XFS.Path(@"c:\a\a\d")
             };
 
             // Act
@@ -43,6 +45,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 { XFS.Path(@"c:\a\a.txt"), new MockFileData("Demo text content") },
                 { XFS.Path(@"c:\a\b.gif"), new MockFileData("Demo text content") },
                 { XFS.Path(@"c:\a\c.txt"), new MockFileData("Demo text content") },
+                { XFS.Path(@"c:\a\d"), new MockFileData("Demo text content") },
                 { XFS.Path(@"c:\a\a\a.txt"), new MockFileData("Demo text content") },
                 { XFS.Path(@"c:\a\a\b.txt"), new MockFileData("Demo text content") },
                 { XFS.Path(@"c:\a\a\c.gif"), new MockFileData("Demo text content") },
@@ -60,7 +63,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             {
                 XFS.Path(@"c:\a\a.txt"),
                 XFS.Path(@"c:\a\b.gif"),
-                XFS.Path(@"c:\a\c.txt")
+                XFS.Path(@"c:\a\c.txt"),
+                XFS.Path(@"c:\a\d")
             };
 
             // Act
@@ -245,6 +249,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var expected = new[]
             {
                 XFS.Path(@"c:\d"),
+                XFS.Path(@"c:\a\d"),
                 XFS.Path(@"c:\a\a\d")
             };
 
@@ -1531,9 +1536,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 XFS.Path(@"c:\a\a.txt"),
                 XFS.Path(@"c:\a\b.gif"),
                 XFS.Path(@"c:\a\c.txt"),
+                XFS.Path(@"c:\a\d"),
                 XFS.Path(@"c:\a\a\a.txt"),
                 XFS.Path(@"c:\a\a\b.txt"),
-                XFS.Path(@"c:\a\a\c.gif")
+                XFS.Path(@"c:\a\a\c.gif"),
+                XFS.Path(@"c:\a\a\d")
             };
 
             // Act
@@ -1623,9 +1630,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 XFS.Path(@"c:\a\a.txt"),
                 XFS.Path(@"c:\a\b.gif"),
                 XFS.Path(@"c:\a\c.txt"),
+                XFS.Path(@"c:\a\d"),
                 XFS.Path(@"c:\a\a\a.txt"),
                 XFS.Path(@"c:\a\a\b.txt"),
                 XFS.Path(@"c:\a\a\c.gif"),
+                XFS.Path(@"c:\a\a\d"),
                 XFS.Path(@"c:\a\a")
             };
 

--- a/System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
@@ -241,7 +241,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var expected = new[]
             {
-                XFS.Path(@"C:\d"),
+                XFS.Path(@"c:\d"),
                 XFS.Path(@"C:\mytestfilename"),
                 XFS.Path(@"C:\mytestfilename."),
                 XFS.Path(@"C:\mytestfile.name."),
@@ -269,9 +269,9 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var expected = new[]
             {
-                XFS.Path(@"C:\d"),
-                XFS.Path(@"C:\a\d"),
-                XFS.Path(@"C:\a\a\d"),
+                XFS.Path(@"c:\d"),
+                XFS.Path(@"c:\a\d"),
+                XFS.Path(@"c:\a\a\d"),
                 XFS.Path(@"C:\specialNameFormats\mytestfilename"),
                 XFS.Path(@"C:\specialNameFormats\mytestfilename."),
                 XFS.Path(@"C:\specialNameFormats\mytestfile.name."),

--- a/System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
@@ -39,12 +39,14 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 { XFS.Path(@"c:\a.gif"), new MockFileData("Demo text content") },
                 { XFS.Path(@"c:\b.txt"), new MockFileData("Demo text content") },
                 { XFS.Path(@"c:\c.txt"), new MockFileData("Demo text content") },
+                { XFS.Path(@"c:\d"), new MockFileData("Demo text content") },
                 { XFS.Path(@"c:\a\a.txt"), new MockFileData("Demo text content") },
                 { XFS.Path(@"c:\a\b.gif"), new MockFileData("Demo text content") },
                 { XFS.Path(@"c:\a\c.txt"), new MockFileData("Demo text content") },
                 { XFS.Path(@"c:\a\a\a.txt"), new MockFileData("Demo text content") },
                 { XFS.Path(@"c:\a\a\b.txt"), new MockFileData("Demo text content") },
                 { XFS.Path(@"c:\a\a\c.gif"), new MockFileData("Demo text content") },
+                { XFS.Path(@"c:\a\a\d"), new MockFileData("Demo text content") }
             });
 
         }
@@ -216,6 +218,38 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             // Act
             var result = fileSystem.Directory.GetFiles(XFS.Path(@"c:\"), "*.gif", SearchOption.TopDirectoryOnly);
+
+            // Assert
+            Assert.That(result, Is.EquivalentTo(expected));
+        }
+
+        [Test]
+        public void MockDirectory_GetFiles_ShouldFilterForFilesWithNoExtensionsAndSearchOptionTopDirectoryOnly()
+        {
+            // Arrange
+            var fileSystem = SetupFileSystem();
+            var expected = new[] { XFS.Path(@"c:\d") };
+
+            // Act
+            var result = fileSystem.Directory.GetFiles(XFS.Path(@"c:\"), "*.", SearchOption.TopDirectoryOnly);
+
+            // Assert
+            Assert.That(result, Is.EquivalentTo(expected));
+        }
+
+        [Test]
+        public void MockDirectory_GetFiles_ShouldFilterForFilesWithNoExtensionsAndSearchOptionAllDirectories()
+        {
+            // Arrange
+            var fileSystem = SetupFileSystem();
+            var expected = new[]
+            {
+                XFS.Path(@"c:\d"),
+                XFS.Path(@"c:\a\a\d")
+            };
+
+            // Act
+            var result = fileSystem.Directory.GetFiles(XFS.Path(@"c:\"), "*.", SearchOption.AllDirectories);
 
             // Assert
             Assert.That(result, Is.EquivalentTo(expected));
@@ -1215,7 +1249,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         {
             string sourceFilePath = XFS.Path(@"c:\demo.txt");
             string sourceFileContent = "this is some content";
-            
+
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
             {
                 { sourceFilePath, new MockFileData(sourceFileContent) }

--- a/System.IO.Abstractions.TestingHelpers/MockDirectory.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockDirectory.cs
@@ -237,6 +237,10 @@ namespace System.IO.Abstractions.TestingHelpers
             {
                 fileNamePattern = isUnix ? @"[^/]*?/?" : @"[^\\]*?\\?";
             }
+            else if (searchPattern == "*.")
+            {
+                fileNamePattern = isUnix ? @"[^/.]*?/?" : @"[^\\.]*?\\?";
+            }
             else
             {
                 fileNamePattern = Regex.Escape(searchPattern)


### PR DESCRIPTION
Add special case to Directory.GetFilesInternal to return only files without extensions when search pattern is "*."
This fixes bug #439 