### PR TITLE
Correctly handle FileMode/FileAccess when creating MockFileStreams

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,14 +6,11 @@
     <SignAssembly Condition="'$(Configuration)' == 'Release'">True</SignAssembly>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)StrongName.snk</AssemblyOriginatorKeyFile>
     <DefineConstants Condition="'$(TargetFramework)' == 'netcoreapp3.0' OR '$(TargetFramework)' == 'netstandard2.1'">$(DefineConstants);FEATURE_ASYNC_FILE;FEATURE_ENUMERATION_OPTIONS;FEATURE_ADVANCED_PATH_OPERATIONS</DefineConstants>
-
   </PropertyGroup>
-  <!--
   <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.1.91">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
-  -->
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,10 +8,12 @@
     <DefineConstants Condition="'$(TargetFramework)' == 'netcoreapp3.0' OR '$(TargetFramework)' == 'netstandard2.1'">$(DefineConstants);FEATURE_ASYNC_FILE;FEATURE_ENUMERATION_OPTIONS;FEATURE_ADVANCED_PATH_OPERATIONS</DefineConstants>
 
   </PropertyGroup>
+  <!--
   <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.1.91">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
+  -->
 </Project>

--- a/System.IO.Abstractions.TestingHelpers.Tests/MockFileStreamFactoryTests.cs
+++ b/System.IO.Abstractions.TestingHelpers.Tests/MockFileStreamFactoryTests.cs
@@ -134,5 +134,18 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             // Assert
             Assert.True(fileSystem.File.Exists(XFS.Path("./some_random_file.txt")));
         }
+
+        [Test]
+        public void MockFileStream_CanRead_ReturnsFalseForAWriteOnlyStream()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+
+            // Act
+            var fileStream = fileSystem.FileStream.Create("file.txt", FileMode.CreateNew, FileAccess.Write);
+
+            // Assert
+            Assert.IsFalse(fileStream.CanRead);
+        }
     }
 }

--- a/System.IO.Abstractions.TestingHelpers/MockFile.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockFile.cs
@@ -369,7 +369,7 @@ namespace System.IO.Abstractions.TestingHelpers
         {
             mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, "path");
 
-            return Open(path, mode, (mode == FileMode.Append ? FileAccess.Write : FileAccess.ReadWrite), FileShare.None);
+            return Open(path, mode, FileAccess.ReadWrite, FileShare.None);
         }
 
         public override Stream Open(string path, FileMode mode, FileAccess access)
@@ -412,13 +412,8 @@ namespace System.IO.Abstractions.TestingHelpers
             mockFileData.CheckFileAccess(path, access);
 
             var length = mockFileData.Contents.Length;
-            MockFileStream.StreamType streamType = MockFileStream.StreamType.WRITE;
-            if (access == FileAccess.Read)
-                streamType = MockFileStream.StreamType.READ;
-            else if (mode == FileMode.Append)
-                streamType = MockFileStream.StreamType.APPEND;
 
-            return new MockFileStream(mockFileDataAccessor, path, streamType, options, mode);
+            return new MockFileStream(mockFileDataAccessor, path, mode, access, options);
         }
 
         public override Stream OpenRead(string path)
@@ -490,9 +485,9 @@ namespace System.IO.Abstractions.TestingHelpers
 
             using (var ms = new MemoryStream(mockFileDataAccessor.GetFile(path).Contents))
             using (var sr = new StreamReader(ms, encoding))
-           {
+            {
                 return sr.ReadToEnd().SplitLines();
-           }
+            }
         }
 
         public override string ReadAllText(string path)

--- a/System.IO.Abstractions.TestingHelpers/MockFileInfo.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockFileInfo.cs
@@ -152,7 +152,7 @@ namespace System.IO.Abstractions.TestingHelpers
 
         public override StreamWriter AppendText()
         {
-            return new StreamWriter(new MockFileStream(mockFileSystem, FullName, MockFileStream.StreamType.APPEND));
+            return new StreamWriter(new MockFileStream(mockFileSystem, FullName, FileMode.Append));
         }
 
         public override IFileInfo CopyTo(string destFileName)
@@ -237,7 +237,7 @@ namespace System.IO.Abstractions.TestingHelpers
         public override Stream OpenRead()
         {
             if (MockFileData == null) throw CommonExceptions.FileNotFound(path);
-            return new MockFileStream(mockFileSystem, path, MockFileStream.StreamType.READ);
+            return new MockFileStream(mockFileSystem, path, FileMode.Open, FileAccess.Read);
         }
 
         public override StreamReader OpenText()
@@ -247,7 +247,7 @@ namespace System.IO.Abstractions.TestingHelpers
 
         public override Stream OpenWrite()
         {
-            return new MockFileStream(mockFileSystem, path, MockFileStream.StreamType.WRITE);
+            return new MockFileStream(mockFileSystem, path, FileMode.Open);
         }
 
         public override IFileInfo Replace(string destinationFileName, string destinationBackupFileName)

--- a/System.IO.Abstractions.TestingHelpers/MockFileStreamFactory.cs
+++ b/System.IO.Abstractions.TestingHelpers/MockFileStreamFactory.cs
@@ -12,80 +12,52 @@ namespace System.IO.Abstractions.TestingHelpers
             => this.mockFileSystem = mockFileSystem ?? throw new ArgumentNullException(nameof(mockFileSystem));
 
         public Stream Create(string path, FileMode mode)
-            => new MockFileStream(mockFileSystem, path, GetStreamType(mode), mode);
+            => new MockFileStream(mockFileSystem, path, mode);
 
         public Stream Create(string path, FileMode mode, FileAccess access)
-            => new MockFileStream(mockFileSystem, path, GetStreamType(mode, access), mode);
+            => new MockFileStream(mockFileSystem, path, mode, access);
 
         public Stream Create(string path, FileMode mode, FileAccess access, FileShare share)
-            => new MockFileStream(mockFileSystem, path, GetStreamType(mode, access), mode);
+            => new MockFileStream(mockFileSystem, path, mode, access);
 
         public Stream Create(string path, FileMode mode, FileAccess access, FileShare share, int bufferSize)
-            => new MockFileStream(mockFileSystem, path, GetStreamType(mode, access), mode);
+            => new MockFileStream(mockFileSystem, path, mode, access);
 
         public Stream Create(string path, FileMode mode, FileAccess access, FileShare share, int bufferSize, FileOptions options)
-            => new MockFileStream(mockFileSystem, path, GetStreamType(mode, access), options, mode);
+            => new MockFileStream(mockFileSystem, path, mode, access, options);
 
         public Stream Create(string path, FileMode mode, FileAccess access, FileShare share, int bufferSize, bool useAsync)
-            => new MockFileStream(mockFileSystem, path, GetStreamType(mode, access), mode);
+            => new MockFileStream(mockFileSystem, path, mode, access);
 
         public Stream Create(string path, FileMode mode, FileSystemRights rights, FileShare share, int bufferSize, FileOptions options, FileSecurity fileSecurity)
-            => new MockFileStream(mockFileSystem, path, GetStreamType(mode), options, mode);
+            => new MockFileStream(mockFileSystem, path, mode, options: options);
 
         public Stream Create(string path, FileMode mode, FileSystemRights rights, FileShare share, int bufferSize, FileOptions options)
-            => new MockFileStream(mockFileSystem, path, GetStreamType(mode), options, mode);
+            => new MockFileStream(mockFileSystem, path, mode, options: options);
 
         [Obsolete("This method has been deprecated. Please use new Create(SafeFileHandle handle, FileAccess access) instead. http://go.microsoft.com/fwlink/?linkid=14202")]
         public Stream Create(IntPtr handle, FileAccess access)
-            => new MockFileStream(mockFileSystem, handle.ToString(), GetStreamType(FileMode.Append, access));
+            => new MockFileStream(mockFileSystem, handle.ToString(), FileMode.Open, access: access);
 
         [Obsolete("This method has been deprecated. Please use new Create(SafeFileHandle handle, FileAccess access) instead, and optionally make a new SafeFileHandle with ownsHandle=false if needed. http://go.microsoft.com/fwlink/?linkid=14202")]
         public Stream Create(IntPtr handle, FileAccess access, bool ownsHandle)
-            => new MockFileStream(mockFileSystem, handle.ToString(), GetStreamType(FileMode.Append, access));
+            => new MockFileStream(mockFileSystem, handle.ToString(), FileMode.Open, access: access);
 
         [Obsolete("This method has been deprecated. Please use new Create(SafeFileHandle handle, FileAccess access, int bufferSize) instead, and optionally make a new SafeFileHandle with ownsHandle=false if needed. http://go.microsoft.com/fwlink/?linkid=14202")]
         public Stream Create(IntPtr handle, FileAccess access, bool ownsHandle, int bufferSize)
-            => new MockFileStream(mockFileSystem, handle.ToString(), GetStreamType(FileMode.Append, access));
+            => new MockFileStream(mockFileSystem, handle.ToString(), FileMode.Open, access: access);
 
         [Obsolete("This method has been deprecated. Please use new Create(SafeFileHandle handle, FileAccess access, int bufferSize, bool isAsync) instead, and optionally make a new SafeFileHandle with ownsHandle=false if needed. http://go.microsoft.com/fwlink/?linkid=14202")]
         public Stream Create(IntPtr handle, FileAccess access, bool ownsHandle, int bufferSize, bool isAsync)
-            => new MockFileStream(mockFileSystem, handle.ToString(), GetStreamType(FileMode.Append, access));
+            => new MockFileStream(mockFileSystem, handle.ToString(), FileMode.Open, access: access);
 
         public Stream Create(SafeFileHandle handle, FileAccess access)
-            => new MockFileStream(mockFileSystem, handle.ToString(), GetStreamType(FileMode.Append, access));
+            => new MockFileStream(mockFileSystem, handle.ToString(), FileMode.Open, access: access);
 
         public Stream Create(SafeFileHandle handle, FileAccess access, int bufferSize)
-            => new MockFileStream(mockFileSystem, handle.ToString(), GetStreamType(FileMode.Append, access));
+            => new MockFileStream(mockFileSystem, handle.ToString(), FileMode.Open, access: access);
 
         public Stream Create(SafeFileHandle handle, FileAccess access, int bufferSize, bool isAsync)
-            => new MockFileStream(mockFileSystem, handle.ToString(), GetStreamType(FileMode.Append, access));
-
-        private static MockFileStream.StreamType GetStreamType(FileMode mode, FileAccess access = FileAccess.ReadWrite)
-        {
-            if (access == FileAccess.Read)
-            {
-                return MockFileStream.StreamType.READ;
-            }
-            else if (mode == FileMode.Append)
-            {
-                return MockFileStream.StreamType.APPEND;
-            }
-            else if (mode == FileMode.Truncate)
-            {
-                return MockFileStream.StreamType.TRUNCATE;
-            }
-            else if (mode == FileMode.Create)
-            {
-                return MockFileStream.StreamType.TRUNCATE;
-            }
-            else if (mode == FileMode.CreateNew)
-            {
-                return MockFileStream.StreamType.TRUNCATE;
-            }
-            else
-            {
-                return MockFileStream.StreamType.WRITE;
-            }
-        }
+            => new MockFileStream(mockFileSystem, handle.ToString(), FileMode.Open, access: access);
     }
 }

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "11.0",
+  "version": "12.0",
   "assemblyVersion": {
     "precision": "major"
   },


### PR DESCRIPTION
Fixes #610

Breaking change:

MockFIleStream.StreamType and the related constructors are gone. The desired FileStream behavior should be specified by passing tje appropriate FileMode/FileAccess/FileOptions instead.