### PR TITLE
chore: bump Mockolate to v1.0.3

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,7 +22,7 @@
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="3.0.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageVersion Include="Mockolate" Version="1.0.2" />
+    <PackageVersion Include="Mockolate" Version="1.0.3" />
     <PackageVersion Include="NUnit" Version="4.4.0" />
     <PackageVersion Include="NUnit.Analyzers" Version="4.11.2" />
     <PackageVersion Include="NUnit3TestAdapter" Version="6.1.0" />


### PR DESCRIPTION
This PR updates the Mockolate package dependency from version 1.0.2 to 1.0.3, aligning with the project's dependency management strategy using Central Package Management.