### PR TITLE
Fixes #568: MockFile.Copy does not honor AccessFileShare on MockFileData

### DIFF
--- a/System.IO.Abstractions.TestingHelpers.Tests/MockFileCopyTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockFileCopyTests.cs
@@ -381,5 +381,24 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             Assert.That(fileSystem.File.Exists(destinationFile));
         }
+
+        [Test]
+        public void MockFile_Copy_ShouldThrowIOExceptionForInvalidFileShare()
+        {
+            string sourceFileName = XFS.Path(@"c:\source\demo.txt");
+            var sourceContents = new MockFileData("Source content")
+            {
+                AllowedFileShare = FileShare.None
+            };
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                {sourceFileName, sourceContents}
+            });
+            fileSystem.AddDirectory(XFS.Path(@"c:\something"));
+
+            TestDelegate action = () => fileSystem.File.Copy(sourceFileName, XFS.Path(@"c:\something\demo.txt"));
+
+            Assert.Throws<IOException>(action);
+        }
     }
 }

--- a/System.IO.Abstractions.TestingHelpers/MockFile.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockFile.cs
@@ -122,6 +122,7 @@ namespace System.IO.Abstractions.TestingHelpers
             }
 
             var sourceFileData = mockFileDataAccessor.GetFile(sourceFileName);
+            sourceFileData.CheckFileAccess(sourceFileName, FileAccess.Read);
             mockFileDataAccessor.AddFile(destFileName, new MockFileData(sourceFileData));
         }
 


### PR DESCRIPTION
- add `CheckFileAccess` on `MockFile.Copy`, so `IOException` is correctly thrown if Read access is not granted.
- added missing coverage on MockFile.Move related to `AccessFileShare`