### PR TITLE
Reset MockFileStream position after flushing

### DIFF
--- a/System.IO.Abstractions.TestingHelpers.Tests/MockFileStreamTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockFileStreamTests.cs
@@ -164,5 +164,25 @@
             // Assert
             Assert.Throws<ObjectDisposedException>(() => stream.WriteByte(0));
         }
+
+        [Test]
+        public void MockFileStream_Flush_ShouldNotChangePosition()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            var path = XFS.Path("C:\\test");
+            fileSystem.AddFile(path, new MockFileData(new byte[0]));
+
+            using (var stream = fileSystem.FileInfo.FromFileName(path).OpenWrite())
+            {
+                // Act
+                stream.Write(new byte[400], 0, 400);
+                stream.Seek(200, SeekOrigin.Begin);
+                stream.Flush();
+
+                // Assert
+                Assert.AreEqual(200, stream.Position);
+            }
+        }
     }
 }

--- a/System.IO.Abstractions.TestingHelpers/MockFileStream.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockFileStream.cs
@@ -94,10 +94,13 @@
             {
                 var mockFileData = mockFileDataAccessor.GetFile(path);
                 /* reset back to the beginning .. */
+                var position = Position;
                 Seek(0, SeekOrigin.Begin);
                 /* .. read everything out */
                 var data = new byte[Length];
                 Read(data, 0, (int)Length);
+                /* restore to original position */
+                Seek(position, SeekOrigin.Begin);
                 /* .. put it in the mock system */
                 mockFileData.Contents = data;
             }


### PR DESCRIPTION
Resets the internal Stream position to the original position after reading the file's data to the `data` array.

Fixes #519 