### PR TITLE
fix: file move after directory move doesn't work correctly

### DIFF
--- a/src/System.IO.Abstractions.TestingHelpers/MockFileSystem.cs
+++ b/src/System.IO.Abstractions.TestingHelpers/MockFileSystem.cs
@@ -249,7 +249,9 @@ namespace System.IO.Abstractions.TestingHelpers
                 foreach (var path in affectedPaths)
                 {
                     var newPath = StringOperations.Replace(path, sourcePath, destPath);
-                    files[newPath] = files[path];
+                    var entry = files[path];
+                    entry.Path = newPath;
+                    files[newPath] = entry;
                     files.Remove(path);
                 }
             }

--- a/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
+++ b/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
@@ -254,13 +254,13 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         public void MockFileSystem_MoveDirectoryAndFile_ShouldMoveCorrectly()
         {
             var fileSystem = new MockFileSystem();
-            fileSystem.AddFile(@"C:\project1\project1.txt", string.Empty);
-            fileSystem.AddFile(@"C:\project1\subdir\other.txt", string.Empty);
+            fileSystem.AddFile(XFS.Path(@"C:\project1\project1.txt"), string.Empty);
+            fileSystem.AddFile(XFS.Path(@"C:\project1\subdir\other.txt"), string.Empty);
 
-            fileSystem.Directory.Move(@"C:\project1", @"C:\proj1");
-            fileSystem.File.Move(@"C:\proj1\project1.txt", @"C:\proj1\proj1.txt");
+            fileSystem.Directory.Move(XFS.Path(@"C:\project1"), XFS.Path(@"C:\proj1"));
+            fileSystem.File.Move(XFS.Path(@"C:\proj1\project1.txt"), XFS.Path(@"C:\proj1\proj1.txt"));
 
-            var expected = new[] { @"C:\proj1\proj1.txt", @"C:\proj1\subdir\other.txt" };
+            var expected = new[] { XFS.Path(@"C:\proj1\proj1.txt"), XFS.Path(@"C:\proj1\subdir\other.txt") };
             CollectionAssert.AreEquivalent(expected, fileSystem.AllFiles);
         }
 

--- a/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
+++ b/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
@@ -251,6 +251,20 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
+        public void MockFileSystem_MoveDirectoryAndFile_ShouldMoveCorrectly()
+        {
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddFile(@"C:\project1\project1.txt", string.Empty);
+            fileSystem.AddFile(@"C:\project1\subdir\other.txt", string.Empty);
+
+            fileSystem.Directory.Move(@"C:\project1", @"C:\proj1");
+            fileSystem.File.Move(@"C:\proj1\project1.txt", @"C:\proj1\proj1.txt");
+
+            var expected = new[] { @"C:\proj1\proj1.txt", @"C:\proj1\subdir\other.txt" };
+            CollectionAssert.AreEquivalent(expected, fileSystem.AllFiles);
+        }
+
+        [Test]
         public void MockFileSystem_RemoveFile_RemovesFiles()
         {
             var fileSystem = new MockFileSystem();

--- a/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
+++ b/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
@@ -254,13 +254,13 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         public void MockFileSystem_MoveDirectoryAndFile_ShouldMoveCorrectly()
         {
             var fileSystem = new MockFileSystem();
-            fileSystem.AddFile(XFS.Path(@"C:\project1\project1.txt"), string.Empty);
-            fileSystem.AddFile(XFS.Path(@"C:\project1\subdir\other.txt"), string.Empty);
+            fileSystem.AddFile(XFS.Path(@"C:\source\project.txt"), string.Empty);
+            fileSystem.AddFile(XFS.Path(@"C:\source\subdir\other.txt"), string.Empty);
 
-            fileSystem.Directory.Move(XFS.Path(@"C:\project1"), XFS.Path(@"C:\proj1"));
-            fileSystem.File.Move(XFS.Path(@"C:\proj1\project1.txt"), XFS.Path(@"C:\proj1\proj1.txt"));
+            fileSystem.Directory.Move(XFS.Path(@"C:\source"), XFS.Path(@"C:\target"));
+            fileSystem.File.Move(XFS.Path(@"C:\target\project.txt"), XFS.Path(@"C:\target\proj.txt"));
 
-            var expected = new[] { XFS.Path(@"C:\proj1\proj1.txt"), XFS.Path(@"C:\proj1\subdir\other.txt") };
+            var expected = new[] { XFS.Path(@"C:\target\proj.txt"), XFS.Path(@"C:\target\subdir\other.txt") };
             CollectionAssert.AreEquivalent(expected, fileSystem.AllFiles);
         }
 

--- a/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
+++ b/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
-using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using System.Text;


### PR DESCRIPTION
This bug was introduced by #698 