### PR TITLE
fix: pin `System.Text.Json` versions for older frameworks

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,10 +3,10 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
     <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-        <PackageVersion Include="System.Text.Json" Version="10.0.2"/>
+        <PackageVersion Include="System.Text.Json" Version="[6.0.11]"/>
     </ItemGroup>
     <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
-        <PackageVersion Include="System.Text.Json" Version="10.0.2"/>
+        <PackageVersion Include="System.Text.Json" Version="[8.0.6]"/>
     </ItemGroup>
     <ItemGroup Condition=" '$(TargetFramework)' != 'net8.0' And '$(TargetFramework)' != 'net6.0' ">
         <PackageVersion Include="System.Text.Json" Version="10.0.2"/>


### PR DESCRIPTION
This PR fixes an issue where `System.Text.Json` version 10.0.2 was incorrectly specified for .NET 6.0 and .NET 8.0 target frameworks. The fix pins appropriate framework-specific versions using exact version notation.

### Changes:
- Freeze `System.Text.Json` to version 6.0.11 for .NET 6.0 targets
- Freeze `System.Text.Json` to version 8.0.6 for .NET 8.0 targets