### PR TITLE
chore: bump Mockolate to v1.0.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,7 +22,7 @@
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="3.0.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageVersion Include="Mockolate" Version="1.0.0" />
+    <PackageVersion Include="Mockolate" Version="1.0.1" />
     <PackageVersion Include="NUnit" Version="4.4.0" />
     <PackageVersion Include="NUnit.Analyzers" Version="4.11.2" />
     <PackageVersion Include="NUnit3TestAdapter" Version="6.1.0" />

--- a/tests/TestableIO.System.IO.Abstractions.Wrappers.Tests/FileSystemTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.Wrappers.Tests/FileSystemTests.cs
@@ -1,5 +1,4 @@
-﻿#if !NET6_0
-using Mockolate;
+﻿using Mockolate;
 
 namespace System.IO.Abstractions.Tests;
 
@@ -112,4 +111,3 @@ public class FileSystemTests
         ).DoesNotThrow();
     }
 }
-#endif


### PR DESCRIPTION
This PR updates the Mockolate testing library dependency from version 1.0.0 to 1.0.1, which includes a fix for a wrapped exception issue in the readme example.

### KeyChanges:
- Updated Mockolate package version from 1.0.0 to 1.0.1
- Removed no longer needed .NET 6.0 exclusion conditional compilation directives from FileSystemTests.cs
