### PR TITLE
feat: Adding 'SubDirectory' and 'File' extension methods to IDirectoryInfo

### DIFF
--- a/src/System.IO.Abstractions/IDirectoryInfoExtensions.cs
+++ b/src/System.IO.Abstractions/IDirectoryInfoExtensions.cs
@@ -1,0 +1,27 @@
+﻿namespace System.IO.Abstractions
+{
+    public static class IDirectoryInfoExtensions
+    {
+        /// <summary>
+        /// Get an <see cref="IDirectoryInfo"/> for the specified sub-directory <paramref name="name"/>
+        /// </summary>
+        /// <param name="info"></param>
+        /// <param name="name">Sub-directory name (ex. "test")</param>
+        /// <returns>An <see cref="IDirectoryInfo"/> for the specified sub-directory</returns>
+        public static IDirectoryInfo SubDirectory(this IDirectoryInfo info, string name)
+        {
+            return info.FileSystem.DirectoryInfo.FromDirectoryName(info.FileSystem.Path.Combine(info.FullName, name));
+        }
+
+        /// <summary>
+        /// Get an <see cref="IFileInfo"/> for the specified file <paramref name="name"/>
+        /// </summary>
+        /// <param name="info"></param>
+        /// <param name="name">File name (ex. "test.txt")</param>
+        /// <returns>An <see cref="IFileInfo"/> for the specified file</returns>
+        public static IFileInfo File(this IDirectoryInfo info, string name)
+        {
+            return info.FileSystem.FileInfo.FromFileName(info.FileSystem.Path.Combine(info.FullName, name));
+        }
+    }
+}

--- a/tests/System.IO.Abstractions.Tests/DirectoryInfoExtensionsTests.cs
+++ b/tests/System.IO.Abstractions.Tests/DirectoryInfoExtensionsTests.cs
@@ -1,0 +1,61 @@
+﻿using NUnit.Framework;
+
+namespace System.IO.Abstractions.Tests
+{
+    [TestFixture]
+    public class DirectoryInfoExtensionsTests
+    {
+        [Test]
+        public void SubDirectory_Extension_Test()
+        {
+            //arrange
+            var fs = new FileSystem();
+            var current =  fs.DirectoryInfo.FromDirectoryName(fs.Directory.GetCurrentDirectory());
+            var guid = Guid.NewGuid().ToString();
+            var expectedPath = fs.Path.Combine(current.FullName, guid);
+
+            //make sure directory doesn't exists
+            Assert.IsFalse(fs.Directory.Exists(expectedPath));
+
+            //create directory
+            var created = current.SubDirectory(guid);
+            created.Create();
+
+            //assert it exists
+            Assert.IsTrue(fs.Directory.Exists(expectedPath));
+            Assert.AreEqual(expectedPath, created.FullName);
+
+            //delete directory
+            created.Delete();
+            Assert.IsFalse(fs.Directory.Exists(expectedPath));
+        }
+
+        [Test]
+        public void File_Extension_Test()
+        {
+            //arrange
+            var fs = new FileSystem();
+            var current = fs.DirectoryInfo.FromDirectoryName(fs.Directory.GetCurrentDirectory());
+            var guid = Guid.NewGuid().ToString();
+            var expectedPath = fs.Path.Combine(current.FullName, guid);
+
+            //make sure file doesn't exists
+            Assert.IsFalse(fs.File.Exists(expectedPath));
+
+            //create file
+            var created = current.File(guid);
+            using (var stream = created.Create())
+            {
+                stream.Dispose();
+            }
+
+            //assert it exists
+            Assert.IsTrue(fs.File.Exists(expectedPath));
+            Assert.AreEqual(expectedPath, created.FullName);
+
+            //delete file
+            created.Delete();
+            Assert.IsFalse(fs.File.Exists(expectedPath));
+        }
+    }
+}


### PR DESCRIPTION
A couple of simple extensions methods for IDirectoryInfo that I personally find extremely useful and saves me a lot of boilerplate code. I thought to share.