### PR TITLE
Fixes #635 Directory.GetParent(..) behaviour for root directories

### DIFF
--- a/src/System.IO.Abstractions/DirectoryWrapper.cs
+++ b/src/System.IO.Abstractions/DirectoryWrapper.cs
@@ -136,7 +136,14 @@ namespace System.IO.Abstractions
 
         public override IDirectoryInfo GetParent(string path)
         {
-            return new DirectoryInfoWrapper(FileSystem, Directory.GetParent(path));
+            var parent = Directory.GetParent(path);
+
+            if (parent == null)
+            {
+                return null;
+            }
+
+            return new DirectoryInfoWrapper(FileSystem, parent);
         }
 
         public override void Move(string sourceDirName, string destDirName)

--- a/tests/System.IO.Abstractions.Tests/DirectoryWrapperTests.cs
+++ b/tests/System.IO.Abstractions.Tests/DirectoryWrapperTests.cs
@@ -10,27 +10,44 @@ namespace System.IO.Abstractions.Tests
         {
             // Arrange
             var wrapperFilesystem = new FileSystem();
+            var root = wrapperFilesystem.Directory.GetDirectoryRoot(".");
 
             // Act
-            var result = wrapperFilesystem.Directory.GetParent(@"C:\");
+            var result = wrapperFilesystem.Directory.GetParent(root);
 
             // Assert
             Assert.IsNull(result);
         }
 
         [Test]
-        public void GetParent_ForSimpleDirectory_ShouldReturnParent()
+        public void GetParent_ForSimpleSubfolderPath_ShouldReturnRoot()
         {
             // Arrange
-            var expectedBaseDirectory = @"C:\directory1";
-
             var wrapperFilesystem = new FileSystem();
+            var root = wrapperFilesystem.Directory.GetDirectoryRoot(".");
+            var subfolder = wrapperFilesystem.Path.Combine(root, "some-folder");
 
             // Act
-            var result = wrapperFilesystem.Directory.GetParent($@"{expectedBaseDirectory}\file1.txt");
+            var result = wrapperFilesystem.Directory.GetParent(subfolder);
 
             // Assert
-            Assert.AreEqual(expectedBaseDirectory, result.FullName);
+            Assert.AreEqual(root, result.FullName);
+        }
+
+        [Test]
+        public void GetParent_ForSimpleFilePath_ShouldReturnSubfolder()
+        {
+            // Arrange
+            var wrapperFilesystem = new FileSystem();
+            var root = wrapperFilesystem.Directory.GetDirectoryRoot(".");
+            var subfolder = wrapperFilesystem.Path.Combine(root, "some-folder");
+            var file = wrapperFilesystem.Path.Combine(subfolder, "some-file.txt");
+
+            // Act
+            var result = wrapperFilesystem.Directory.GetParent(file);
+
+            // Assert
+            Assert.AreEqual(subfolder, result.FullName);
         }
     }
 }

--- a/tests/System.IO.Abstractions.Tests/DirectoryWrapperTests.cs
+++ b/tests/System.IO.Abstractions.Tests/DirectoryWrapperTests.cs
@@ -1,0 +1,36 @@
+﻿using NUnit.Framework;
+
+namespace System.IO.Abstractions.Tests
+{
+    [TestFixture]
+    public class DirectoryWrapperTests
+    {
+        [Test]
+        public void GetParent_ForRootDirectory_ShouldReturnNull()
+        {
+            // Arrange
+            var wrapperFilesystem = new FileSystem();
+
+            // Act
+            var result = wrapperFilesystem.Directory.GetParent(@"C:\");
+
+            // Assert
+            Assert.IsNull(result);
+        }
+
+        [Test]
+        public void GetParent_ForSimpleDirectory_ShouldReturnParent()
+        {
+            // Arrange
+            var expectedBaseDirectory = @"C:\directory1";
+
+            var wrapperFilesystem = new FileSystem();
+
+            // Act
+            var result = wrapperFilesystem.Directory.GetParent($@"{expectedBaseDirectory}\file1.txt");
+
+            // Assert
+            Assert.AreEqual(expectedBaseDirectory, result.FullName);
+        }
+    }
+}


### PR DESCRIPTION
See issue #635 .

I hope my changes are properly done.
Would i need to adjust any versioning info, because this changes API behaviour..?