### PR TITLE
refactor: remove explicit .NET6 tests

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,7 +21,7 @@
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="3.0.1" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageVersion Include="Mockolate" Version="1.0.0" />
     <PackageVersion Include="NUnit" Version="4.4.0" />
     <PackageVersion Include="NUnit.Analyzers" Version="4.11.2" />

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -4,7 +4,7 @@
             Condition="Exists('$(MSBuildThisFileDirectory)/../Directory.Build.props')"/>
 
     <PropertyGroup>
-        <TargetFrameworks>net10.0;net9.0;net8.0;net6.0</TargetFrameworks>
+        <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
         <TargetFrameworks Condition="!$([MSBuild]::IsOsUnixLike())">$(TargetFrameworks);net472</TargetFrameworks>
         <NoWarn>$(NoWarn);S2699</NoWarn>
         <IsPackable>false</IsPackable>


### PR DESCRIPTION
This PR removes .NET 6.0 from the test target frameworks to enable upgrading `Microsoft.NET.Test.Sdk` to version 18, which no longer supports .NET 6.0.

### Key changes:
- Removed `net6.0` from the test target frameworks
- Updated Microsoft.NET.Test.Sdk from version 17.14.0 to 18.0.1