### PR TITLE
fix: update `FileVersionInfos` when calling CopyTo, MoveTo and Replace on a IFileInfo

### DIFF
--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFileData.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFileData.cs
@@ -107,6 +107,7 @@ public class MockFileData
         Attributes = template.Attributes;
         Contents = template.Contents.ToArray();
         CreationTime = template.CreationTime;
+        FileVersionInfo = template.FileVersionInfo;
         LastAccessTime = template.LastAccessTime;
         LastWriteTime = template.LastWriteTime;
 #if FEATURE_FILE_SYSTEM_INFO_LINK_TARGET

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileInfoTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileInfoTests.cs
@@ -654,6 +654,82 @@ public class MockFileInfoTests
         await That(action).Throws<FileNotFoundException>();
     }
 
+    [Test]
+    public async Task MockFileInfo_CopyTo_ShouldPreserveMockFileDataFileVersionInfo()
+    {
+        string sourcePath = XFS.Path(@"c:\temp\file.txt");
+        string destinationPath = XFS.Path(@"c:\temp\file2.txt");
+        var expectedFileVersionInfo = new MockFileVersionInfo(
+            sourcePath,
+            fileVersion: "1.2.3.4",
+            productVersion: "5.6.7-beta",
+            fileDescription: "Demo file");
+        var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+        {
+            { sourcePath, new MockFileData("Demo text content") { FileVersionInfo = expectedFileVersionInfo } }
+        });
+
+        fileSystem.FileInfo.New(sourcePath).CopyTo(destinationPath);
+
+        var fileVersionInfo = fileSystem.FileVersionInfo.GetVersionInfo(destinationPath);
+
+        await That(fileVersionInfo).IsEqualTo(expectedFileVersionInfo);
+        await That(fileVersionInfo.FileVersion).IsEqualTo("1.2.3.4");
+        await That(fileVersionInfo.ProductVersion).IsEqualTo("5.6.7-beta");
+        await That(fileVersionInfo.FileDescription).IsEqualTo("Demo file");
+    }
+
+    [Test]
+    public async Task MockFileInfo_MoveTo_ShouldPreserveMockFileDataFileVersionInfo()
+    {
+        string sourcePath = XFS.Path(@"c:\temp\file.txt");
+        string destinationPath = XFS.Path(@"c:\temp\file2.txt");
+        var expectedFileVersionInfo = new MockFileVersionInfo(
+            sourcePath,
+            fileVersion: "1.2.3.4",
+            productVersion: "5.6.7-beta",
+            fileDescription: "Demo file");
+        var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+        {
+            { sourcePath, new MockFileData("Demo text content") { FileVersionInfo = expectedFileVersionInfo } }
+        });
+
+        fileSystem.FileInfo.New(sourcePath).MoveTo(destinationPath);
+
+        var fileVersionInfo = fileSystem.FileVersionInfo.GetVersionInfo(destinationPath);
+
+        await That(fileVersionInfo).IsEqualTo(expectedFileVersionInfo);
+        await That(fileVersionInfo.FileVersion).IsEqualTo("1.2.3.4");
+        await That(fileVersionInfo.ProductVersion).IsEqualTo("5.6.7-beta");
+        await That(fileVersionInfo.FileDescription).IsEqualTo("Demo file");
+    }
+
+    [Test]
+    public async Task MockFileInfo_Replace_ShouldPreserveMockFileDataFileVersionInfo()
+    {
+        string sourcePath = XFS.Path(@"c:\temp\file.txt");
+        string destinationPath = XFS.Path(@"c:\temp\file2.txt");
+        var expectedFileVersionInfo = new MockFileVersionInfo(
+            sourcePath,
+            fileVersion: "1.2.3.4",
+            productVersion: "5.6.7-beta",
+            fileDescription: "Demo file");
+        var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+        {
+            { sourcePath, new MockFileData("Demo text content") { FileVersionInfo = expectedFileVersionInfo } },
+            { destinationPath, new MockFileData("Demo2 text content") }
+        });
+
+        fileSystem.FileInfo.New(sourcePath).Replace(destinationPath, null);
+
+        var fileVersionInfo = fileSystem.FileVersionInfo.GetVersionInfo(destinationPath);
+
+        await That(fileVersionInfo).IsEqualTo(expectedFileVersionInfo);
+        await That(fileVersionInfo.FileVersion).IsEqualTo("1.2.3.4");
+        await That(fileVersionInfo.ProductVersion).IsEqualTo("5.6.7-beta");
+        await That(fileVersionInfo.FileDescription).IsEqualTo("Demo file");
+    }
+
     [TestCase(@"..\..\..\c.txt")]
     [TestCase(@"c:\a\b\c.txt")]
     [TestCase(@"c:\a\c.txt")]


### PR DESCRIPTION
This PR fixes an issue where copying, moving or replacing a file would lose all the `FileVersionInfo` informations when using a `MockFileSystem`

Changes:
- When creating a new `MockFileData` also copy the `FileVersionInfo`
- Added tests to validate the fix

Open questions:
- should `FileVersionInfo` be cloned or is the current fix enough?