### PR TITLE
fix: make invalid UNC path error message platform-specific

### DIFF
--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/CommonExceptions.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/CommonExceptions.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Runtime.InteropServices;
 
 namespace System.IO.Abstractions.TestingHelpers;
 
@@ -55,7 +56,9 @@ internal static class CommonExceptions
             : new ArgumentException(StringResources.Manager.GetString("ILLEGAL_CHARACTERS_IN_PATH_EXCEPTION"));
 
     public static ArgumentException InvalidUncPath(string paramName) =>
-        new ArgumentException(@"The UNC path should be of the form \\server\share.", paramName);
+        RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? new ArgumentException(@"The UNC path should be of the form \\server\share.", paramName)
+            : new ArgumentException(@"The UNC path should be of the form //server/share.", paramName);
 
     public static IOException ProcessCannotAccessFileInUse(string paramName = null) =>
         paramName != null


### PR DESCRIPTION
Closes #1350

This PR updates the `InvalidUncPath` error message to be platform specific, referencing the form `\\server\share` in Windows environments, and `//server/share` in other environments.

The method now checks the environment's platform (`RuntimeInformation.IsOSPlatform(OSPlatform.Windows)`) and conditionally returns an `IOException` with the correctly-formed UNC path in the message, using `System.Runtime.InteropServices` in the `CommonExceptions` class.