### PR TITLE
fix: Add TypeForwardedTo attribute to forward IFileSystem usage to its new…

### DIFF
--- a/src/TestableIO.System.IO.Abstractions/AssemblyRedirects.cs
+++ b/src/TestableIO.System.IO.Abstractions/AssemblyRedirects.cs
@@ -1,0 +1,4 @@
+﻿using System.IO.Abstractions;
+using System.Runtime.CompilerServices;
+
+[assembly: TypeForwardedTo(typeof(IFileSystem))]


### PR DESCRIPTION
This PR adds `TypeForwardedToAttribute` to fix a problem where a transitive dependency on ver 21 can't find `IFileSystem` interface that was moved to a separate assembly in version 22.

Using the attribute, allows third parties that are built with ver 21 to be redirected to `Testably.Abstractions.FileSystem.Interface.dll` when trying to resolve the interface in its old location: `TestableIO.System.IO.Abstractions.dll`

This change adds backwards compatibility with ver 21. 
Users of ver 22 are not affected in any way.