### PR TITLE
Feature/588 default virtual temp folder

### DIFF
--- a/System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
@@ -342,6 +342,18 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
+        public void MockFileSystem_DefaultState_DefaultTempDirectoryExists()
+        {
+            var tempDirectory = @"C:\temp";
+
+            var mockFileSystem = new MockFileSystem();
+            var mockFileSystemOverload = new MockFileSystem(null, string.Empty);
+            
+            Assert.IsTrue(mockFileSystem.Directory.Exists(tempDirectory));
+            Assert.IsTrue(mockFileSystemOverload.Directory.Exists(tempDirectory));
+        }
+
+        [Test]
         public void MockFileSystem_FileSystemWatcher_PathShouldBeAssignable()
         {
             var path = XFS.Path(@"C:\root");

--- a/System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
@@ -292,7 +292,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 XFS.Path(@"c:\something\demo.txt"),
                 XFS.Path(@"c:\something\other.gif"),
                 XFS.Path(@"d:\foobar"),
-                XFS.Path(@"d:\foo\bar")
+                XFS.Path(@"d:\foo\bar"),
+                XFS.Path(@"C:\temp")
             };
 
             var result = fileSystem.AllNodes;

--- a/System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
@@ -344,7 +344,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         [Test]
         public void MockFileSystem_DefaultState_DefaultTempDirectoryExists()
         {
-            var tempDirectory = @"C:\temp";
+            var tempDirectory = XFS.Path(@"C:\temp");
 
             var mockFileSystem = new MockFileSystem();
             var mockFileSystemOverload = new MockFileSystem(null, string.Empty);

--- a/System.IO.Abstractions.TestingHelpers.Tests/MockPathTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockPathTests.cs
@@ -373,6 +373,48 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase(@"C:\temp")]
+        public void GetTempPath_Called_ReturnsStringLengthGreaterThanZero(string tempDirectory) {
+            //Arrange
+            var mockPath = new MockPath(new MockFileSystem(),tempDirectory);
+
+            //Act
+            var result = mockPath.GetTempPath();
+
+            //Assert
+            Assert.IsTrue(result.Length > 0);
+        }
+
+        [Test]
+        public void GetTempPath_Called_WithNonNullVirtualTempDirectory_ReturnsVirtualTempDirectory() {
+            //Arrange
+            var tempDirectory = @"C:\temp";
+            var mockPath = new MockPath(new MockFileSystem(), tempDirectory);
+
+            //Act
+            var result = mockPath.GetTempPath();
+
+            //Assert
+            Assert.AreEqual(tempDirectory,result);
+        }
+
+        [Test]
+        [TestCase(null)]
+        [TestCase("")]
+        public void GetTempPath_Called_WithNullOrEmptyVirtualTempDirectory_ReturnsFallbackTempDirectory(string tempDirectory) {
+            //Arrange
+            var mockPath = new MockPath(new MockFileSystem(), tempDirectory);
+
+            //Act
+            var result = mockPath.GetTempPath();
+
+            //Assert
+            Assert.IsTrue(result.Length > 0);
+        }
+
+        [Test]
         public void HasExtension_PathSentIn_DeterminesExtension()
         {
             //Arrange

--- a/System.IO.Abstractions.TestingHelpers.Tests/MockPathTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockPathTests.cs
@@ -378,7 +378,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         [TestCase(@"C:\temp")]
         public void GetTempPath_Called_ReturnsStringLengthGreaterThanZero(string tempDirectory) {
             //Arrange
-            var mockPath = new MockPath(new MockFileSystem(),tempDirectory);
+            var mockPath = new MockPath(new MockFileSystem(), XFS.Path(tempDirectory));
 
             //Act
             var result = mockPath.GetTempPath();
@@ -390,7 +390,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         [Test]
         public void GetTempPath_Called_WithNonNullVirtualTempDirectory_ReturnsVirtualTempDirectory() {
             //Arrange
-            var tempDirectory = @"C:\temp";
+            var tempDirectory = XFS.Path(@"C:\temp");
+
             var mockPath = new MockPath(new MockFileSystem(), tempDirectory);
 
             //Act

--- a/System.IO.Abstractions.TestingHelpers.Tests/MockPathTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockPathTests.cs
@@ -378,7 +378,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         [TestCase(@"C:\temp")]
         public void GetTempPath_Called_ReturnsStringLengthGreaterThanZero(string tempDirectory) {
             //Arrange
-            var mockPath = new MockPath(new MockFileSystem(), XFS.Path(tempDirectory));
+            var mockPath = new MockPath(new MockFileSystem(), string.IsNullOrEmpty(tempDirectory)? tempDirectory: XFS.Path(tempDirectory));
 
             //Act
             var result = mockPath.GetTempPath();

--- a/System.IO.Abstractions.TestingHelpers/MockFileSystem.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockFileSystem.cs
@@ -11,7 +11,7 @@ namespace System.IO.Abstractions.TestingHelpers
     public class MockFileSystem : IFileSystem, IMockFileDataAccessor
     {
         private const string DEFAULT_CURRENT_DIRECTORY = @"C:\";
-        private const string DEFAULT_TEMP_DIRECTORY = @"C:\temp";
+        private const string TEMP_DIRECTORY = @"C:\temp";
 
         private readonly IDictionary<string, MockFileData> files;
         private readonly PathVerifier pathVerifier;
@@ -25,7 +25,7 @@ namespace System.IO.Abstractions.TestingHelpers
                 currentDirectory = XFS.Path(DEFAULT_CURRENT_DIRECTORY);
             }
 
-            var defaultTempDirectory = XFS.Path(DEFAULT_TEMP_DIRECTORY);
+            var defaultTempDirectory = XFS.Path(TEMP_DIRECTORY);
 
             StringOperations = new StringOperations(XFS.IsUnixPlatform());
             pathVerifier = new PathVerifier(this);

--- a/System.IO.Abstractions.TestingHelpers/MockFileSystem.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockFileSystem.cs
@@ -11,6 +11,7 @@ namespace System.IO.Abstractions.TestingHelpers
     public class MockFileSystem : IFileSystem, IMockFileDataAccessor
     {
         private const string DEFAULT_CURRENT_DIRECTORY = @"C:\";
+        private const string DEFAULT_TEMP_DIRECTORY = @"C:\temp";
 
         private readonly IDictionary<string, MockFileData> files;
         private readonly PathVerifier pathVerifier;
@@ -24,11 +25,13 @@ namespace System.IO.Abstractions.TestingHelpers
                 currentDirectory = XFS.Path(DEFAULT_CURRENT_DIRECTORY);
             }
 
+            var defaultTempDirectory = XFS.Path(DEFAULT_TEMP_DIRECTORY);
+
             StringOperations = new StringOperations(XFS.IsUnixPlatform());
             pathVerifier = new PathVerifier(this);
             this.files = new Dictionary<string, MockFileData>(StringOperations.Comparer);
 
-            Path = new MockPath(this);
+            Path = new MockPath(this,defaultTempDirectory);
             File = new MockFile(this);
             Directory = new MockDirectory(this, currentDirectory);
             FileInfo = new MockFileInfoFactory(this);
@@ -48,6 +51,11 @@ namespace System.IO.Abstractions.TestingHelpers
             if (!FileExists(currentDirectory))
             {
                 AddDirectory(currentDirectory);
+            }
+
+            if (!FileExists(defaultTempDirectory)) 
+            {
+                AddDirectory(defaultTempDirectory);
             }
         }
 

--- a/System.IO.Abstractions.TestingHelpers/MockPath.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockPath.cs
@@ -18,7 +18,7 @@ namespace System.IO.Abstractions.TestingHelpers
         public MockPath(IMockFileDataAccessor mockFileDataAccessor,string defaultTempDirectory) : base(mockFileDataAccessor?.FileSystem)
         {
             this.mockFileDataAccessor = mockFileDataAccessor ?? throw new ArgumentNullException(nameof(mockFileDataAccessor));
-            this.defaultTempDirectory = defaultTempDirectory;
+            this.defaultTempDirectory = !string.IsNullOrEmpty(defaultTempDirectory) ? defaultTempDirectory : base.GetTempPath();
         }
 
         public override string GetFullPath(string path)
@@ -141,9 +141,6 @@ namespace System.IO.Abstractions.TestingHelpers
             return fullPath;
         }
 
-        public override string GetTempPath()
-        {
-            return !string.IsNullOrEmpty(defaultTempDirectory) ? defaultTempDirectory : base.GetTempPath();
-        }
+        public override string GetTempPath() => defaultTempDirectory;
     }
 }

--- a/System.IO.Abstractions.TestingHelpers/MockPath.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockPath.cs
@@ -11,10 +11,14 @@ namespace System.IO.Abstractions.TestingHelpers
     public class MockPath : PathWrapper
     {
         private readonly IMockFileDataAccessor mockFileDataAccessor;
+        private readonly string defaultTempDirectory;
 
-        public MockPath(IMockFileDataAccessor mockFileDataAccessor) : base(mockFileDataAccessor?.FileSystem)
+        public MockPath(IMockFileDataAccessor mockFileDataAccessor) : this(mockFileDataAccessor,string.Empty) { }
+
+        public MockPath(IMockFileDataAccessor mockFileDataAccessor,string defaultTempDirectory) : base(mockFileDataAccessor?.FileSystem)
         {
             this.mockFileDataAccessor = mockFileDataAccessor ?? throw new ArgumentNullException(nameof(mockFileDataAccessor));
+            this.defaultTempDirectory = defaultTempDirectory;
         }
 
         public override string GetFullPath(string path)
@@ -128,13 +132,18 @@ namespace System.IO.Abstractions.TestingHelpers
         public override string GetTempFileName()
         {
             string fileName = mockFileDataAccessor.Path.GetRandomFileName();
-            string tempDir = mockFileDataAccessor.Path.GetTempPath();
+            string tempDir = this.GetTempPath();
 
             string fullPath = mockFileDataAccessor.Path.Combine(tempDir, fileName);
 
             mockFileDataAccessor.AddFile(fullPath, new MockFileData(string.Empty));
 
             return fullPath;
+        }
+
+        public override string GetTempPath()
+        {
+            return !string.IsNullOrEmpty(defaultTempDirectory) ? defaultTempDirectory : base.GetTempPath();
         }
     }
 }


### PR DESCRIPTION
As discussed in the issue #588 I've added a default temp directory to MockFileSystem (ping @fgreinacher )

I'm not 100% sure with my solution to use the previous GetTempPath as a fallback if the path passed in to the MockPath is null or empty (or the original constructor is called). 

Let me know what you think, I'm torn but decided on the fallback as not to add a breaking change.
