### PR TITLE
ci: remove install steps for .NET SDK

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,26 +17,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Install .NET Core 2.1 SDK
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: "2.1.x"
-      - name: Install .NET Core 3.1 SDK
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: "3.1.x"
-      - name: Merge installed .NET SDKs
-        shell: pwsh
-        run: |
-          $version = Split-Path (Split-Path $ENV:DOTNET_ROOT -Parent) -Leaf;
-          $root = Split-Path (Split-Path $ENV:DOTNET_ROOT -Parent) -Parent;
-          $directories = Get-ChildItem $root | Where-Object { $_.Name -ne $version };
-          foreach ($dir in $directories) {
-            $from = $dir.FullName;
-            $to = "$root/$version";
-            Write-Host Copying from $from to $to;
-            Copy-Item "$from\*" $to -Recurse -Force;
-          }
       - name: Run tests
         run: dotnet test --verbosity normal
   pack:


### PR DESCRIPTION
The build environment now contains the .NET SDK, so we don't need to pull it in additionally.