### PR TITLE
fix: Updated MockDirectoryInfo.Name to be consistent with DirectoryInfo.Name

### DIFF
--- a/src/System.IO.Abstractions.TestingHelpers/MockDirectoryInfo.cs
+++ b/src/System.IO.Abstractions.TestingHelpers/MockDirectoryInfo.cs
@@ -120,7 +120,11 @@ namespace System.IO.Abstractions.TestingHelpers
 
         public override string Name
         {
-            get { return new MockPath(mockFileDataAccessor).GetFileName(directoryPath.TrimEnd(mockFileDataAccessor.Path.DirectorySeparatorChar)); }
+            get
+            {
+                var mockPath = new MockPath(mockFileDataAccessor);
+                return string.Equals(mockPath.GetPathRoot(directoryPath), directoryPath) ? directoryPath : mockPath.GetFileName(directoryPath.TrimEnd(mockFileDataAccessor.Path.DirectorySeparatorChar));
+            }
         }
 
         public override void Create()

--- a/tests/System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryInfoTests.cs
+++ b/tests/System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryInfoTests.cs
@@ -324,6 +324,21 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             Assert.AreEqual(expectedName, actualName);
         }
 
+        [TestCase(@"c:\", @"c:\")]
+        [WindowsOnly(WindowsSpecifics.Drives)]
+        public void MockDirectoryInfo_Name_ShouldReturnPathRoot_IfDirectoryPathIsPathRoot(string directoryPath, string expectedName)
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            var directoryInfo = new MockDirectoryInfo(fileSystem, directoryPath);
+
+            // Act
+            var actualName = directoryInfo.Name;
+
+            // Assert
+            Assert.AreEqual(expectedName, actualName);
+        }
+
         [Test]
         public void MockDirectoryInfo_Constructor_ShouldThrowArgumentNullException_IfArgumentDirectoryIsNull()
         {


### PR DESCRIPTION
Fixes #697. When constructed with only the root; MockDirectoryInfo.Name now returns the the root value instead of an empty string. Making it consistent with DirectoryInfo.Name.