### PR TITLE
Enable File.Replace for all but netstandard1.4

### DIFF
--- a/System.IO.Abstractions.TestingHelpers.Tests/MockFileTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockFileTests.cs
@@ -610,7 +610,6 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 #endif
 
-#if NET40
         [Test]
         public void MockFile_Replace_ShouldReplaceFileContents()
         {
@@ -683,6 +682,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             Assert.Throws<FileNotFoundException>(() => fileSystem.File.Replace(path1, path2, null));
         }
 
+#if NET40
         [Test]
         public void MockFile_OpenRead_ShouldReturnReadOnlyStream()
         {

--- a/System.IO.Abstractions.TestingHelpers/MockFile.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockFile.cs
@@ -597,7 +597,7 @@ namespace System.IO.Abstractions.TestingHelpers
             return ReadAllLines(path, encoding);
         }
 
-#if NET40
+#if !NETSTANDARD1_4
         public override void Replace(string sourceFileName, string destinationFileName, string destinationBackupFileName)
         {
             Replace(sourceFileName, destinationFileName, destinationBackupFileName, false);

--- a/System.IO.Abstractions/FileBase.cs
+++ b/System.IO.Abstractions/FileBase.cs
@@ -347,7 +347,7 @@ namespace System.IO.Abstractions
         /// <inheritdoc cref="File.ReadLines(string,Encoding)"/>
         public abstract IEnumerable<string> ReadLines(string path, Encoding encoding);
 
-#if NET40
+#if !NETSTANDARD1_4
         /// <inheritdoc cref="File.Replace(string,string,string)"/>
         public abstract void Replace(string sourceFileName, string destinationFileName, string destinationBackupFileName);
 
@@ -657,11 +657,11 @@ namespace System.IO.Abstractions
         /// The file handle is guaranteed to be closed by this method, even if exceptions are raised.
         /// </remarks>
         public abstract void WriteAllText(string path, string contents, Encoding encoding);
-        
+
 #if NETCOREAPP2_0 || NETSTANDARD2_1
         /// <inheritdoc cref="File.WriteAllTextAsync(string,string,CancellationToken)"/>
         public abstract Task WriteAllTextAsync(string path, string contents, CancellationToken cancellationToken);
-        
+
         /// <inheritdoc cref="File.WriteAllTextAsync(string,string,Encoding,CancellationToken)"/>
         public abstract Task WriteAllTextAsync(string path, string contents, Encoding encoding, CancellationToken cancellationToken);
 #endif

--- a/System.IO.Abstractions/FileWrapper.cs
+++ b/System.IO.Abstractions/FileWrapper.cs
@@ -285,7 +285,7 @@ namespace System.IO.Abstractions
             return File.ReadLines(path, encoding);
         }
 
-#if NET40
+#if !NETSTANDARD1_4
         public override void Replace(string sourceFileName, string destinationFileName, string destinationBackupFileName)
         {
             File.Replace(sourceFileName, destinationFileName, destinationBackupFileName);

--- a/System.IO.Abstractions/IFile.cs
+++ b/System.IO.Abstractions/IFile.cs
@@ -128,7 +128,7 @@ namespace System.IO.Abstractions
         IEnumerable<string> ReadLines(string path);
         /// <inheritdoc cref="File.ReadLines(string,Encoding)"/>
         IEnumerable<string> ReadLines(string path, Encoding encoding);
-#if NET40
+#if !NETSTANDARD1_4
         /// <inheritdoc cref="File.Replace(string,string,string)"/>
         void Replace(string sourceFileName, string destinationFileName, string destinationBackupFileName);
         /// <inheritdoc cref="File.Replace(string,string,string,bool)"/>

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "7.0",
+  "version": "7.1",
   "assemblyVersion": {
     "precision": "major"
   },


### PR DESCRIPTION
According to [the documentation](https://docs.microsoft.com/en-us/dotnet/api/system.io.file.replace?f1url=https%3A%2F%2Fmsdn.microsoft.com%2Fquery%2Fdev16.query%3FappId%3DDev16IDEF1%26l%3DEN-US%26k%3Dk%2520System.IO.File.Replace%2520%253Bk%2520DevLang-csharp%2520%26rd%3Dtrue%230877433039133023292&view=netcore-2.0#applies-to), File.Replace is a part of .NET Standard 2.0 and supported by Core 2.0 and later.

Related to #334 but does not attempt to address all methods that might be supported by .NET Standard/Core 2.0 and later.

This also enables the File.Replace unit tests in the same way. The tests pass on Windows 10 and Ubuntu on Windows.