### PR TITLE
feat: speed up MockFileSystem constructor

### DIFF
--- a/benchmarks/System.IO.Abstractions.Benchmarks/MockFileSystemBenchmarks.cs
+++ b/benchmarks/System.IO.Abstractions.Benchmarks/MockFileSystemBenchmarks.cs
@@ -10,9 +10,9 @@ namespace System.IO.Abstractions.Benchmarks
     [MemoryDiagnoser]
     public class MockFileSystemBenchmarks
     {
-        private static readonly Dictionary<string, MockFileData> testData = CreateTestData();
+        private readonly Dictionary<string, MockFileData> testData = CreateTestData();
 
-        private static Dictionary<string, MockFileData> CreateTestData()
+        private Dictionary<string, MockFileData> CreateTestData()
         {
             var filesCount = 100000;
             var maxDirectoryDepth = 8;

--- a/benchmarks/System.IO.Abstractions.Benchmarks/MockFileSystemBenchmarks.cs
+++ b/benchmarks/System.IO.Abstractions.Benchmarks/MockFileSystemBenchmarks.cs
@@ -10,16 +10,15 @@ namespace System.IO.Abstractions.Benchmarks
     [MemoryDiagnoser]
     public class MockFileSystemBenchmarks
     {
-        private Dictionary<string, MockFileData> testData = CreateTestData();
+        private static readonly Dictionary<string, MockFileData> testData = CreateTestData();
 
         private static Dictionary<string, MockFileData> CreateTestData()
         {
             var filesCount = 100000;
             var maxDirectoryDepth = 8;
-            var testData = Enumerable.Range(0, filesCount).ToDictionary(
+            return Enumerable.Range(0, filesCount).ToDictionary(
                 i => XFS.Path(@$"C:\{string.Join(@"\", Enumerable.Range(0, i % maxDirectoryDepth + 1).Select(i => i.ToString()))}\{i}.bin"),
                 i => new MockFileData(i.ToString()));
-            return testData;
         }
 
         [Benchmark]

--- a/benchmarks/System.IO.Abstractions.Benchmarks/MockFileSystemBenchmarks.cs
+++ b/benchmarks/System.IO.Abstractions.Benchmarks/MockFileSystemBenchmarks.cs
@@ -12,7 +12,7 @@ namespace System.IO.Abstractions.Benchmarks
     {
         private readonly Dictionary<string, MockFileData> testData = CreateTestData();
 
-        private Dictionary<string, MockFileData> CreateTestData()
+        private static Dictionary<string, MockFileData> CreateTestData()
         {
             var filesCount = 100000;
             var maxDirectoryDepth = 8;

--- a/benchmarks/System.IO.Abstractions.Benchmarks/MockFileSystemBenchmarks.cs
+++ b/benchmarks/System.IO.Abstractions.Benchmarks/MockFileSystemBenchmarks.cs
@@ -1,0 +1,28 @@
+﻿using BenchmarkDotNet.Attributes;
+using System.Collections.Generic;
+using System.IO.Abstractions.TestingHelpers;
+using System.Linq;
+using XFS = System.IO.Abstractions.TestingHelpers.MockUnixSupport;
+
+namespace System.IO.Abstractions.Benchmarks
+{
+    [RPlotExporter]
+    [MemoryDiagnoser]
+    public class MockFileSystemBenchmarks
+    {
+        private Dictionary<string, MockFileData> testData = CreateTestData();
+
+        private static Dictionary<string, MockFileData> CreateTestData()
+        {
+            var filesCount = 100000;
+            var maxDirectoryDepth = 8;
+            var testData = Enumerable.Range(0, filesCount).ToDictionary(
+                i => XFS.Path(@$"C:\{string.Join(@"\", Enumerable.Range(0, i % maxDirectoryDepth + 1).Select(i => i.ToString()))}\{i}.bin"),
+                i => new MockFileData(i.ToString()));
+            return testData;
+        }
+
+        [Benchmark]
+        public MockFileSystem MockFileSystem_Constructor() => new MockFileSystem(testData);
+    }
+}

--- a/benchmarks/System.IO.Abstractions.Benchmarks/Program.cs
+++ b/benchmarks/System.IO.Abstractions.Benchmarks/Program.cs
@@ -1,12 +1,13 @@
 ﻿namespace System.IO.Abstractions.Benchmarks
 {
     using BenchmarkDotNet.Running;
+    using System.Reflection;
 
     class Program
     {
         public static void Main(string[] args)
         {
-            BenchmarkRunner.Run<FileSystemAbstractionBenchmarks>();
+            BenchmarkRunner.Run(typeof(Program).Assembly);
         }
     }
 }

--- a/benchmarks/System.IO.Abstractions.Benchmarks/System.IO.Abstractions.Benchmarks.csproj
+++ b/benchmarks/System.IO.Abstractions.Benchmarks/System.IO.Abstractions.Benchmarks.csproj
@@ -14,6 +14,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<ProjectReference Include="../../src/System.IO.Abstractions/System.IO.Abstractions.csproj" />
+		<ProjectReference Include="../../src/System.IO.Abstractions.TestingHelpers/System.IO.Abstractions.TestingHelpers.csproj" />
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net461" Version="1.0.0">

--- a/src/System.IO.Abstractions.TestingHelpers/MockFileSystem.cs
+++ b/src/System.IO.Abstractions.TestingHelpers/MockFileSystem.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-
 using System.Globalization;
 using System.Linq;
 using System.Reflection;

--- a/src/System.IO.Abstractions.TestingHelpers/MockFileSystem.cs
+++ b/src/System.IO.Abstractions.TestingHelpers/MockFileSystem.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+
 using System.Globalization;
 using System.Linq;
 using System.Reflection;

--- a/src/System.IO.Abstractions.TestingHelpers/MockFileSystem.cs
+++ b/src/System.IO.Abstractions.TestingHelpers/MockFileSystem.cs
@@ -357,7 +357,7 @@ namespace System.IO.Abstractions.TestingHelpers
         {
             lock (files)
             {
-                return files.TryGetValue(path, out var result) ? result.Data : default(MockFileData) ;
+                return files.TryGetValue(path, out var result) ? result.Data : null;
             }
         }
 

--- a/src/System.IO.Abstractions.TestingHelpers/MockFileSystem.cs
+++ b/src/System.IO.Abstractions.TestingHelpers/MockFileSystem.cs
@@ -103,7 +103,6 @@ namespace System.IO.Abstractions.TestingHelpers
 
                 if (DirectoryExistsWithoutFixingPath(leftHalf))
                 {
-                    leftHalf = Path.GetFullPath(leftHalf).TrimSlashes();
                     string baseDirectory = files[leftHalf].Path;
                     return baseDirectory + Path.DirectorySeparatorChar + rightHalf;
                 }
@@ -358,7 +357,7 @@ namespace System.IO.Abstractions.TestingHelpers
         {
             lock (files)
             {
-                return files.TryGetValue(path, out var result) ? result.Data : null;
+                return files.TryGetValue(path, out var result) ? result.Data : default(MockFileData) ;
             }
         }
 

--- a/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
+++ b/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
@@ -353,7 +353,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
-        public void MockFileSystem_Constructor_InitializedQuicklyWithLargeAmountOfData()
+        public void MockFileSystem_Constructor_ShouldInitializeFastWithLargeAmountOfFiles()
         {
             var filesCount = 100000;
             var maxDirectoryDepth = 8;

--- a/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
+++ b/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
@@ -355,7 +355,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         [Test]
         public void MockFileSystem_Constructor_InitializedQuicklyWithLargeAmountOfData()
         {
-            var filesCount = 1000000;
+            var filesCount = 100000;
             var maxDirectoryDepth = 8;
             var testData = Enumerable.Range(0, filesCount).ToDictionary(
                 i => XFS.Path(@$"C:\{string.Join("\\", Enumerable.Range(0, i % maxDirectoryDepth + 1).Select(i => i.ToString()))}\{i}.bin"),

--- a/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
+++ b/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
@@ -353,7 +353,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
-        public void MockFileSystem_Constructor_ShouldInitializeFastWithLargeAmountOfFiles()
+        public void MockFileSystem_Constructor_ShouldExecuteFastWithLargeAmountOfFiles()
         {
             var filesCount = 100000;
             var maxDirectoryDepth = 8;

--- a/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
+++ b/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
@@ -358,7 +358,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var filesCount = 100000;
             var maxDirectoryDepth = 8;
             var testData = Enumerable.Range(0, filesCount).ToDictionary(
-                i => XFS.Path(@$"C:\{string.Join("\\", Enumerable.Range(0, i % maxDirectoryDepth + 1).Select(i => i.ToString()))}\{i}.bin"),
+                i => XFS.Path(@$"C:\{string.Join(@"\", Enumerable.Range(0, i % maxDirectoryDepth + 1).Select(i => i.ToString()))}\{i}.bin"),
                 i => new MockFileData(i.ToString()));
             var stopWatch = Stopwatch.StartNew();
 

--- a/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
+++ b/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
@@ -353,22 +353,6 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
-        public void MockFileSystem_Constructor_ShouldExecuteFastWithLargeAmountOfFiles()
-        {
-            var filesCount = 100000;
-            var maxDirectoryDepth = 8;
-            var testData = Enumerable.Range(0, filesCount).ToDictionary(
-                i => XFS.Path(@$"C:\{string.Join(@"\", Enumerable.Range(0, i % maxDirectoryDepth + 1).Select(i => i.ToString()))}\{i}.bin"),
-                i => new MockFileData(i.ToString()));
-            var stopWatch = Stopwatch.StartNew();
-
-            var mockFileSystem = new MockFileSystem(testData);
-
-            stopWatch.Stop();
-            Assert.IsTrue(stopWatch.Elapsed < TimeSpan.FromSeconds(30));
-        }
-
-        [Test]
         public void MockFileSystem_DefaultState_DefaultTempDirectoryExists()
         {
             var tempDirectory = XFS.Path(@"C:\temp");

--- a/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
+++ b/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using System.Text;
@@ -349,6 +350,22 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 new MockFileSystem(null, "non-rooted")
             );
             Assert.AreEqual("currentDirectory", ae.ParamName);
+        }
+
+        [Test]
+        public void MockFileSystem_Constructor_InitializedQuicklyWithLargeAmountOfData()
+        {
+            var filesCount = 1000000;
+            var maxDirectoryDepth = 8;
+            var testData = Enumerable.Range(0, filesCount).ToDictionary(
+                i => XFS.Path(@$"C:\{string.Join("\\", Enumerable.Range(0, i % maxDirectoryDepth + 1).Select(i => i.ToString()))}\{i}.bin"),
+                i => new MockFileData(i.ToString()));
+            var stopWatch = Stopwatch.StartNew();
+
+            var mockFileSystem = new MockFileSystem(testData);
+
+            stopWatch.Stop();
+            Assert.IsTrue(stopWatch.Elapsed < TimeSpan.FromSeconds(30));
         }
 
         [Test]


### PR DESCRIPTION
This PR is an alternative to the PR #695. It has a slightly better performance and does not change the concept of having all paths in one collection.
I created this PR after discussion with @jflepp.