### PR TITLE
Copy metadata when a MockFile is moved

### DIFF
--- a/System.IO.Abstractions.TestingHelpers.Tests/MockFileMoveTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockFileMoveTests.cs
@@ -362,5 +362,24 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             Assert.Throws<FileNotFoundException>(action);
         }
+
+        [Test]
+        public void MockFile_Move_ShouldRetainMetadata()
+        {
+            string sourceFilePath = XFS.Path(@"c:\something\demo.txt");
+            string sourceFileContent = "this is some content";
+            DateTimeOffset creationTime = DateTimeOffset.Now;
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                {sourceFilePath, new MockFileData(sourceFileContent){CreationTime = creationTime}},
+                {XFS.Path(@"c:\somethingelse\dummy.txt"), new MockFileData(new byte[] {0})}
+            });
+
+            string destFilePath = XFS.Path(@"c:\somethingelse\demo1.txt");
+
+            fileSystem.File.Move(sourceFilePath, destFilePath);
+
+            Assert.That(fileSystem.File.GetCreationTimeUtc(@"c:\somethingelse\demo1.txt"), Is.EqualTo(creationTime.UtcDateTime));
+        }
     }
 }

--- a/System.IO.Abstractions.TestingHelpers.Tests/MockFileMoveTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockFileMoveTests.cs
@@ -379,7 +379,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             fileSystem.File.Move(sourceFilePath, destFilePath);
 
-            Assert.That(fileSystem.File.GetCreationTimeUtc(@"c:\somethingelse\demo1.txt"), Is.EqualTo(creationTime.UtcDateTime));
+            Assert.That(fileSystem.File.GetCreationTimeUtc(destFilePath), Is.EqualTo(creationTime.UtcDateTime));
         }
     }
 }

--- a/System.IO.Abstractions.TestingHelpers/MockFile.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockFile.cs
@@ -360,7 +360,7 @@ namespace System.IO.Abstractions.TestingHelpers
             }
             VerifyDirectoryExists(destFileName);
 
-            mockFileDataAccessor.AddFile(destFileName, new MockFileData(sourceFile.Contents));
+            mockFileDataAccessor.AddFile(destFileName, new MockFileData(sourceFile));
             mockFileDataAccessor.RemoveFile(sourceFileName);
         }
 


### PR DESCRIPTION
Instead of copying only the data array, use the constructor that clones the `MockFile` properties, too.

Fixes #557 