### PR TITLE
chore: bump Mockolate to v1.4.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,7 +22,7 @@
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="3.0.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageVersion Include="Mockolate" Version="1.4.0" />
+    <PackageVersion Include="Mockolate" Version="1.4.1" />
     <PackageVersion Include="NUnit" Version="4.4.0" />
     <PackageVersion Include="NUnit.Analyzers" Version="4.11.2" />
     <PackageVersion Include="NUnit3TestAdapter" Version="6.1.0" />


### PR DESCRIPTION
Bumps the Mockolate dependency version to pick up the latest patch release.

**Changes:**
- Update `Mockolate` package version from `1.4.0` to `1.4.1` in central package management.