### PR TITLE
Fixes #532: throw IOException: File already exists, if the file already exists when creating a FileSystem with FileMode.CreateNew

### DIFF
--- a/System.IO.Abstractions.TestingHelpers.Tests/MockFileStreamFactoryTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockFileStreamFactoryTests.cs
@@ -47,8 +47,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
         [Test]
         [TestCase(FileMode.Create)]
-        [TestCase(FileMode.CreateNew)]
-        public void MockFileStreamFactory_CreateForAnExistingFile_ShouldTruncateExistingFile(FileMode fileMode)
+        public void MockFileStreamFactory_CreateForAnExistingFile_ShouldReplaceFileContents(FileMode fileMode)
         {
             var fileSystem = new MockFileSystem();
             string FilePath = XFS.Path("C:\\File.txt");
@@ -82,7 +81,23 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var fileStreamFactory = new MockFileStreamFactory(fileSystem);
 
             // Assert
-            Assert.Throws<DirectoryNotFoundException>(() => fileStreamFactory.Create(@"C:\Test\NonExistingDirectory\some_random_file.txt", fileMode));
+            Assert.Throws<DirectoryNotFoundException>(() => fileStreamFactory.Create(XFS.Path(@"C:\Test\NonExistingDirectory\some_random_file.txt"), fileMode));
+        }
+
+        [Test]
+        [TestCase(FileMode.CreateNew)]
+        public void MockFileStreamFactory_CreateExistingFile_Should_Throw_IOException(FileMode fileMode)
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddFile(XFS.Path(@"C:\Test\some_random_file.txt"), MockFileData.NullObject);
+
+            // Act
+            var fileStreamFactory = new MockFileStreamFactory(fileSystem);
+
+            // Assert
+            Assert.Throws<IOException>(() => fileStreamFactory.Create(XFS.Path(@"C:\Test\some_random_file.txt"), fileMode));
+
         }
     }
 }

--- a/System.IO.Abstractions.TestingHelpers.Tests/MockFileStreamFactoryTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockFileStreamFactoryTests.cs
@@ -71,6 +71,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         [Test]
         [TestCase(FileMode.Create)]
         [TestCase(FileMode.Open)]
+        [TestCase(FileMode.CreateNew)]
+        [TestCase(FileMode.Append)]
         public void MockFileStreamFactory_CreateInNonExistingDirectory_ShouldThrowDirectoryNotFoundException(FileMode fileMode)
         {
             // Arrange

--- a/System.IO.Abstractions.TestingHelpers.Tests/MockFileStreamFactoryTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockFileStreamFactoryTests.cs
@@ -85,6 +85,22 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
+        [TestCase(FileMode.Open)]
+        [TestCase(FileMode.Truncate)]
+        public void MockFileStreamFactory_OpenNonExistingFile_ShouldThrowFileNotFoundException(FileMode fileMode)
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddDirectory(XFS.Path(@"C:\Test"));
+
+            // Act
+            var fileStreamFactory = new MockFileStreamFactory(fileSystem);
+
+            // Assert
+            Assert.Throws<FileNotFoundException>(() => fileStreamFactory.Create(XFS.Path(@"C:\Test\some_random_file.txt"), fileMode));
+        }
+
+        [Test]
         [TestCase(FileMode.CreateNew)]
         public void MockFileStreamFactory_CreateExistingFile_Should_Throw_IOException(FileMode fileMode)
         {

--- a/System.IO.Abstractions.TestingHelpers/CommonExceptions.cs
+++ b/System.IO.Abstractions.TestingHelpers/CommonExceptions.cs
@@ -61,5 +61,8 @@ namespace System.IO.Abstractions.TestingHelpers
             paramName != null
             ? new IOException(string.Format(StringResources.Manager.GetString("PROCESS_CANNOT_ACCESS_FILE_IN_USE_WITH_FILENAME"), paramName), _fileLockHResult)
             : new IOException(StringResources.Manager.GetString("PROCESS_CANNOT_ACCESS_FILE_IN_USE"), _fileLockHResult);
+
+        public static IOException FileAlreadyExists(string paramName) =>
+            new IOException(string.Format(StringResources.Manager.GetString("FILE_ALREADY_EXISTS"), paramName));
     }
 }

--- a/System.IO.Abstractions.TestingHelpers/MockFile.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockFile.cs
@@ -417,7 +417,7 @@ namespace System.IO.Abstractions.TestingHelpers
             else if (mode == FileMode.Append)
                 streamType = MockFileStream.StreamType.APPEND;
 
-            return new MockFileStream(mockFileDataAccessor, path, streamType, options);
+            return new MockFileStream(mockFileDataAccessor, path, streamType, options, mode);
         }
 
         public override Stream OpenRead(string path)

--- a/System.IO.Abstractions.TestingHelpers/MockFileStream.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockFileStream.cs
@@ -73,7 +73,9 @@
                     throw CommonExceptions.CouldNotFindPartOfPath(path);
                 }
 
-                if (StreamType.READ.Equals(streamType))
+                if (StreamType.READ.Equals(streamType)
+                    || fileMode.Equals(FileMode.Open)
+                    || fileMode.Equals(FileMode.Truncate))
                 {
                     throw CommonExceptions.FileNotFound(path);
                 }

--- a/System.IO.Abstractions.TestingHelpers/MockFileStream.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockFileStream.cs
@@ -21,8 +21,17 @@
         public MockFileStream(
             IMockFileDataAccessor mockFileDataAccessor,
             string path,
+            StreamType streamType,
+            FileMode fileMode)
+            : this(mockFileDataAccessor, path, streamType, FileOptions.None, fileMode)
+        {
+        }
+
+        public MockFileStream(
+            IMockFileDataAccessor mockFileDataAccessor,
+            string path,
             StreamType streamType)
-            : this(mockFileDataAccessor, path, streamType, FileOptions.None)
+            : this(mockFileDataAccessor, path, streamType, FileOptions.None, FileMode.Append)
         {
         }
 
@@ -30,7 +39,8 @@
             IMockFileDataAccessor mockFileDataAccessor,
             string path,
             StreamType streamType,
-            FileOptions options)
+            FileOptions options,
+            FileMode fileMode = FileMode.Append)
         {
             this.mockFileDataAccessor = mockFileDataAccessor ?? throw new ArgumentNullException(nameof(mockFileDataAccessor));
             this.path = path;
@@ -38,6 +48,11 @@
 
             if (mockFileDataAccessor.FileExists(path))
             {
+                if (fileMode.Equals(FileMode.CreateNew))
+                {
+                    throw CommonExceptions.FileAlreadyExists(path);
+                }
+
                 var fileData = mockFileDataAccessor.GetFile(path);
                 fileData.CheckFileAccess(path, streamType != StreamType.READ ? FileAccess.Write : FileAccess.Read);
 

--- a/System.IO.Abstractions.TestingHelpers/MockFileStreamFactory.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockFileStreamFactory.cs
@@ -12,28 +12,28 @@ namespace System.IO.Abstractions.TestingHelpers
             => this.mockFileSystem = mockFileSystem ?? throw new ArgumentNullException(nameof(mockFileSystem));
 
         public Stream Create(string path, FileMode mode)
-            => new MockFileStream(mockFileSystem, path, GetStreamType(mode));
+            => new MockFileStream(mockFileSystem, path, GetStreamType(mode), mode);
 
         public Stream Create(string path, FileMode mode, FileAccess access)
-            => new MockFileStream(mockFileSystem, path, GetStreamType(mode, access));
+            => new MockFileStream(mockFileSystem, path, GetStreamType(mode, access), mode);
 
         public Stream Create(string path, FileMode mode, FileAccess access, FileShare share)
-            => new MockFileStream(mockFileSystem, path, GetStreamType(mode, access));
+            => new MockFileStream(mockFileSystem, path, GetStreamType(mode, access), mode);
 
         public Stream Create(string path, FileMode mode, FileAccess access, FileShare share, int bufferSize)
-            => new MockFileStream(mockFileSystem, path, GetStreamType(mode, access));
+            => new MockFileStream(mockFileSystem, path, GetStreamType(mode, access), mode);
 
         public Stream Create(string path, FileMode mode, FileAccess access, FileShare share, int bufferSize, FileOptions options)
-            => new MockFileStream(mockFileSystem, path, GetStreamType(mode, access), options);
+            => new MockFileStream(mockFileSystem, path, GetStreamType(mode, access), options, mode);
 
         public Stream Create(string path, FileMode mode, FileAccess access, FileShare share, int bufferSize, bool useAsync)
-            => new MockFileStream(mockFileSystem, path, GetStreamType(mode, access));
+            => new MockFileStream(mockFileSystem, path, GetStreamType(mode, access), mode);
 
         public Stream Create(string path, FileMode mode, FileSystemRights rights, FileShare share, int bufferSize, FileOptions options, FileSecurity fileSecurity)
-            => new MockFileStream(mockFileSystem, path, GetStreamType(mode), options);
+            => new MockFileStream(mockFileSystem, path, GetStreamType(mode), options, mode);
 
         public Stream Create(string path, FileMode mode, FileSystemRights rights, FileShare share, int bufferSize, FileOptions options)
-            => new MockFileStream(mockFileSystem, path, GetStreamType(mode), options);
+            => new MockFileStream(mockFileSystem, path, GetStreamType(mode), options, mode);
 
         [Obsolete("This method has been deprecated. Please use new Create(SafeFileHandle handle, FileAccess access) instead. http://go.microsoft.com/fwlink/?linkid=14202")]
         public Stream Create(IntPtr handle, FileAccess access)

--- a/System.IO.Abstractions.TestingHelpers/Properties/Resources.resx
+++ b/System.IO.Abstractions.TestingHelpers/Properties/Resources.resx
@@ -153,4 +153,7 @@
   <data name="PROCESS_CANNOT_ACCESS_FILE_IN_USE_WITH_FILENAME" xml:space="preserve">
     <value>The process cannot access the file '{0}' because it is being used by another process.</value>
   </data>
+  <data name="FILE_ALREADY_EXISTS" xml:space="preserve">
+    <value>The file '{0}' already exists.</value>
+  </data>
 </root>


### PR DESCRIPTION
- additional unreported fix: FileStream created with FileMode.Open or Truncate should throw an exception if the file is missing
- added a couple missing cases