### PR TITLE
Add validation for illegal characters when creating MockDirectory

### DIFF
--- a/System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
@@ -637,6 +637,22 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             Assert.IsTrue(fileSystem.AllDirectories.Any(d => d == XFS.Path(@"c:\bar")));
         }
 
+        [Test]
+        public void MockDirectory_CreateDirectory_ShouldThrowIfIllegalCharacterInPath()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\foo.txt"), new MockFileData("Demo text content") }
+            });
+
+            // Act
+            TestDelegate createDelegate = () => fileSystem.Directory.CreateDirectory(XFS.Path(@"c:\bar_?_"));
+
+            // Assert
+            Assert.Throws<ArgumentException>(createDelegate);
+        }
+
         // Issue #210
         [Test]
         public void MockDirectory_CreateDirectory_ShouldIgnoreExistingDirectoryRegardlessOfTrailingSlash()

--- a/System.IO.Abstractions.TestingHelpers/MockDirectory.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockDirectory.cs
@@ -47,6 +47,11 @@ namespace System.IO.Abstractions.TestingHelpers
                 throw new ArgumentException(StringResources.Manager.GetString("PATH_CANNOT_BE_THE_EMPTY_STRING_OR_ALL_WHITESPACE"), "path");
             }
 
+            if (mockFileDataAccessor.PathVerifier.HasIllegalCharacters(path, true))
+            {
+                throw CommonExceptions.IllegalCharactersInPath(nameof(path));
+            }
+
             path = mockFileDataAccessor.Path.GetFullPath(path).TrimSlashes();
             if (XFS.IsWindowsPlatform())
             {


### PR DESCRIPTION
This fixes #546 

MockFileSystem did not check for illegal characters such as '_' and '?' when creating a directory and instead `CreateDirectory` just returned `null`.

We now check for illegal characters with `PathVerifier.HasIllegalCharacters()` and throw `CommonExceptions.IllegalCharactersInPath` accordingly.