### PR TITLE
On Directory.Move, first check to ensure the parent directory for the indicated target folder exists

### DIFF
--- a/System.IO.Abstractions.TestingHelpers/MockDirectory.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockDirectory.cs
@@ -415,6 +415,11 @@ namespace System.IO.Abstractions.TestingHelpers
                 throw new DirectoryNotFoundException($"Could not find a part of the path '{sourceDirName}'.");
             }
 
+            if (!mockFileDataAccessor.Directory.GetParent(fullDestPath).Exists)
+            {
+                throw new DirectoryNotFoundException($"Could not find a part of the path.");
+            }
+
             if (mockFileDataAccessor.Directory.Exists(fullDestPath) || mockFileDataAccessor.File.Exists(fullDestPath))
             {
                 throw new IOException($"Cannot create '{fullDestPath}' because a file or directory with the same name already exists.");


### PR DESCRIPTION
The solution turns out to be much simpler than I had thought, which is that the target directory structure much exist before copying into a 'new' folder.