### PR TITLE
feat: increase MockFileSystem constructor speed

### DIFF
--- a/src/System.IO.Abstractions.TestingHelpers/MockFileSystem.cs
+++ b/src/System.IO.Abstractions.TestingHelpers/MockFileSystem.cs
@@ -253,21 +253,21 @@ namespace System.IO.Abstractions.TestingHelpers
 
             lock (@lock)
             {
-                MoveFiles(files, sourcePathSequence, sourcePath, destPath);
-                MoveFiles(directories, sourcePathSequence, sourcePath, destPath);
+                Move(files, sourcePathSequence, sourcePath, destPath);
+                Move(directories, sourcePathSequence, sourcePath, destPath);
             }
 
-            void MoveFiles<T>(IDictionary<string, T> dictionary, string[] sourcePathSequence, string sourcePath, string destPath)
+            void Move(IDictionary<string, MockFileData> nodes, string[] sourcePathSequence, string sourcePath, string destPath)
             {
-                var affectedPaths = dictionary.Keys
+                var affectedPaths = nodes.Keys
                     .Where(p => PathStartsWith(p, sourcePathSequence))
                     .ToList();
 
                 foreach (var path in affectedPaths)
                 {
                     var newPath = StringOperations.Replace(path, sourcePath, destPath);
-                    dictionary[newPath] = dictionary[path];
-                    dictionary.Remove(path);
+                    nodes[newPath] = nodes[path];
+                    nodes.Remove(path);
                 }
             }
 
@@ -376,7 +376,9 @@ namespace System.IO.Abstractions.TestingHelpers
             lock (@lock)
             {
                 if(files.TryGetValue(path, out var fileResult))
+                {
                     return fileResult;
+                }
                 directories.TryGetValue(path, out var directoryResult);
                 return directoryResult;
             }

--- a/src/System.IO.Abstractions.TestingHelpers/MockFileSystem.cs
+++ b/src/System.IO.Abstractions.TestingHelpers/MockFileSystem.cs
@@ -15,7 +15,7 @@ namespace System.IO.Abstractions.TestingHelpers
 
         private readonly object @lock = new object();
         private readonly IDictionary<string, MockFileData> files;
-        private readonly IDictionary<string, MockDirectoryData> directories;
+        private readonly IDictionary<string, MockFileData> directories;
         private readonly PathVerifier pathVerifier;
 
         public MockFileSystem() : this(null) { }
@@ -36,7 +36,7 @@ namespace System.IO.Abstractions.TestingHelpers
             StringOperations = new StringOperations(XFS.IsUnixPlatform());
             pathVerifier = new PathVerifier(this);
             this.files = new Dictionary<string, MockFileData>(StringOperations.Comparer);
-            this.directories = new Dictionary<string, MockDirectoryData>(StringOperations.Comparer);
+            this.directories = new Dictionary<string, MockFileData>(StringOperations.Comparer);
 
             Path = new MockPath(this, defaultTempDirectory);
             File = new MockFile(this);
@@ -124,10 +124,14 @@ namespace System.IO.Abstractions.TestingHelpers
         private void SetEntry(string path, MockFileData mockFile)
         {
             path = FixPath(path, true).TrimSlashes();
-            if (mockFile is MockDirectoryData directory)
-                directories[path] = directory;
+            if (mockFile.IsDirectory)
+            {
+                directories[path] = mockFile;
+            }
             else
+            {
                 files[path] = mockFile;
+            }
         }
 
         public void AddFile(string path, MockFileData mockFile)

--- a/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
+++ b/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
@@ -356,13 +356,13 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         public void MockFileSystem_Constructor_InitializedQuicklyWithLargeAmountOfData()
         {
             var testData = Enumerable.Range(0, 100000).ToDictionary(
-                i =>  XFS.Path(@$"C:\{string.Join("\\", Enumerable.Range(0, i % 10).Select(i => i.ToString()))}\{i}.bin"),
+                i =>  XFS.Path(@$"C:\{string.Join("\\", Enumerable.Range(0, i % 7).Select(i => i.ToString()))}\{i}.bin"),
                 i => (MockFileData)i.ToString());
-
             var stopWatch = Stopwatch.StartNew();
-            var mockFileSystem = new MockFileSystem(testData);
-            stopWatch.Stop();
 
+            var mockFileSystem = new MockFileSystem(testData);
+
+            stopWatch.Stop();
             Assert.IsTrue(stopWatch.Elapsed < TimeSpan.FromMinutes(1));
         }
 

--- a/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
+++ b/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
@@ -357,13 +357,13 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         {
             var testData = Enumerable.Range(0, 100000).ToDictionary(
                 i =>  XFS.Path(@$"C:\{string.Join("\\", Enumerable.Range(0, i % 7).Select(i => i.ToString()))}\{i}.bin"),
-                i => (MockFileData)i.ToString());
+                i => new MockFileData(i.ToString()));
             var stopWatch = Stopwatch.StartNew();
 
             var mockFileSystem = new MockFileSystem(testData);
 
             stopWatch.Stop();
-            Assert.IsTrue(stopWatch.Elapsed < TimeSpan.FromMinutes(1));
+            Assert.IsTrue(stopWatch.Elapsed < TimeSpan.FromSeconds(30));
         }
 
         [Test]

--- a/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
+++ b/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
@@ -360,6 +360,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 i => new MockFileData(i.ToString()));
             var stopWatch = Stopwatch.StartNew();
 
+
             var mockFileSystem = new MockFileSystem(testData);
 
             stopWatch.Stop();

--- a/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
+++ b/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
@@ -353,6 +353,20 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
+        public void MockFileSystem_Constructor_InitializedQuicklyWithLargeAmountOfData()
+        {
+            var testData = Enumerable.Range(0, 100000).ToDictionary(
+                i =>  XFS.Path(@$"C:\{string.Join("\\", Enumerable.Range(0, i % 10).Select(i => i.ToString()))}\{i}.bin"),
+                i => (MockFileData)i.ToString());
+
+            var stopWatch = Stopwatch.StartNew();
+            var mockFileSystem = new MockFileSystem(testData);
+            stopWatch.Stop();
+
+            Assert.IsTrue(stopWatch.Elapsed < TimeSpan.FromMinutes(1));
+        }
+
+        [Test]
         public void MockFileSystem_DefaultState_DefaultTempDirectoryExists()
         {
             var tempDirectory = XFS.Path(@"C:\temp");
@@ -362,18 +376,6 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             Assert.IsTrue(mockFileSystem.Directory.Exists(tempDirectory));
             Assert.IsTrue(mockFileSystemOverload.Directory.Exists(tempDirectory));
-        }
-
-        [Test]
-        public void MockFileSystem_Constructor_InitializedQuicklyWithLargeAmountOfData()
-        {
-            var watch = new Stopwatch();
-            var testData = Enumerable.Range(0, 100000).ToDictionary(
-                i => @$"C:\{string.Join("\\", Enumerable.Range(0, i % 10).Select(i => i.ToString()))}\{i}.bin", i => (MockFileData)i.ToString());
-            watch.Start();
-            var mockFileSystem = new MockFileSystem(testData);
-            watch.Stop();
-            Console.Write(watch.Elapsed.TotalSeconds);
         }
 
         [Test]

--- a/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
+++ b/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
@@ -360,7 +360,6 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 i => new MockFileData(i.ToString()));
             var stopWatch = Stopwatch.StartNew();
 
-
             var mockFileSystem = new MockFileSystem(testData);
 
             stopWatch.Stop();

--- a/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
+++ b/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using System.Text;
@@ -361,6 +362,18 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             Assert.IsTrue(mockFileSystem.Directory.Exists(tempDirectory));
             Assert.IsTrue(mockFileSystemOverload.Directory.Exists(tempDirectory));
+        }
+
+        [Test]
+        public void MockFileSystem_Constructor_InitializedQuicklyWithLargeAmountOfData()
+        {
+            var watch = new Stopwatch();
+            var testData = Enumerable.Range(0, 100000).ToDictionary(
+                i => @$"C:\{string.Join("\\", Enumerable.Range(0, i % 10).Select(i => i.ToString()))}\{i}.bin", i => (MockFileData)i.ToString());
+            watch.Start();
+            var mockFileSystem = new MockFileSystem(testData);
+            watch.Stop();
+            Console.Write(watch.Elapsed.TotalSeconds);
         }
 
         [Test]

--- a/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
+++ b/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
@@ -356,7 +356,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         public void MockFileSystem_Constructor_InitializedQuicklyWithLargeAmountOfData()
         {
             var testData = Enumerable.Range(0, 100000).ToDictionary(
-                i =>  XFS.Path(@$"C:\{string.Join("\\", Enumerable.Range(0, i % 7).Select(i => i.ToString()))}\{i}.bin"),
+                i =>  XFS.Path(@$"C:\{string.Join("\\", Enumerable.Range(0, i % 8 + 1).Select(i => i.ToString()))}\{i}.bin"),
                 i => new MockFileData(i.ToString()));
             var stopWatch = Stopwatch.StartNew();
 


### PR DESCRIPTION
The `MockFileSystem` constructor builds the internal `IDictionary<string, MockFileData>` from a given one. While doing so, its performance decreased significantly with large data sets.

This PR splits the internal dictionary into one containing the files and one containing the directories. Some of our internal test durations were decreased by a factor >10 with these changes.

We would be happy if we could get this speedup out of the box.