### PR TITLE
Added possibility to fake file size

### DIFF
--- a/src/System.IO.Abstractions.TestingHelpers/MockFileData.cs
+++ b/src/System.IO.Abstractions.TestingHelpers/MockFileData.cs
@@ -10,6 +10,8 @@ namespace System.IO.Abstractions.TestingHelpers
     [Serializable]
     public class MockFileData
     {
+        public const long LengthIsNotFaked = -1;
+
         /// <summary>
         /// The default encoding.
         /// </summary>
@@ -37,6 +39,7 @@ namespace System.IO.Abstractions.TestingHelpers
         /// </summary>
         [NonSerialized]
         private FileSecurity accessControl;
+        private long length = LengthIsNotFaked;
 
         /// <summary>
         /// Gets a value indicating whether the <see cref="MockFileData"/> is a directory or not.
@@ -49,6 +52,16 @@ namespace System.IO.Abstractions.TestingHelpers
         private MockFileData()
         {
             // empty
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MockFileData"/> class with content of a specific size.
+        /// </summary>
+        /// <param name="fileLength">Length of file in bytes</param>
+        public MockFileData(long fileLength)
+            : this(DefaultEncoding.GetBytes("dummy content"))
+        {
+            this.length = fileLength;
         }
 
         /// <summary>
@@ -100,6 +113,22 @@ namespace System.IO.Abstractions.TestingHelpers
             CreationTime = template.CreationTime;
             LastAccessTime = template.LastAccessTime;
             LastWriteTime = template.LastWriteTime;
+        }
+
+
+        public long Length
+        {
+            get
+            {
+                if (length == LengthIsNotFaked)
+                {
+                    return Contents.Length;
+                }
+                else
+                {
+                    return length;
+                }
+            }
         }
 
         /// <summary>

--- a/src/System.IO.Abstractions.TestingHelpers/MockFileData.cs
+++ b/src/System.IO.Abstractions.TestingHelpers/MockFileData.cs
@@ -10,7 +10,7 @@ namespace System.IO.Abstractions.TestingHelpers
     [Serializable]
     public class MockFileData
     {
-        public const long LengthIsNotFaked = -1;
+        private static readonly long LengthIsNotFaked = -1;
 
         /// <summary>
         /// The default encoding.

--- a/src/System.IO.Abstractions.TestingHelpers/MockFileInfo.cs
+++ b/src/System.IO.Abstractions.TestingHelpers/MockFileInfo.cs
@@ -326,7 +326,7 @@ namespace System.IO.Abstractions.TestingHelpers
                 {
                     throw CommonExceptions.FileNotFound(path);
                 }
-                return MockFileData.Contents.Length;
+                return MockFileData.Length;
             }
         }
 

--- a/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileInfoTests.cs
+++ b/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileInfoTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using NUnit.Framework;
 
 namespace System.IO.Abstractions.TestingHelpers.Tests
@@ -70,7 +71,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             const string fileContent = "Demo text content";
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
             {
-                { XFS.Path(@"c:\a.txt"), new MockFileData(fileContent) },
+                { XFS.Path(@"c:\a.txt"), new MockFileData(fileContent)},
                 { XFS.Path(@"c:\a\b\c.txt"), new MockFileData(fileContent) },
             });
             var fileInfo = new MockFileInfo(fileSystem, XFS.Path(@"c:\a.txt"));
@@ -78,6 +79,25 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileInfo.Length;
 
             Assert.AreEqual(fileContent.Length, result);
+        }
+
+        [Test]
+        public void MockFileInfo_Length_ShouldReturnFakedLength()
+        {
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\a.txt"), new MockFileData(200L)},
+                { XFS.Path(@"c:\a\b\c.txt"), new MockFileData(300_000_000L) },
+            });
+            var fileInfo1 = new MockFileInfo(fileSystem, XFS.Path(@"c:\a.txt"));
+
+            var file2 = fileSystem.DirectoryInfo.FromDirectoryName(XFS.Path(@"c:\a\b\")).GetFiles().First();
+            var result2 = file2.Length;
+
+            var result1 = fileInfo1.Length;
+
+            Assert.AreEqual(200, result1);
+            Assert.AreEqual(300_000_000, result2);
         }
 
         [Test]


### PR DESCRIPTION
This PR introduces a way to fake large files without caring about the file content. Useful if you want to test a function which shall limit directory size or file size.