### PR TITLE
chore: bump Mockolate and aweXpect.Mockolate to v3.0.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,14 +22,14 @@
     <PackageVersion Include="coverlet.collector" Version="10.0.0" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="3.0.3" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
-    <PackageVersion Include="Mockolate" Version="2.4.0" />
+    <PackageVersion Include="Mockolate" Version="3.0.0" />
     <PackageVersion Include="NUnit" Version="4.5.1" />
     <PackageVersion Include="NUnit.Analyzers" Version="4.12.0" />
     <PackageVersion Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageVersion Include="PublicApiGenerator" Version="11.5.4"/>
     <PackageVersion Include="aweXpect" Version="2.31.0"/>
     <PackageVersion Include="aweXpect.Testably" Version="0.13.0"/>
-    <PackageVersion Include="aweXpect.Mockolate" Version="2.3.0"/>
+    <PackageVersion Include="aweXpect.Mockolate" Version="3.0.0"/>
   </ItemGroup>
   <ItemGroup>
     <PackageVersion Include="Nuke.Common" Version="10.1.0"/>


### PR DESCRIPTION
This pull request updates dependency versions in the `Directory.Packages.props` file, specifically upgrading the `Mockolate` and `aweXpect.Mockolate` packages to their latest major versions. This ensures compatibility with newer features and bug fixes from these libraries.

Dependency upgrades:

* Upgraded `Mockolate` package version from `2.4.0` to `3.0.0` to use the latest major release.
* Upgraded `aweXpect.Mockolate` package version from `2.3.0` to `3.0.0` for compatibility with the latest `Mockolate`.