### PR TITLE
refactor: improve mocking tests in `FileSystemTests`

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,13 +22,14 @@
     <PackageVersion Include="coverlet.collector" Version="8.0.1" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="3.0.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-    <PackageVersion Include="Mockolate" Version="2.0.2" />
+    <PackageVersion Include="Mockolate" Version="2.4.0" />
     <PackageVersion Include="NUnit" Version="4.5.1" />
     <PackageVersion Include="NUnit.Analyzers" Version="4.12.0" />
     <PackageVersion Include="NUnit3TestAdapter" Version="6.1.0" />
     <PackageVersion Include="PublicApiGenerator" Version="11.5.4"/>
     <PackageVersion Include="aweXpect" Version="2.31.0"/>
     <PackageVersion Include="aweXpect.Testably" Version="0.13.0"/>
+    <PackageVersion Include="aweXpect.Mockolate" Version="2.3.0"/>
   </ItemGroup>
   <ItemGroup>
     <PackageVersion Include="Nuke.Common" Version="10.1.0"/>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -27,6 +27,7 @@
         <PackageReference Include="NUnit3TestAdapter" />
         <PackageReference Include="aweXpect"/>
         <PackageReference Include="aweXpect.Testably"/>
+        <PackageReference Include="aweXpect.Mockolate"/>
     </ItemGroup>
 
     <PropertyGroup>

--- a/tests/TestableIO.System.IO.Abstractions.Wrappers.Tests/FileSystemTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.Wrappers.Tests/FileSystemTests.cs
@@ -39,77 +39,77 @@ public class FileSystemTests
     [Test]
     public async Task Mock_Directory_Succeeds()
     {
-        var fileSystemMock = IFileSystem.CreateMock(fs =>
+        var fileSystem = IFileSystem.CreateMock(fs =>
             fs.Directory.InitializeWith(IDirectory.CreateMock()));
 
         await That(() =>
-            fileSystemMock.Directory.Mock.Setup.CreateDirectory(It.IsAny<string>())
+            fileSystem.Directory.Mock.Setup.CreateDirectory(It.IsAny<string>())
         ).DoesNotThrow();
     }
 
     [Test]
     public async Task Mock_FileInfo_Succeeds()
     {
-        var fileSystemMock = IFileSystem.CreateMock(fs =>
+        var fileSystem = IFileSystem.CreateMock(fs =>
             fs.FileInfo.InitializeWith(IFileInfoFactory.CreateMock()));
 
         await That(() =>
-            fileSystemMock.FileInfo.Mock.Setup.New(It.IsAny<string>())
+            fileSystem.FileInfo.Mock.Setup.New(It.IsAny<string>())
         ).DoesNotThrow();
     }
 
     [Test]
     public async Task Mock_FileStream_Succeeds()
     {
-        var fileSystemMock = IFileSystem.CreateMock(fs =>
+        var fileSystem = IFileSystem.CreateMock(fs =>
             fs.FileStream.InitializeWith(IFileStreamFactory.CreateMock()));
 
         await That(() =>
-            fileSystemMock.FileStream.Mock.Setup.New(It.IsAny<string>(), It.IsAny<FileMode>())
+            fileSystem.FileStream.Mock.Setup.New(It.IsAny<string>(), It.IsAny<FileMode>())
         ).DoesNotThrow();
     }
 
     [Test]
     public async Task Mock_Path_Succeeds()
     {
-        var fileSystemMock = IFileSystem.CreateMock(fs =>
+        var fileSystem = IFileSystem.CreateMock(fs =>
             fs.Path.InitializeWith(IPath.CreateMock()));
 
         await That(() =>
-            fileSystemMock.Path.Mock.Setup.Combine(It.IsAny<string>(), It.IsAny<string>())
+            fileSystem.Path.Mock.Setup.Combine(It.IsAny<string>(), It.IsAny<string>())
         ).DoesNotThrow();
     }
 
     [Test]
     public async Task Mock_DirectoryInfo_Succeeds()
     {
-        var fileSystemMock = IFileSystem.CreateMock(fs =>
+        var fileSystem = IFileSystem.CreateMock(fs =>
             fs.DirectoryInfo.InitializeWith(IDirectoryInfoFactory.CreateMock()));
 
         await That(() =>
-            fileSystemMock.DirectoryInfo.Mock.Setup.New(It.IsAny<string>())
+            fileSystem.DirectoryInfo.Mock.Setup.New(It.IsAny<string>())
         ).DoesNotThrow();
     }
 
     [Test]
     public async Task Mock_DriveInfo_Succeeds()
     {
-        var fileSystemMock = IFileSystem.CreateMock(fs =>
+        var fileSystem = IFileSystem.CreateMock(fs =>
             fs.DriveInfo.InitializeWith(IDriveInfoFactory.CreateMock()));
 
         await That(() =>
-            fileSystemMock.DriveInfo.Mock.Setup.New(It.IsAny<string>())
+            fileSystem.DriveInfo.Mock.Setup.New(It.IsAny<string>())
         ).DoesNotThrow();
     }
 
     [Test]
     public async Task Mock_FileSystemWatcher_Succeeds()
     {
-        var fileSystemMock = IFileSystem.CreateMock(fs =>
+        var fileSystem = IFileSystem.CreateMock(fs =>
             fs.FileSystemWatcher.InitializeWith(IFileSystemWatcherFactory.CreateMock()));
 
         await That(() =>
-            fileSystemMock.FileSystemWatcher.Mock.Setup.New(It.IsAny<string>())
+            fileSystem.FileSystemWatcher.Mock.Setup.New(It.IsAny<string>())
         ).DoesNotThrow();
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.Wrappers.Tests/FileSystemTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.Wrappers.Tests/FileSystemTests.cs
@@ -26,12 +26,14 @@ public class FileSystemTests
     [Test]
     public async Task Mock_File_Succeeds()
     {
-        var fileSystemMock = IFileSystem.CreateMock(fs =>
+        var fileSystem = IFileSystem.CreateMock(fs =>
             fs.File.InitializeWith(IFile.CreateMock()));
-
-        await That(() =>
-            fileSystemMock.File.Mock.Setup.ReadAllText(It.IsAny<string>()).Returns("")
-        ).DoesNotThrow();
+        fileSystem.File.Mock.Setup.ReadAllText(It.IsAny<string>()).Returns("foo");
+        
+        var result = fileSystem.File.ReadAllText("any path");
+        
+        await That(result).IsEqualTo("foo");
+        await That(fileSystem.File.Mock.Verify.ReadAllText(It.Is("any path"))).Once();
     }
 
     [Test]

--- a/tests/TestableIO.System.IO.Abstractions.Wrappers.Tests/FileSystemTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.Wrappers.Tests/FileSystemTests.cs
@@ -29,7 +29,7 @@ public class FileSystemTests
         var fileSystem = IFileSystem.CreateMock(fs =>
             fs.File.InitializeWith(IFile.CreateMock()));
         fileSystem.File.Mock.Setup.ReadAllText(It.IsAny<string>()).Returns("foo");
-        
+
         var result = fileSystem.File.ReadAllText("any path");
         
         await That(result).IsEqualTo("foo");


### PR DESCRIPTION
Refactors `FileSystemTests` to more directly validate mocked `IFile` behavior, and updates test dependencies to support the new assertion/verification style.

**Changes:**
- Update `Mock_File_Succeeds` to assert `ReadAllText` returns a configured value and verify the call occurred.
- Add `aweXpect.Mockolate` to the shared test package references.
- Bump `Mockolate` package version and centrally define the `aweXpect.Mockolate` version.