### PR TITLE
EnumerationOptions With recursion

### DIFF
--- a/src/System.IO.Abstractions.TestingHelpers/MockDirectory.cs
+++ b/src/System.IO.Abstractions.TestingHelpers/MockDirectory.cs
@@ -177,7 +177,7 @@ namespace System.IO.Abstractions.TestingHelpers
 #if FEATURE_ENUMERATION_OPTIONS
         public override string[] GetDirectories(string path, string searchPattern, EnumerationOptions enumerationOptions)
         {
-            return GetDirectories(path, "*");
+            return GetDirectories(path, "*", enumerationOptions.RecurseSubdirectories ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly);
         }
 #endif
 
@@ -206,7 +206,7 @@ namespace System.IO.Abstractions.TestingHelpers
 #if FEATURE_ENUMERATION_OPTIONS
         public override string[] GetFiles(string path, string searchPattern, EnumerationOptions enumerationOptions)
         {
-            return GetFiles(path, "*");
+            return GetFiles(path, "*", enumerationOptions.RecurseSubdirectories ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly);
         }
 #endif
 

--- a/tests/System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryInfoTests.cs
+++ b/tests/System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryInfoTests.cs
@@ -158,6 +158,51 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
+        public void MockDirectoryInfo_EnumerateFileSystemInfos_ShouldReturnDirectoriesAndNamesWithSearchPatternRecursive()
+        {
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\temp\folder\file.txt"), new MockFileData("") },
+                { XFS.Path(@"c:\temp\folder\folder"), new MockDirectoryData() },
+                { XFS.Path(@"c:\temp\folder\older"), new MockDirectoryData() }
+            });
+
+            var directoryInfo = new MockDirectoryInfo(fileSystem, XFS.Path(@"c:\"));
+            var result = directoryInfo.EnumerateFileSystemInfos("*", SearchOption.AllDirectories).ToArray();
+
+            Assert.That(result.Length, Is.EqualTo(5));
+        }
+
+#if FEATURE_ENUMERATION_OPTIONS
+        [Test]
+        public void MockDirectoryInfo_EnumerateFileSystemInfos_ShouldReturnDirectoriesAndNamesWithSearchPatternRecursiveEnumerateOptions()
+        {
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\temp\folder\file.txt"), new MockFileData("") },
+                { XFS.Path(@"c:\temp\folder\folder"), new MockDirectoryData() },
+                { XFS.Path(@"c:\temp\folder\older"), new MockDirectoryData() }
+            });
+
+            var directoryInfo = new MockDirectoryInfo(fileSystem, XFS.Path(@"c:\"));
+
+            var enumerationOptions = new EnumerationOptions()
+            {
+                MatchType = MatchType.Win32,
+                RecurseSubdirectories = true,
+                IgnoreInaccessible = true,
+                ReturnSpecialDirectories = false,
+                AttributesToSkip = FileAttributes.Hidden,
+                MatchCasing = MatchCasing.PlatformDefault,
+            };
+
+            var result = directoryInfo.EnumerateFileSystemInfos("*", enumerationOptions).ToArray();
+
+            Assert.That(result.Length, Is.EqualTo(5));
+        }
+#endif
+
+        [Test]
         public void MockDirectoryInfo_GetParent_ShouldReturnDirectoriesAndNamesWithSearchPattern()
         {
             // Arrange


### PR DESCRIPTION
See issue #651

It looks like the code is not checking the `EnumerationOptions.RecurseSubdirectories`.

This fixes my problem with the recursion, but I see more problems in the future with the following settings in:
* MatchType = MatchType.Win32,
* IgnoreInaccessible
* ReturnSpecialDirectories
* AttributesToSkip
* MatchCasing

Will creating a seperate issue for these.