### PR TITLE
Fixed #464

### DIFF
--- a/System.IO.Abstractions.TestingHelpers.Tests/MockFileReadAllLinesTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockFileReadAllLinesTests.cs
@@ -70,6 +70,22 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             Assert.That(exception.Message, Is.EqualTo("Could not find file '" + absentFileNameFullPath + "'."));
         }
 
+        [Test]
+        public void MockFile_ReadAllLines_ShouldNotReturnBom()
+        {
+            // Arrange
+            var testFilePath = XFS.Path(@"c:\a test file.txt");
+            const string testText = "Hello World";
+            var fileSystem = new MockFileSystem();
+            fileSystem.File.WriteAllLines(testFilePath, new[] { testText }, Encoding.UTF8);
+
+            // Act
+            var result = fileSystem.File.ReadAllLines(testFilePath, Encoding.UTF8);
+
+            // Assert
+            Assert.That(result.Length, Is.EqualTo(1));
+            Assert.That(result[0], Is.EqualTo(testText));
+        }
 #if FEATURE_ASYNC_FILE
         [Test]
         public async Task MockFile_ReadAllLinesAsync_ShouldReturnOriginalTextData()

--- a/System.IO.Abstractions.TestingHelpers/MockFile.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockFile.cs
@@ -490,7 +490,9 @@ namespace System.IO.Abstractions.TestingHelpers
 
             using (var ms = new MemoryStream(mockFileDataAccessor.GetFile(path).Contents))
             using (var sr = new StreamReader(ms, encoding))
+           {
                 return sr.ReadToEnd().SplitLines();
+           }
         }
 
         public override string ReadAllText(string path)

--- a/System.IO.Abstractions.TestingHelpers/MockFile.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockFile.cs
@@ -487,9 +487,10 @@ namespace System.IO.Abstractions.TestingHelpers
             }
 
             mockFileDataAccessor.GetFile(path).CheckFileAccess(path, FileAccess.Read);
-            return encoding
-                .GetString(mockFileDataAccessor.GetFile(path).Contents)
-                .SplitLines();
+
+            using (var ms = new MemoryStream(mockFileDataAccessor.GetFile(path).Contents))
+            using (var sr = new StreamReader(ms, encoding))
+                return sr.ReadToEnd().SplitLines();
         }
 
         public override string ReadAllText(string path)


### PR DESCRIPTION
Fixed https://github.com/System-IO-Abstractions/System.IO.Abstractions/issues/464 by using the test case provided. The change is small: StreamReader honours BOMs, but to preserve big-endian Unicode support you must pass an encoding in that case. Since encoding is always provided into that method, I pass it always.