### PR TITLE
Add methods with EnumerationOptions parameter to IDirectoryInfo

### DIFF
--- a/src/System.IO.Abstractions.TestingHelpers/MockDirectory.cs
+++ b/src/System.IO.Abstractions.TestingHelpers/MockDirectory.cs
@@ -174,6 +174,13 @@ namespace System.IO.Abstractions.TestingHelpers
             return EnumerateDirectories(path, searchPattern, searchOption).ToArray();
         }
 
+#if FEATURE_ENUMERATION_OPTIONS
+        public override string[] GetDirectories(string path, string searchPattern, EnumerationOptions enumerationOptions)
+        {
+            return GetDirectories(path, "*");
+        }
+#endif
+
         public override string GetDirectoryRoot(string path)
         {
             return Path.GetPathRoot(path);
@@ -195,6 +202,13 @@ namespace System.IO.Abstractions.TestingHelpers
         {
             return GetFilesInternal(mockFileDataAccessor.AllFiles, path, searchPattern, searchOption);
         }
+
+#if FEATURE_ENUMERATION_OPTIONS
+        public override string[] GetFiles(string path, string searchPattern, EnumerationOptions enumerationOptions)
+        {
+            return GetFiles(path, "*");
+        }
+#endif
 
         private string[] GetFilesInternal(
             IEnumerable<string> files,

--- a/src/System.IO.Abstractions.TestingHelpers/MockDirectoryInfo.cs
+++ b/src/System.IO.Abstractions.TestingHelpers/MockDirectoryInfo.cs
@@ -158,6 +158,13 @@ namespace System.IO.Abstractions.TestingHelpers
             return GetDirectories(searchPattern, searchOption);
         }
 
+#if FEATURE_ENUMERATION_OPTIONS
+        public override IEnumerable<IDirectoryInfo> EnumerateDirectories(string searchPattern, EnumerationOptions enumerationOptions)
+        {
+            return GetDirectories(searchPattern, enumerationOptions);
+        }
+#endif
+
         public override IEnumerable<IFileInfo> EnumerateFiles()
         {
             return GetFiles();
@@ -173,6 +180,13 @@ namespace System.IO.Abstractions.TestingHelpers
             return GetFiles(searchPattern, searchOption);
         }
 
+#if FEATURE_ENUMERATION_OPTIONS
+        public override IEnumerable<IFileInfo> EnumerateFiles(string searchPattern, EnumerationOptions enumerationOptions)
+        {
+            return GetFiles(searchPattern, enumerationOptions);
+        }
+#endif
+
         public override IEnumerable<IFileSystemInfo> EnumerateFileSystemInfos()
         {
             return GetFileSystemInfos();
@@ -187,6 +201,13 @@ namespace System.IO.Abstractions.TestingHelpers
         {
             return GetFileSystemInfos(searchPattern, searchOption);
         }
+
+#if FEATURE_ENUMERATION_OPTIONS
+        public override IEnumerable<IFileSystemInfo> EnumerateFileSystemInfos(string searchPattern, EnumerationOptions enumerationOptions)
+        {
+            return GetFileSystemInfos(searchPattern, enumerationOptions);
+        }
+#endif
 
         public override DirectorySecurity GetAccessControl()
         {
@@ -213,6 +234,13 @@ namespace System.IO.Abstractions.TestingHelpers
             return ConvertStringsToDirectories(mockFileDataAccessor.Directory.GetDirectories(directoryPath, searchPattern, searchOption));
         }
 
+#if FEATURE_ENUMERATION_OPTIONS
+        public override IDirectoryInfo[] GetDirectories(string searchPattern, EnumerationOptions enumerationOptions)
+        {
+            return ConvertStringsToDirectories(mockFileDataAccessor.Directory.GetDirectories(directoryPath, searchPattern, enumerationOptions));
+        }
+#endif
+
         private DirectoryInfoBase[] ConvertStringsToDirectories(IEnumerable<string> paths)
         {
             return paths
@@ -236,6 +264,13 @@ namespace System.IO.Abstractions.TestingHelpers
             return ConvertStringsToFiles(mockFileDataAccessor.Directory.GetFiles(FullName, searchPattern, searchOption));
         }
 
+#if FEATURE_ENUMERATION_OPTIONS
+        public override IFileInfo[] GetFiles(string searchPattern, EnumerationOptions enumerationOptions)
+        {
+            return ConvertStringsToFiles(mockFileDataAccessor.Directory.GetFiles(FullName, searchPattern, enumerationOptions));
+        }
+#endif
+
         IFileInfo[] ConvertStringsToFiles(IEnumerable<string> paths)
         {
             return paths
@@ -257,6 +292,13 @@ namespace System.IO.Abstractions.TestingHelpers
         {
             return GetDirectories(searchPattern, searchOption).OfType<IFileSystemInfo>().Concat(GetFiles(searchPattern, searchOption)).ToArray();
         }
+
+#if FEATURE_ENUMERATION_OPTIONS
+        public override IFileSystemInfo[] GetFileSystemInfos(string searchPattern, EnumerationOptions enumerationOptions)
+        {
+            return GetDirectories(searchPattern, enumerationOptions).OfType<IFileSystemInfo>().Concat(GetFiles(searchPattern, enumerationOptions)).ToArray();
+        }
+#endif
 
         public override void MoveTo(string destDirName)
         {

--- a/src/System.IO.Abstractions/DirectoryBase.cs
+++ b/src/System.IO.Abstractions/DirectoryBase.cs
@@ -59,6 +59,11 @@ namespace System.IO.Abstractions
         /// <inheritdoc cref="Directory.GetDirectories(string,string,SearchOption)"/>
         public abstract string[] GetDirectories(string path, string searchPattern, SearchOption searchOption);
 
+#if FEATURE_ENUMERATION_OPTIONS
+        /// <inheritdoc cref="Directory.GetDirectories(string,string,EnumerationOptions)"/>
+        public abstract string[] GetDirectories(string path, string searchPattern, EnumerationOptions enumerationOptions);
+#endif
+
         /// <inheritdoc cref="Directory.GetDirectoryRoot"/>
         public abstract string GetDirectoryRoot(string path);
 
@@ -70,6 +75,11 @@ namespace System.IO.Abstractions
 
         /// <inheritdoc cref="Directory.GetFiles(string,string,SearchOption)"/>
         public abstract string[] GetFiles(string path, string searchPattern, SearchOption searchOption);
+
+#if FEATURE_ENUMERATION_OPTIONS
+        /// <inheritdoc cref="Directory.GetFiles(string,string,EnumerationOptions)"/>
+        public abstract string[] GetFiles(string path, string searchPattern, EnumerationOptions enumerationOptions);
+#endif
 
         /// <inheritdoc cref="Directory.GetFileSystemEntries(string)"/>
         public abstract string[] GetFileSystemEntries(string path);

--- a/src/System.IO.Abstractions/DirectoryInfoBase.cs
+++ b/src/System.IO.Abstractions/DirectoryInfoBase.cs
@@ -34,6 +34,11 @@ namespace System.IO.Abstractions
         /// <inheritdoc cref="DirectoryInfo.EnumerateDirectories(string,SearchOption)"/>
         public abstract IEnumerable<IDirectoryInfo> EnumerateDirectories(string searchPattern, SearchOption searchOption);
 
+#if FEATURE_ENUMERATION_OPTIONS
+        /// <inheritdoc cref="DirectoryInfo.EnumerateDirectories(string,EnumerationOptions)"/>
+        public abstract IEnumerable<IDirectoryInfo> EnumerateDirectories(string searchPattern, EnumerationOptions enumerationOptions);
+#endif
+
         /// <inheritdoc cref="DirectoryInfo.EnumerateFiles()"/>
         public abstract IEnumerable<IFileInfo> EnumerateFiles();
 
@@ -43,6 +48,11 @@ namespace System.IO.Abstractions
         /// <inheritdoc cref="DirectoryInfo.EnumerateFiles(string,SearchOption)"/>
         public abstract IEnumerable<IFileInfo> EnumerateFiles(string searchPattern, SearchOption searchOption);
 
+#if FEATURE_ENUMERATION_OPTIONS
+        /// <inheritdoc cref="DirectoryInfo.EnumerateFiles(string,EnumerationOptions)"/>
+        public abstract IEnumerable<IFileInfo> EnumerateFiles(string searchPattern, EnumerationOptions enumerationOptions);
+#endif
+
         /// <inheritdoc cref="DirectoryInfo.EnumerateFileSystemInfos()"/>
         public abstract IEnumerable<IFileSystemInfo> EnumerateFileSystemInfos();
 
@@ -51,6 +61,11 @@ namespace System.IO.Abstractions
 
         /// <inheritdoc cref="DirectoryInfo.EnumerateFileSystemInfos(string,SearchOption)"/>
         public abstract IEnumerable<IFileSystemInfo> EnumerateFileSystemInfos(string searchPattern, SearchOption searchOption);
+
+#if FEATURE_ENUMERATION_OPTIONS
+        /// <inheritdoc cref="DirectoryInfo.EnumerateFileSystemInfos(string,EnumerationOptions)"/>
+        public abstract IEnumerable<IFileSystemInfo> EnumerateFileSystemInfos(string searchPattern, EnumerationOptions enumerationOptions);
+#endif
 
         /// <inheritdoc cref="DirectoryInfo.GetAccessControl()"/>
         public abstract DirectorySecurity GetAccessControl();
@@ -67,6 +82,11 @@ namespace System.IO.Abstractions
         /// <inheritdoc cref="DirectoryInfo.GetDirectories(string,SearchOption)"/>
         public abstract IDirectoryInfo[] GetDirectories(string searchPattern, SearchOption searchOption);
 
+#if FEATURE_ENUMERATION_OPTIONS
+        /// <inheritdoc cref="DirectoryInfo.GetDirectories(string,EnumerationOptions)"/>
+        public abstract IDirectoryInfo[] GetDirectories(string searchPattern, EnumerationOptions enumerationOptions);
+#endif
+
         /// <inheritdoc cref="DirectoryInfo.GetFiles(string)"/>
         public abstract IFileInfo[] GetFiles();
 
@@ -76,6 +96,12 @@ namespace System.IO.Abstractions
         /// <inheritdoc cref="DirectoryInfo.GetFiles(string,SearchOption)"/>
         public abstract IFileInfo[] GetFiles(string searchPattern, SearchOption searchOption);
 
+
+#if FEATURE_ENUMERATION_OPTIONS
+        /// <inheritdoc cref="DirectoryInfo.GetFiles(string,EnumerationOptions)"/>
+        public abstract IFileInfo[] GetFiles(string searchPattern, EnumerationOptions enumerationOptions);
+#endif
+
         /// <inheritdoc cref="DirectoryInfo.GetFileSystemInfos()"/>
         public abstract IFileSystemInfo[] GetFileSystemInfos();
 
@@ -84,6 +110,11 @@ namespace System.IO.Abstractions
 
         /// <inheritdoc cref="DirectoryInfo.GetFileSystemInfos(string,SearchOption)"/>
         public abstract IFileSystemInfo[] GetFileSystemInfos(string searchPattern, SearchOption searchOption);
+
+#if FEATURE_ENUMERATION_OPTIONS
+        /// <inheritdoc cref="DirectoryInfo.GetFileSystemInfos(string,EnumerationOptions)"/>
+        public abstract IFileSystemInfo[] GetFileSystemInfos(string searchPattern, EnumerationOptions enumerationOptions);
+#endif
 
         /// <inheritdoc cref="DirectoryInfo.MoveTo"/>
         public abstract void MoveTo(string destDirName);

--- a/src/System.IO.Abstractions/DirectoryInfoWrapper.cs
+++ b/src/System.IO.Abstractions/DirectoryInfoWrapper.cs
@@ -121,6 +121,13 @@ namespace System.IO.Abstractions
             return instance.EnumerateDirectories(searchPattern, searchOption).Select(directoryInfo => new DirectoryInfoWrapper(FileSystem, directoryInfo));
         }
 
+#if FEATURE_ENUMERATION_OPTIONS
+        public override IEnumerable<IDirectoryInfo> EnumerateDirectories(string searchPattern, EnumerationOptions enumerationOptions)
+        {
+            return instance.EnumerateDirectories(searchPattern, enumerationOptions).Select(directoryInfo => new DirectoryInfoWrapper(FileSystem, directoryInfo));
+        }
+#endif
+
         public override IEnumerable<IFileInfo> EnumerateFiles()
         {
             return instance.EnumerateFiles().Select(fileInfo => new FileInfoWrapper(FileSystem, fileInfo));
@@ -136,6 +143,13 @@ namespace System.IO.Abstractions
             return instance.EnumerateFiles(searchPattern, searchOption).Select(fileInfo => new FileInfoWrapper(FileSystem, fileInfo));
         }
 
+#if FEATURE_ENUMERATION_OPTIONS
+        public override IEnumerable<IFileInfo> EnumerateFiles(string searchPattern, EnumerationOptions enumerationOptions)
+        {
+            return instance.EnumerateFiles(searchPattern, enumerationOptions).Select(fileInfo => new FileInfoWrapper(FileSystem, fileInfo));
+        }
+#endif
+
         public override IEnumerable<IFileSystemInfo> EnumerateFileSystemInfos()
         {
             return instance.EnumerateFileSystemInfos().WrapFileSystemInfos(FileSystem);
@@ -150,6 +164,13 @@ namespace System.IO.Abstractions
         {
             return instance.EnumerateFileSystemInfos(searchPattern, searchOption).WrapFileSystemInfos(FileSystem);
         }
+
+#if FEATURE_ENUMERATION_OPTIONS
+        public override IEnumerable<IFileSystemInfo> EnumerateFileSystemInfos(string searchPattern, EnumerationOptions enumerationOptions)
+        {
+            return instance.EnumerateFileSystemInfos(searchPattern, enumerationOptions).WrapFileSystemInfos(FileSystem);
+        }
+#endif
 
         public override DirectorySecurity GetAccessControl()
         {
@@ -176,6 +197,13 @@ namespace System.IO.Abstractions
             return instance.GetDirectories(searchPattern, searchOption).WrapDirectories(FileSystem);
         }
 
+#if FEATURE_ENUMERATION_OPTIONS
+        public override IDirectoryInfo[] GetDirectories(string searchPattern, EnumerationOptions enumerationOptions)
+        {
+            return instance.GetDirectories(searchPattern, enumerationOptions).WrapDirectories(FileSystem);
+        }
+#endif
+
         public override IFileInfo[] GetFiles()
         {
             return instance.GetFiles().WrapFiles(FileSystem);
@@ -191,6 +219,13 @@ namespace System.IO.Abstractions
             return instance.GetFiles(searchPattern, searchOption).WrapFiles(FileSystem);
         }
 
+#if FEATURE_ENUMERATION_OPTIONS
+        public override IFileInfo[] GetFiles(string searchPattern, EnumerationOptions enumerationOptions)
+        {
+            return instance.GetFiles(searchPattern, enumerationOptions).WrapFiles(FileSystem);
+        }
+#endif
+
         public override IFileSystemInfo[] GetFileSystemInfos()
         {
             return instance.GetFileSystemInfos().WrapFileSystemInfos(FileSystem);
@@ -205,6 +240,13 @@ namespace System.IO.Abstractions
         {
             return instance.GetFileSystemInfos(searchPattern, searchOption).WrapFileSystemInfos(FileSystem);
         }
+
+#if FEATURE_ENUMERATION_OPTIONS
+        public override IFileSystemInfo[] GetFileSystemInfos(string searchPattern, EnumerationOptions enumerationOptions)
+        {
+            return instance.GetFileSystemInfos(searchPattern, enumerationOptions).WrapFileSystemInfos(FileSystem);
+        }
+#endif
 
         public override void MoveTo(string destDirName)
         {

--- a/src/System.IO.Abstractions/DirectoryWrapper.cs
+++ b/src/System.IO.Abstractions/DirectoryWrapper.cs
@@ -79,6 +79,13 @@ namespace System.IO.Abstractions
             return Directory.GetDirectories(path, searchPattern, searchOption);
         }
 
+#if FEATURE_ENUMERATION_OPTIONS
+        public override string[] GetDirectories(string path, string searchPattern, EnumerationOptions enumerationOptions)
+        {
+            return Directory.GetDirectories(path, searchPattern, enumerationOptions);
+        }
+#endif
+
         public override string GetDirectoryRoot(string path)
         {
             return Directory.GetDirectoryRoot(path);
@@ -98,6 +105,13 @@ namespace System.IO.Abstractions
         {
             return Directory.GetFiles(path, searchPattern, searchOption);
         }
+
+#if FEATURE_ENUMERATION_OPTIONS
+        public override string[] GetFiles(string path, string searchPattern, EnumerationOptions enumerationOptions)
+        {
+            return Directory.GetFiles(path, searchPattern, enumerationOptions);
+        }
+#endif
 
         public override string[] GetFileSystemEntries(string path)
         {

--- a/src/System.IO.Abstractions/IDirectory.cs
+++ b/src/System.IO.Abstractions/IDirectory.cs
@@ -39,6 +39,10 @@ namespace System.IO.Abstractions
         string[] GetDirectories(string path, string searchPattern);
         /// <inheritdoc cref="Directory.GetDirectories(string,string,SearchOption)"/>
         string[] GetDirectories(string path, string searchPattern, SearchOption searchOption);
+#if FEATURE_ENUMERATION_OPTIONS
+        /// <inheritdoc cref="Directory.GetDirectories(string,string,EnumerationOptions)"/>
+        string[] GetDirectories(string path, string searchPattern, EnumerationOptions enumerationOptions);
+#endif
         /// <inheritdoc cref="Directory.GetDirectoryRoot"/>
         string GetDirectoryRoot(string path);
         /// <inheritdoc cref="Directory.GetFiles(string)"/>
@@ -47,6 +51,10 @@ namespace System.IO.Abstractions
         string[] GetFiles(string path, string searchPattern);
         /// <inheritdoc cref="Directory.GetFiles(string,string,SearchOption)"/>
         string[] GetFiles(string path, string searchPattern, SearchOption searchOption);
+#if FEATURE_ENUMERATION_OPTIONS
+        /// <inheritdoc cref="Directory.GetFiles(string,string,EnumerationOptions)"/>
+        string[] GetFiles(string path, string searchPattern, EnumerationOptions enumerationOptions);
+#endif
         /// <inheritdoc cref="Directory.GetFileSystemEntries(string)"/>
         string[] GetFileSystemEntries(string path);
         /// <inheritdoc cref="Directory.GetFileSystemEntries(string,string)"/>

--- a/src/System.IO.Abstractions/IDirectoryInfo.cs
+++ b/src/System.IO.Abstractions/IDirectoryInfo.cs
@@ -20,18 +20,35 @@ namespace System.IO.Abstractions
         IEnumerable<IDirectoryInfo> EnumerateDirectories(string searchPattern);
         /// <inheritdoc cref="DirectoryInfo.EnumerateDirectories(string,SearchOption)"/>
         IEnumerable<IDirectoryInfo> EnumerateDirectories(string searchPattern, SearchOption searchOption);
+
+#if FEATURE_ENUMERATION_OPTIONS
+        /// <inheritdoc cref="DirectoryInfo.EnumerateDirectories(string,EnumerationOptions)"/>
+        IEnumerable<IDirectoryInfo> EnumerateDirectories(string searchPattern, EnumerationOptions enumerationOptions);
+#endif
+
         /// <inheritdoc cref="DirectoryInfo.EnumerateFiles()"/>
         IEnumerable<IFileInfo> EnumerateFiles();
         /// <inheritdoc cref="DirectoryInfo.EnumerateFiles(string)"/>
         IEnumerable<IFileInfo> EnumerateFiles(string searchPattern);
         /// <inheritdoc cref="DirectoryInfo.EnumerateFiles(string,SearchOption)"/>
         IEnumerable<IFileInfo> EnumerateFiles(string searchPattern, SearchOption searchOption);
+
+#if FEATURE_ENUMERATION_OPTIONS
+        /// <inheritdoc cref="DirectoryInfo.EnumerateFiles(string,EnumerationOptions)"/>
+        IEnumerable<IFileInfo> EnumerateFiles(string searchPattern, EnumerationOptions enumerationOptions);
+#endif
+
         /// <inheritdoc cref="DirectoryInfo.EnumerateFileSystemInfos()"/>
         IEnumerable<IFileSystemInfo> EnumerateFileSystemInfos();
         /// <inheritdoc cref="DirectoryInfo.EnumerateFileSystemInfos(string)"/>
         IEnumerable<IFileSystemInfo> EnumerateFileSystemInfos(string searchPattern);
         /// <inheritdoc cref="DirectoryInfo.EnumerateFileSystemInfos(string,SearchOption)"/>
         IEnumerable<IFileSystemInfo> EnumerateFileSystemInfos(string searchPattern, SearchOption searchOption);
+
+#if FEATURE_ENUMERATION_OPTIONS
+        /// <inheritdoc cref="DirectoryInfo.EnumerateFileSystemInfos(string,EnumerationOptions)"/>
+        IEnumerable<IFileSystemInfo> EnumerateFileSystemInfos(string searchPattern, EnumerationOptions enumerationOptions);
+#endif
 
         /// <inheritdoc cref="DirectoryInfo.GetAccessControl()"/>
         DirectorySecurity GetAccessControl();
@@ -44,18 +61,36 @@ namespace System.IO.Abstractions
         IDirectoryInfo[] GetDirectories(string searchPattern);
         /// <inheritdoc cref="DirectoryInfo.GetDirectories(string,SearchOption)"/>
         IDirectoryInfo[] GetDirectories(string searchPattern, SearchOption searchOption);
+
+#if FEATURE_ENUMERATION_OPTIONS
+        /// <inheritdoc cref="DirectoryInfo.GetDirectories(string,EnumerationOptions)"/>
+        IDirectoryInfo[] GetDirectories(string searchPattern, EnumerationOptions enumerationOptions);
+#endif
+
         /// <inheritdoc cref="DirectoryInfo.GetFiles(string)"/>
         IFileInfo[] GetFiles();
         /// <inheritdoc cref="DirectoryInfo.GetFiles(string)"/>
         IFileInfo[] GetFiles(string searchPattern);
         /// <inheritdoc cref="DirectoryInfo.GetFiles(string,SearchOption)"/>
         IFileInfo[] GetFiles(string searchPattern, SearchOption searchOption);
+
+#if FEATURE_ENUMERATION_OPTIONS
+        /// <inheritdoc cref="DirectoryInfo.GetFiles(string,EnumerationOptions)"/>
+        IFileInfo[] GetFiles(string searchPattern, EnumerationOptions enumerationOptions);
+#endif
+
         /// <inheritdoc cref="DirectoryInfo.GetFileSystemInfos()"/>
         IFileSystemInfo[] GetFileSystemInfos();
         /// <inheritdoc cref="DirectoryInfo.GetFileSystemInfos(string)"/>
         IFileSystemInfo[] GetFileSystemInfos(string searchPattern);
         /// <inheritdoc cref="DirectoryInfo.GetFileSystemInfos(string,SearchOption)"/>
         IFileSystemInfo[] GetFileSystemInfos(string searchPattern, SearchOption searchOption);
+
+#if FEATURE_ENUMERATION_OPTIONS
+        /// <inheritdoc cref="DirectoryInfo.GetFileSystemInfos(string,EnumerationOptions)"/>
+        IFileSystemInfo[] GetFileSystemInfos(string searchPattern, EnumerationOptions enumerationOptions);
+#endif
+
         /// <inheritdoc cref="DirectoryInfo.MoveTo"/>
         void MoveTo(string destDirName);
 

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "12.1",
+  "version": "12.2",
   "assemblyVersion": {
     "precision": "major"
   },


### PR DESCRIPTION
In .NET Standard 2.1, new method overloads were introduced to DirectoryInfo that take in an EnumerationOptions as a parameter. This PR adds those.