### PR TITLE
Support the FileStream constructor with FileOptions

### DIFF
--- a/System.IO.Abstractions/IFileStreamFactory.cs
+++ b/System.IO.Abstractions/IFileStreamFactory.cs
@@ -13,6 +13,8 @@ namespace System.IO.Abstractions
 
         Stream Create(string path, FileMode mode, FileAccess access, FileShare share, int bufferSize);
 
+        Stream Create(string path, FileMode mode, FileAccess access, FileShare share, int bufferSize, FileOptions options);
+
         Stream Create(string path, FileMode mode, FileAccess access, FileShare share, int bufferSize, bool useAsync);
 
         Stream Create(SafeFileHandle handle, FileAccess access);

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "9.0",
+  "version": "10.0",
   "assemblyVersion": {
     "precision": "major"
   },


### PR DESCRIPTION
Support the FileStream constructor with FileOptions parameter, which is present in implementations, but not in the IFileStreamFactory.