### PR TITLE
Add back a .NET Framework target

### DIFF
--- a/System.IO.Abstractions.TestingHelpers.Tests/System.IO.Abstractions.TestingHelpers.Tests.csproj
+++ b/System.IO.Abstractions.TestingHelpers.Tests/System.IO.Abstractions.TestingHelpers.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
-    <TargetFrameworks Condition="!$([MSBuild]::IsOsUnixLike())">$(TargetFrameworks);net472</TargetFrameworks>
+    <TargetFrameworks Condition="!$([MSBuild]::IsOsUnixLike())">$(TargetFrameworks);net461</TargetFrameworks>
     <Description>The unit tests for our pre-built mocks</Description>
     <AssemblyName>System.IO.Abstractions.TestingHelpers.Tests</AssemblyName>
     <RootNamespace>System.IO.Abstractions.TestingHelpers.Tests</RootNamespace>

--- a/System.IO.Abstractions.TestingHelpers/System.IO.Abstractions.TestingHelpers.csproj
+++ b/System.IO.Abstractions.TestingHelpers/System.IO.Abstractions.TestingHelpers.csproj
@@ -3,7 +3,7 @@
         <AssemblyName>System.IO.Abstractions.TestingHelpers</AssemblyName>
         <RootNamespace>System.IO.Abstractions.TestingHelpers</RootNamespace>
         <Description>A set of pre-built mocks to help when testing file system interactions.</Description>
-        <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;netstandard2.1;net461</TargetFrameworks>
         <PackageProjectUrl>https://github.com/System-IO-Abstractions/System.IO.Abstractions</PackageProjectUrl>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageTags>testing</PackageTags>
@@ -11,5 +11,11 @@
     </PropertyGroup>
     <ItemGroup>
         <ProjectReference Include="..\System.IO.Abstractions\System.IO.Abstractions.csproj" />
+    </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net461" Version="1.0.0">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+        </PackageReference>
     </ItemGroup>
 </Project>

--- a/System.IO.Abstractions/System.IO.Abstractions.csproj
+++ b/System.IO.Abstractions/System.IO.Abstractions.csproj
@@ -3,13 +3,19 @@
     <AssemblyName>System.IO.Abstractions</AssemblyName>
     <RootNamespace>System.IO.Abstractions</RootNamespace>
     <Description>A set of abstractions to help make file system interactions testable.</Description>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net461</TargetFrameworks>
     <PackageProjectUrl>https://github.com/System-IO-Abstractions/System.IO.Abstractions</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageTags>testing</PackageTags>
     <DefineConstants Condition="'$(TargetFramework)' == 'netstandard2.1'">$(DefineConstants);FEATURE_ASYNC_FILE;FEATURE_ENUMERATION_OPTIONS</DefineConstants>
   </PropertyGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' != 'net461'">
     <PackageReference Include="System.IO.FileSystem.AccessControl" Version="4.7.0"/>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net461" Version="1.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 </Project>

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "8.0",
+  "version": "8.1",
   "assemblyVersion": {
     "precision": "major"
   },


### PR DESCRIPTION
This changes adds a target for .NET Framework 4.6.1 so that we can get
rid of the System.IO.FileSystem.AccessControl reference which causes
problems for certain .NET Framework consumption patterns

Fixes #547