### PR TITLE
fix: #739 - MockDirectory.GetDirectories empty searchOption

### DIFF
--- a/src/System.IO.Abstractions.TestingHelpers/MockDirectory.cs
+++ b/src/System.IO.Abstractions.TestingHelpers/MockDirectory.cs
@@ -230,6 +230,11 @@ namespace System.IO.Abstractions.TestingHelpers
             }
 
             CheckSearchPattern(searchPattern);
+            if (searchPattern.Equals(string.Empty, StringComparison.OrdinalIgnoreCase))
+            {
+                searchPattern = "*";
+            }
+
             path = path.TrimSlashes();
             path = path.NormalizeSlashes();
             path = mockFileDataAccessor.Path.GetFullPath(path);

--- a/tests/System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
+++ b/tests/System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
@@ -11,6 +11,50 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
     public class MockDirectoryTests
     {
         [Test]
+        public void MockDirectory_GetFiles_ShouldReturnAllFilesBelowPathWhenPatternIsEmptyAndSearchOptionIsAllDirectories()
+        {
+            // Arrange
+            var fileSystem = SetupFileSystem();
+            var expected = new[]
+            {
+                XFS.Path(@"c:\a\a.txt"),
+                XFS.Path(@"c:\a\b.gif"),
+                XFS.Path(@"c:\a\c.txt"),
+                XFS.Path(@"c:\a\d"),
+                XFS.Path(@"c:\a\a\a.txt"),
+                XFS.Path(@"c:\a\a\b.txt"),
+                XFS.Path(@"c:\a\a\c.gif"),
+                XFS.Path(@"c:\a\a\d")
+            };
+
+            // Act
+            var result = fileSystem.Directory.GetFiles(XFS.Path(@"c:\a"), "", SearchOption.AllDirectories);
+
+            // Assert
+            Assert.That(result, Is.EquivalentTo(expected));
+        }
+
+        [Test]
+        public void MockDirectory_GetFiles_ShouldReturnFilesDirectlyBelowPathWhenPatternIsEmptyAndSearchOptionIsTopDirectoryOnly()
+        {
+            // Arrange
+            var fileSystem = SetupFileSystem();
+            var expected = new[]
+            {
+                XFS.Path(@"c:\a\a.txt"),
+                XFS.Path(@"c:\a\b.gif"),
+                XFS.Path(@"c:\a\c.txt"),
+                XFS.Path(@"c:\a\d")
+            };
+
+            // Act
+            var result = fileSystem.Directory.GetFiles(XFS.Path(@"c:\a"), "", SearchOption.TopDirectoryOnly);
+
+            // Assert
+            Assert.That(result, Is.EquivalentTo(expected));
+        }
+
+        [Test]
         public void MockDirectory_GetFiles_ShouldReturnAllFilesBelowPathWhenPatternIsWildcardAndSearchOptionIsAllDirectories()
         {
             // Arrange


### PR DESCRIPTION
This PR fixes #739 and also adds corresponding tests.